### PR TITLE
Fix transfer to public serialization

### DIFF
--- a/src/types/transactions.rs
+++ b/src/types/transactions.rs
@@ -396,7 +396,7 @@ impl Serial for Payload {
                 out.put(amount);
             }
             Payload::TransferToPublic { data } => {
-                out.put(&18);
+                out.put(&18u8);
                 out.put(data);
             }
             Payload::TransferWithSchedule { to, schedule } => {


### PR DESCRIPTION
Fix serialization for `Payload::TransferToPublic`