### PR TITLE
Re-export concordium-contracts-common and enable derive-serde feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,7 +35,7 @@ aggregate_sig = { version = "*", path = "./concordium-base/rust-src/aggregate_si
 encrypted_transfers = { version = "*", path = "./concordium-base/rust-src/encrypted_transfers" }
 eddsa_ed25519 = { version = "*", path = "./concordium-base/rust-src/eddsa_ed25519/" }
 pedersen_scheme = { version = "*", path = "./concordium-base/rust-src/pedersen_scheme/" }
-concordium-contracts-common = { version = "*", path = "./concordium-contracts-common/"}
+concordium-contracts-common = { version = "*", path = "./concordium-contracts-common/", features = ["derive-serde"]}
 
 [dev-dependencies]
 rand = "0.7"

--- a/src/types/smart_contracts.rs
+++ b/src/types/smart_contracts.rs
@@ -2,6 +2,7 @@
 
 use super::hashes;
 use crate::constants::*;
+pub use concordium_contracts_common;
 use crypto_common::{
     derive,
     derive::{Serial, Serialize},

--- a/src/types/smart_contracts.rs
+++ b/src/types/smart_contracts.rs
@@ -2,6 +2,8 @@
 
 use super::hashes;
 use crate::constants::*;
+/// Re-export of common helper functionality for smart contract, such as types
+/// and serialization specific for smart contracts.
 pub use concordium_contracts_common;
 use crypto_common::{
     derive,


### PR DESCRIPTION
## Purpose

When working with smart contracts types and serialization from `concordium-contracts-common` is useful.

## Changes

- Re-export `concordium-contracts-common`.
- Enable `derive-serde` feature on `concordium-contracts-common`.

## Checklist

- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [x] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [ ] (If necessary) I have updated the CHANGELOG.

