### PR TITLE
Update generator example to support a transfer amount.

### DIFF
--- a/examples/generator.rs
+++ b/examples/generator.rs
@@ -29,6 +29,12 @@ struct App {
     receivers: Option<PathBuf>,
     #[structopt(long = "tps")]
     tps:       u16,
+    #[structopt(
+        long = "amount",
+        help = "CCD amount to send in each transaction",
+        default_value = "0"
+    )]
+    amount:    Amount,
 }
 
 #[derive(SerdeSerialize, SerdeDeserialize)]
@@ -79,6 +85,8 @@ async fn main() -> anyhow::Result<()> {
     // Create a channel between the task signing and the task sending transactions.
     let (sender, mut rx) = tokio::sync::mpsc::channel(100);
 
+    let transfer_amount = app.amount;
+
     // A task that will generate and sign transactions. Transactions are sent in a
     // round-robin fashion to all accounts in the list of receivers.
     let generator = async move {
@@ -93,7 +101,7 @@ async fn main() -> anyhow::Result<()> {
                 nonce,
                 expiry,
                 accounts[count % accounts.len()],
-                Amount::zero(),
+                transfer_amount,
             );
             nonce.next_mut();
             count += 1;


### PR DESCRIPTION
## Purpose

Add support for setting the amount to send in the generator example.

## Changes

- Add an `--amount` command-line parameter to the generator example for providing the transfer amount.

## Checklist

- [X] My code follows the style of this project.
- [X] The code compiles without warnings.
- [X] I have performed a self-review of the changes.
- [ ] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [ ] (If necessary) I have updated the CHANGELOG.
