### PR TITLE
Update base dependency and remove some re-exports

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,7 +30,6 @@ tokio-postgres = { version = "0.7", features = ["with-serde_json-1"] }
 
 crypto_common = { version = "*", path = "./concordium-base/rust-src/crypto_common", features = ["encryption"] }
 id = { version = "*", path = "./concordium-base/rust-src/id", default-features=false }
-elgamal = { version = "*", path = "./concordium-base/rust-src/elgamal" }
 ecvrf = { version = "*", path = "./concordium-base/rust-src/ecvrf" }
 aggregate_sig = { version = "*", path = "./concordium-base/rust-src/aggregate_sig" }
 encrypted_transfers = { version = "*", path = "./concordium-base/rust-src/encrypted_transfers" }
@@ -38,6 +37,7 @@ eddsa_ed25519 = { version = "*", path = "./concordium-base/rust-src/eddsa_ed2551
 pedersen_scheme = { version = "*", path = "./concordium-base/rust-src/pedersen_scheme/" }
 concordium-contracts-common = { version = "*", path = "./concordium-contracts-common/", features = ["derive-serde"]}
 random_oracle = { version = "*", path = "./concordium-base/rust-src/random_oracle/" }
+
 
 [dev-dependencies]
 structopt = "0.3"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,7 +34,6 @@ ecvrf = { version = "*", path = "./concordium-base/rust-src/ecvrf" }
 aggregate_sig = { version = "*", path = "./concordium-base/rust-src/aggregate_sig" }
 encrypted_transfers = { version = "*", path = "./concordium-base/rust-src/encrypted_transfers" }
 eddsa_ed25519 = { version = "*", path = "./concordium-base/rust-src/eddsa_ed25519/" }
-pedersen_scheme = { version = "*", path = "./concordium-base/rust-src/pedersen_scheme/" }
 concordium-contracts-common = { version = "*", path = "./concordium-contracts-common/", features = ["derive-serde"]}
 random_oracle = { version = "*", path = "./concordium-base/rust-src/random_oracle/" }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -25,10 +25,8 @@ pub use encrypted_transfers;
 /// signatures. This is useful for constructing baker transactions.
 pub use aggregate_sig;
 
-
 /// Re-export of Elgamal encryption.
 pub use eddsa_ed25519;
 
 /// Re-export of Elgamal encryption.
 pub use ecvrf;
-

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -25,8 +25,6 @@ pub use encrypted_transfers;
 /// signatures. This is useful for constructing baker transactions.
 pub use aggregate_sig;
 
-/// Re-export of Elgamal encryption.
-pub use elgamal;
 
 /// Re-export of Elgamal encryption.
 pub use eddsa_ed25519;
@@ -34,5 +32,3 @@ pub use eddsa_ed25519;
 /// Re-export of Elgamal encryption.
 pub use ecvrf;
 
-/// Re-export of Pedersen commitments functionality.
-pub use pedersen_scheme as pedersen_commitment;

--- a/src/types/mod.rs
+++ b/src/types/mod.rs
@@ -18,6 +18,7 @@ use derive_more::*;
 use id::{
     constants::{ArCurve, AttributeKind},
     types::{AccountAddress, AccountCredentialWithoutProofs},
+    elgamal
 };
 use std::{
     collections::{BTreeMap, BTreeSet},

--- a/src/types/mod.rs
+++ b/src/types/mod.rs
@@ -17,8 +17,8 @@ use crypto_common::{
 use derive_more::*;
 use id::{
     constants::{ArCurve, AttributeKind},
+    elgamal,
     types::{AccountAddress, AccountCredentialWithoutProofs},
-    elgamal
 };
 use std::{
     collections::{BTreeMap, BTreeSet},


### PR DESCRIPTION
## Purpose
To update dependency to concordium-base and to remove some re-exports.

## Changes

* Updated base dependency
* Remove re-exports of pedersen_scheme and elgamal since they are now re-exported by the id crate in concordium-base.

