### PR TITLE
Add baker key functions

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,6 +24,7 @@ anyhow = "1.0"
 rust_decimal = { version = "1.14", features = ["serde-float", "serde-arbitrary-precision"]}
 ed25519-dalek = "1"
 sha2 = "0.9"
+rand = "0.7"
 
 tokio-postgres = { version = "0.7", features = ["with-serde_json-1"] }
 
@@ -36,9 +37,9 @@ encrypted_transfers = { version = "*", path = "./concordium-base/rust-src/encryp
 eddsa_ed25519 = { version = "*", path = "./concordium-base/rust-src/eddsa_ed25519/" }
 pedersen_scheme = { version = "*", path = "./concordium-base/rust-src/pedersen_scheme/" }
 concordium-contracts-common = { version = "*", path = "./concordium-contracts-common/", features = ["derive-serde"]}
+random_oracle = { version = "*", path = "./concordium-base/rust-src/random_oracle/" }
 
 [dev-dependencies]
-rand = "0.7"
 structopt = "0.3"
 clap = "2.33.3"
 csv = "1.1"

--- a/src/types/basic.rs
+++ b/src/types/basic.rs
@@ -285,6 +285,8 @@ impl BakerAggregationSignKey {
         }
     }
 
+    /// Prove knowledge of the baker aggregation signing key with respect to the
+    /// challenge given via the random oracle.
     pub fn prove<T: Rng>(
         &self,
         csprng: &mut T,

--- a/src/types/mod.rs
+++ b/src/types/mod.rs
@@ -133,7 +133,7 @@ pub struct AccountBaker {
     pub baker_election_verify_key:    BakerElectionVerifyKey,
     /// Baker's public key used to check that they are indeed the ones who
     /// produced the block.
-    pub baker_signature_verify_key:   BakerSignVerifyKey,
+    pub baker_signature_verify_key:   BakerSignatureVerifyKey,
     /// Baker's public key used to check signatures on finalization records.
     /// This is only used if the baker has sufficient stake to participate in
     /// finalization.
@@ -710,7 +710,7 @@ pub struct BakerKeysEvent {
     /// Account address of the baker.
     pub account:         AccountAddress,
     /// The new public key for verifying block signatures.
-    pub sign_key:        BakerSignVerifyKey,
+    pub sign_key:        BakerSignatureVerifyKey,
     /// The new public key for verifying whether the baker won the block
     /// lottery.
     pub election_key:    BakerElectionVerifyKey,


### PR DESCRIPTION
## Purpose
See https://github.com/Concordium/concordium-base/pull/76

Add functions for generating baker keys and constructing the relevant transactions payload with proofs of knowledge of the bakers secret keys.

## Changes

- Add newtypes for the baker signing keys.
- Add `BakerKeyPairs` struct containing both the bakers secret and public keys.
- Add functions to construct `BakerKeysPayload` using a `BakerKeyPairs` struct.
- Extend `BakerKeysPayload` with a marker for whether the proofs are generated for adding or updating baker keys.

## Checklist

- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [ ] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [ ] (If necessary) I have updated the CHANGELOG.
