### PR TITLE
Add method for resolving TransactionType of a Payload

### DIFF
--- a/src/types/mod.rs
+++ b/src/types/mod.rs
@@ -283,48 +283,6 @@ pub enum TransactionType {
     TransferWithScheduleAndMemo,
 }
 
-impl TransactionType {
-    /// Resolve the TransactionType corresponding to the variant of the provided
-    /// Payload.
-    pub fn from_payload(p: &transactions::Payload) -> TransactionType {
-        match p {
-            transactions::Payload::DeployModule { .. } => TransactionType::DeployModule,
-            transactions::Payload::InitContract { .. } => TransactionType::InitContract,
-            transactions::Payload::Update { .. } => TransactionType::Update,
-            transactions::Payload::Transfer { .. } => TransactionType::Transfer,
-            transactions::Payload::AddBaker { .. } => TransactionType::AddBaker,
-            transactions::Payload::RemoveBaker { .. } => TransactionType::RemoveBaker,
-            transactions::Payload::UpdateBakerStake { .. } => TransactionType::UpdateBakerStake,
-            transactions::Payload::UpdateBakerRestakeEarnings { .. } => {
-                TransactionType::UpdateBakerRestakeEarnings
-            }
-            transactions::Payload::UpdateBakerKeys { .. } => TransactionType::UpdateBakerKeys,
-            transactions::Payload::UpdateCredentialKeys { .. } => {
-                TransactionType::UpdateCredentialKeys
-            }
-            transactions::Payload::EncryptedAmountTransfer { .. } => {
-                TransactionType::EncryptedAmountTransfer
-            }
-            transactions::Payload::TransferToEncrypted { .. } => {
-                TransactionType::TransferToEncrypted
-            }
-            transactions::Payload::TransferToPublic { .. } => TransactionType::TransferToPublic,
-            transactions::Payload::TransferWithSchedule { .. } => {
-                TransactionType::TransferWithSchedule
-            }
-            transactions::Payload::UpdateCredentials { .. } => TransactionType::UpdateCredentials,
-            transactions::Payload::RegisterData { .. } => TransactionType::RegisterData,
-            transactions::Payload::TransferWithMemo { .. } => TransactionType::TransferWithMemo,
-            transactions::Payload::EncryptedAmountTransferWithMemo { .. } => {
-                TransactionType::EncryptedAmountTransferWithMemo
-            }
-            transactions::Payload::TransferWithScheduleAndMemo { .. } => {
-                TransactionType::TransferWithScheduleAndMemo
-            }
-        }
-    }
-}
-
 #[derive(SerdeSerialize, SerdeDeserialize, Debug)]
 #[serde(tag = "status", content = "result", rename_all = "camelCase")]
 /// Status of a transaction in a given block.

--- a/src/types/mod.rs
+++ b/src/types/mod.rs
@@ -284,6 +284,7 @@ pub enum TransactionType {
 }
 
 impl TransactionType {
+    /// Resolve the TransactionType corresponding to the variant of the provided Payload.
     pub fn from_payload(p: &transactions::Payload) -> TransactionType {
         match p {
             transactions::Payload::DeployModule { .. } => TransactionType::DeployModule,

--- a/src/types/mod.rs
+++ b/src/types/mod.rs
@@ -283,6 +283,32 @@ pub enum TransactionType {
     TransferWithScheduleAndMemo,
 }
 
+impl TransactionType {
+    pub fn from_payload(p: &transactions::Payload) -> TransactionType {
+        match p {
+            transactions::Payload::DeployModule { .. } => TransactionType::DeployModule,
+            transactions::Payload::InitContract { .. } => TransactionType::InitContract,
+            transactions::Payload::Update { .. } => TransactionType::Update,
+            transactions::Payload::Transfer { .. } => TransactionType::Transfer,
+            transactions::Payload::AddBaker { .. } => TransactionType::AddBaker,
+            transactions::Payload::RemoveBaker { .. } => TransactionType::RemoveBaker,
+            transactions::Payload::UpdateBakerStake { .. } => TransactionType::UpdateBakerStake,
+            transactions::Payload::UpdateBakerRestakeEarnings { .. } => TransactionType::UpdateBakerRestakeEarnings,
+            transactions::Payload::UpdateBakerKeys { .. } => TransactionType::UpdateBakerKeys,
+            transactions::Payload::UpdateCredentialKeys { .. } => TransactionType::UpdateCredentialKeys,
+            transactions::Payload::EncryptedAmountTransfer { .. } => TransactionType::EncryptedAmountTransfer,
+            transactions::Payload::TransferToEncrypted { .. } => TransactionType::TransferToEncrypted,
+            transactions::Payload::TransferToPublic { .. } => TransactionType::TransferToPublic,
+            transactions::Payload::TransferWithSchedule { .. } => TransactionType::TransferWithSchedule,
+            transactions::Payload::UpdateCredentials { .. } => TransactionType::UpdateCredentials,
+            transactions::Payload::RegisterData { .. } => TransactionType::RegisterData,
+            transactions::Payload::TransferWithMemo { .. } => TransactionType::TransferWithMemo,
+            transactions::Payload::EncryptedAmountTransferWithMemo { .. } => TransactionType::EncryptedAmountTransferWithMemo,
+            transactions::Payload::TransferWithScheduleAndMemo { .. } => TransactionType::TransferWithScheduleAndMemo,
+        }
+    }
+}
+
 #[derive(SerdeSerialize, SerdeDeserialize, Debug)]
 #[serde(tag = "status", content = "result", rename_all = "camelCase")]
 /// Status of a transaction in a given block.

--- a/src/types/mod.rs
+++ b/src/types/mod.rs
@@ -284,7 +284,8 @@ pub enum TransactionType {
 }
 
 impl TransactionType {
-    /// Resolve the TransactionType corresponding to the variant of the provided Payload.
+    /// Resolve the TransactionType corresponding to the variant of the provided
+    /// Payload.
     pub fn from_payload(p: &transactions::Payload) -> TransactionType {
         match p {
             transactions::Payload::DeployModule { .. } => TransactionType::DeployModule,
@@ -294,18 +295,32 @@ impl TransactionType {
             transactions::Payload::AddBaker { .. } => TransactionType::AddBaker,
             transactions::Payload::RemoveBaker { .. } => TransactionType::RemoveBaker,
             transactions::Payload::UpdateBakerStake { .. } => TransactionType::UpdateBakerStake,
-            transactions::Payload::UpdateBakerRestakeEarnings { .. } => TransactionType::UpdateBakerRestakeEarnings,
+            transactions::Payload::UpdateBakerRestakeEarnings { .. } => {
+                TransactionType::UpdateBakerRestakeEarnings
+            }
             transactions::Payload::UpdateBakerKeys { .. } => TransactionType::UpdateBakerKeys,
-            transactions::Payload::UpdateCredentialKeys { .. } => TransactionType::UpdateCredentialKeys,
-            transactions::Payload::EncryptedAmountTransfer { .. } => TransactionType::EncryptedAmountTransfer,
-            transactions::Payload::TransferToEncrypted { .. } => TransactionType::TransferToEncrypted,
+            transactions::Payload::UpdateCredentialKeys { .. } => {
+                TransactionType::UpdateCredentialKeys
+            }
+            transactions::Payload::EncryptedAmountTransfer { .. } => {
+                TransactionType::EncryptedAmountTransfer
+            }
+            transactions::Payload::TransferToEncrypted { .. } => {
+                TransactionType::TransferToEncrypted
+            }
             transactions::Payload::TransferToPublic { .. } => TransactionType::TransferToPublic,
-            transactions::Payload::TransferWithSchedule { .. } => TransactionType::TransferWithSchedule,
+            transactions::Payload::TransferWithSchedule { .. } => {
+                TransactionType::TransferWithSchedule
+            }
             transactions::Payload::UpdateCredentials { .. } => TransactionType::UpdateCredentials,
             transactions::Payload::RegisterData { .. } => TransactionType::RegisterData,
             transactions::Payload::TransferWithMemo { .. } => TransactionType::TransferWithMemo,
-            transactions::Payload::EncryptedAmountTransferWithMemo { .. } => TransactionType::EncryptedAmountTransferWithMemo,
-            transactions::Payload::TransferWithScheduleAndMemo { .. } => TransactionType::TransferWithScheduleAndMemo,
+            transactions::Payload::EncryptedAmountTransferWithMemo { .. } => {
+                TransactionType::EncryptedAmountTransferWithMemo
+            }
+            transactions::Payload::TransferWithScheduleAndMemo { .. } => {
+                TransactionType::TransferWithScheduleAndMemo
+            }
         }
     }
 }

--- a/src/types/transactions.rs
+++ b/src/types/transactions.rs
@@ -1444,10 +1444,10 @@ pub mod construct {
     /// it.
     /// This is deliberately made private so that the inconsistent internal
     /// state does not leak.
-    struct TransactionBuilder {
-        header:  TransactionHeader,
-        payload: Payload,
-        encoded: EncodedPayload,
+    pub struct TransactionBuilder {
+        pub header:  TransactionHeader,
+        pub payload: Payload,
+        pub encoded: EncodedPayload,
     }
 
     /// Size of a transaction header. This is currently always 60 bytes.
@@ -1478,7 +1478,7 @@ pub mod construct {
         }
 
         #[inline]
-        fn size(&self) -> u64 {
+        pub fn size(&self) -> u64 {
             TRANSACTION_HEADER_SIZE + u64::from(u32::from(self.header.payload_size))
         }
 

--- a/src/types/transactions.rs
+++ b/src/types/transactions.rs
@@ -469,7 +469,7 @@ pub enum Payload {
 }
 
 impl Payload {
-    /// Resolve the TransactionType corresponding to the variant of the Payload.
+    /// Resolve the [TransactionType] corresponding to the variant of the Payload.
     pub fn transaction_type(&self) -> TransactionType {
         match self {
             Payload::DeployModule { .. } => TransactionType::DeployModule,


### PR DESCRIPTION
## Purpose

Ensure that the SDK serves the needs of the Rosetta implementation (WIP).

## Changes

Add a function for getting the `TransactionType` of a `Payload` object (used [here](https://gitlab.com/Concordium/concordium-rosetta/-/blob/ab9de7480b0222e61816b5e8e4a2ec16d634029f/src/api/construction.rs#L449) for error reporting).

## Checklist

- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [x] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [ ] (If necessary) I have updated the CHANGELOG.