### PR TITLE
First round of gRPC api v2 functions

### DIFF
--- a/examples/v2_get_account_info.rs
+++ b/examples/v2_get_account_info.rs
@@ -1,4 +1,4 @@
-/// Test the `GetAccountInfo` endpoint.
+//! Test the `GetAccountInfo` endpoint.
 use anyhow::Context;
 use clap::AppSettings;
 use concordium_rust_sdk::id::types::AccountAddress;

--- a/examples/v2_get_account_list.rs
+++ b/examples/v2_get_account_list.rs
@@ -1,4 +1,4 @@
-/// Test the `GetAccountList` endpoint.
+//! Test the `GetAccountList` endpoint.
 use anyhow::Context;
 use clap::AppSettings;
 use concordium_rust_sdk::v2;

--- a/examples/v2_get_ancestors.rs
+++ b/examples/v2_get_ancestors.rs
@@ -1,0 +1,48 @@
+/// Test the `GetAncestors` endpoint.
+use anyhow::Context;
+use clap::AppSettings;
+use concordium_rust_sdk::{types::hashes::BlockHash, v2, v2::BlockIdentifier};
+use futures::StreamExt;
+use structopt::StructOpt;
+
+#[derive(StructOpt)]
+struct App {
+    #[structopt(
+        long = "node",
+        help = "GRPC interface of the node.",
+        default_value = "http://localhost:10001"
+    )]
+    endpoint: tonic::transport::Endpoint,
+    #[structopt(
+        long = "block_hash",
+        help = "Block hash to query. Default: \"best\" block."
+    )]
+    block:    Option<BlockHash>,
+    #[structopt(long = "amount", help = "Maximum amount of ancestors to be returned.")]
+    amount:   u64,
+}
+
+#[tokio::main(flavor = "multi_thread")]
+async fn main() -> anyhow::Result<()> {
+    let app = {
+        let app = App::clap().global_setting(AppSettings::ColoredHelp);
+        let matches = app.get_matches();
+        App::from_clap(&matches)
+    };
+
+    let mut client = v2::Client::new(app.endpoint)
+        .await
+        .context("Cannot connect.")?;
+
+    let bi = app
+        .block
+        .map_or(BlockIdentifier::Best, BlockIdentifier::Given);
+
+    let mut res = client.get_ancestors(&bi, app.amount).await?;
+    println!("Blockhash: {}", res.block_hash);
+    while let Some(a) = res.response.next().await {
+        println!("{}", a?);
+    }
+
+    Ok(())
+}

--- a/examples/v2_get_ancestors.rs
+++ b/examples/v2_get_ancestors.rs
@@ -1,7 +1,7 @@
-/// Test the `GetAncestors` endpoint.
+//! Test the `GetAncestors` endpoint.
 use anyhow::Context;
 use clap::AppSettings;
-use concordium_rust_sdk::{types::hashes::BlockHash, v2, v2::BlockIdentifier};
+use concordium_rust_sdk::{endpoints, types::hashes::BlockHash, v2, v2::BlockIdentifier};
 use futures::StreamExt;
 use structopt::StructOpt;
 
@@ -12,7 +12,7 @@ struct App {
         help = "GRPC interface of the node.",
         default_value = "http://localhost:10001"
     )]
-    endpoint: tonic::transport::Endpoint,
+    endpoint: endpoints::Endpoint,
     #[structopt(
         long = "block_hash",
         help = "Block hash to query. Default: \"best\" block."

--- a/examples/v2_get_consensus_info.rs
+++ b/examples/v2_get_consensus_info.rs
@@ -1,0 +1,33 @@
+/// Test the `GetAccountInfo` endpoint.
+use anyhow::Context;
+use clap::AppSettings;
+use concordium_rust_sdk::v2;
+use structopt::StructOpt;
+
+#[derive(StructOpt)]
+struct App {
+    #[structopt(
+        long = "node",
+        help = "GRPC interface of the node.",
+        default_value = "http://localhost:10001"
+    )]
+    endpoint: tonic::transport::Endpoint,
+}
+
+#[tokio::main(flavor = "multi_thread")]
+async fn main() -> anyhow::Result<()> {
+    let app = {
+        let app = App::clap().global_setting(AppSettings::ColoredHelp);
+        let matches = app.get_matches();
+        App::from_clap(&matches)
+    };
+
+    let mut client = v2::Client::new(app.endpoint)
+        .await
+        .context("Cannot connect.")?;
+
+    let info = client.get_consensus_info().await?;
+    println!("{:#?}", info);
+
+    Ok(())
+}

--- a/examples/v2_get_consensus_info.rs
+++ b/examples/v2_get_consensus_info.rs
@@ -1,4 +1,4 @@
-/// Test the `GetAccountInfo` endpoint.
+/// Test the `GetConsensusInfo` endpoint.
 use anyhow::Context;
 use clap::AppSettings;
 use concordium_rust_sdk::v2;

--- a/examples/v2_get_consensus_info.rs
+++ b/examples/v2_get_consensus_info.rs
@@ -1,7 +1,7 @@
-/// Test the `GetConsensusInfo` endpoint.
+//! Test the `GetConsensusInfo` endpoint.
 use anyhow::Context;
 use clap::AppSettings;
-use concordium_rust_sdk::v2;
+use concordium_rust_sdk::{endpoints, v2};
 use structopt::StructOpt;
 
 #[derive(StructOpt)]
@@ -11,7 +11,7 @@ struct App {
         help = "GRPC interface of the node.",
         default_value = "http://localhost:10001"
     )]
-    endpoint: tonic::transport::Endpoint,
+    endpoint: endpoints::Endpoint,
 }
 
 #[tokio::main(flavor = "multi_thread")]
@@ -22,7 +22,7 @@ async fn main() -> anyhow::Result<()> {
         App::from_clap(&matches)
     };
 
-    let mut client = v2::Client::new(app.endpoint)
+    let mut client = v2::Client::new(app.endpoint.clone())
         .await
         .context("Cannot connect.")?;
 

--- a/examples/v2_get_finalized_blocks.rs
+++ b/examples/v2_get_finalized_blocks.rs
@@ -1,4 +1,4 @@
-/// Test the `GetFinalizedBlocks` endpoint.
+//! Test the `GetFinalizedBlocks` endpoint.
 use anyhow::Context;
 use clap::AppSettings;
 use concordium_rust_sdk::v2;

--- a/examples/v2_get_instance_list.rs
+++ b/examples/v2_get_instance_list.rs
@@ -1,7 +1,7 @@
-/// Test the `GetInstanceList` endpoint.
+//! Test the `GetInstanceList` endpoint.
 use anyhow::Context;
 use clap::AppSettings;
-use concordium_rust_sdk::v2;
+use concordium_rust_sdk::{endpoints, v2};
 use futures::StreamExt;
 use structopt::StructOpt;
 
@@ -12,7 +12,7 @@ struct App {
         help = "GRPC interface of the node.",
         default_value = "http://localhost:10001"
     )]
-    endpoint: tonic::transport::Endpoint,
+    endpoint: endpoints::Endpoint,
 }
 
 #[tokio::main(flavor = "multi_thread")]

--- a/examples/v2_get_instance_list.rs
+++ b/examples/v2_get_instance_list.rs
@@ -1,4 +1,4 @@
-/// Test the `GetModuleList` endpoint.
+/// Test the `GetInstanceList` endpoint.
 use anyhow::Context;
 use clap::AppSettings;
 use concordium_rust_sdk::v2;
@@ -26,11 +26,11 @@ async fn main() -> anyhow::Result<()> {
     let mut client = v2::Client::new(app.endpoint)
         .await
         .context("Cannot connect.")?;
-    let mut al = client
-        .get_module_list(&v2::BlockIdentifier::LastFinal)
+    let mut res = client
+        .get_instance_list(&v2::BlockIdentifier::LastFinal)
         .await?;
-    println!("Blockhash: {}", al.block_hash);
-    while let Some(a) = al.response.next().await {
+    println!("Blockhash: {}", res.block_hash);
+    while let Some(a) = res.response.next().await {
         println!("{}", a?);
     }
     Ok(())

--- a/examples/v2_get_module_list.rs
+++ b/examples/v2_get_module_list.rs
@@ -1,4 +1,4 @@
-/// Test the `GetModuleList` endpoint.
+/// Test the `GetAccountList` endpoint.
 use anyhow::Context;
 use clap::AppSettings;
 use concordium_rust_sdk::v2;
@@ -27,7 +27,7 @@ async fn main() -> anyhow::Result<()> {
         .await
         .context("Cannot connect.")?;
     let mut al = client
-        .get_account_list(&v2::BlockIdentifier::LastFinal)
+        .get_module_list(&v2::BlockIdentifier::LastFinal)
         .await?;
     println!("Blockhash: {}", al.block_hash);
     while let Some(a) = al.response.next().await {

--- a/examples/v2_get_module_list.rs
+++ b/examples/v2_get_module_list.rs
@@ -1,7 +1,7 @@
-/// Test the `GetModuleList` endpoint.
+//! Test the `GetModuleList` endpoint.
 use anyhow::Context;
 use clap::AppSettings;
-use concordium_rust_sdk::v2;
+use concordium_rust_sdk::{endpoints,v2};
 use futures::StreamExt;
 use structopt::StructOpt;
 
@@ -12,7 +12,7 @@ struct App {
         help = "GRPC interface of the node.",
         default_value = "http://localhost:10001"
     )]
-    endpoint: tonic::transport::Endpoint,
+    endpoint: endpoints::Endpoint,
 }
 
 #[tokio::main(flavor = "multi_thread")]

--- a/examples/v2_get_module_source.rs
+++ b/examples/v2_get_module_source.rs
@@ -31,10 +31,10 @@ async fn main() -> anyhow::Result<()> {
         .context("Cannot connect.")?;
 
     let res = client
-        .get_module_source(&app.module.into(), &v2::BlockIdentifier::LastFinal)
+        .get_module_source(&app.module, &v2::BlockIdentifier::LastFinal)
         .await?;
     // TODO: Print in binary so you can pipe to file, or make user provide file.
-    println!("{:#?}", res);
+    println!("{:?}", res);
 
     Ok(())
 }

--- a/examples/v2_get_next_account_nonce.rs
+++ b/examples/v2_get_next_account_nonce.rs
@@ -1,0 +1,41 @@
+/// Test the `GetAccountInfo` endpoint.
+use anyhow::Context;
+use clap::AppSettings;
+use concordium_rust_sdk::v2;
+use futures::StreamExt;
+use structopt::StructOpt;
+
+#[derive(StructOpt)]
+struct App {
+    #[structopt(
+        long = "node",
+        help = "GRPC interface of the node.",
+        default_value = "http://localhost:10001"
+    )]
+    endpoint: tonic::transport::Endpoint,
+}
+
+#[tokio::main(flavor = "multi_thread")]
+async fn main() -> anyhow::Result<()> {
+    let app = {
+        let app = App::clap().global_setting(AppSettings::ColoredHelp);
+        let matches = app.get_matches();
+        App::from_clap(&matches)
+    };
+
+    let mut client = v2::Client::new(app.endpoint)
+        .await
+        .context("Cannot connect.")?;
+
+    let mut accounts = client.get_account_list(&v2::BlockIdentifier::Best).await?;
+    while let Some(account) = accounts.response.next().await {
+        let account = account?;
+        let next_nonce = client.get_next_account_nonce(&account.into()).await?;
+        println!(
+            "{}: nonce {}, all_final {:?}",
+            account, next_nonce.nonce, next_nonce.all_final
+        );
+    }
+
+    Ok(())
+}

--- a/examples/v2_get_next_account_sequence_number.rs
+++ b/examples/v2_get_next_account_sequence_number.rs
@@ -1,4 +1,4 @@
-/// Test the `GetAccountInfo` endpoint.
+/// Test the `GetNextAccountSequenceNumber` endpoint.
 use anyhow::Context;
 use clap::AppSettings;
 use concordium_rust_sdk::v2;
@@ -30,9 +30,7 @@ async fn main() -> anyhow::Result<()> {
     let mut accounts = client.get_account_list(&v2::BlockIdentifier::Best).await?;
     while let Some(account) = accounts.response.next().await {
         let account = account?;
-        let next_nonce = client
-            .get_next_account_sequence_number(&account.into())
-            .await?;
+        let next_nonce = client.get_next_account_sequence_number(&account).await?;
         println!(
             "{}: nonce {}, all_final {:?}",
             account, next_nonce.nonce, next_nonce.all_final

--- a/examples/v2_get_next_account_sequence_number.rs
+++ b/examples/v2_get_next_account_sequence_number.rs
@@ -30,7 +30,9 @@ async fn main() -> anyhow::Result<()> {
     let mut accounts = client.get_account_list(&v2::BlockIdentifier::Best).await?;
     while let Some(account) = accounts.response.next().await {
         let account = account?;
-        let next_nonce = client.get_next_account_nonce(&account.into()).await?;
+        let next_nonce = client
+            .get_next_account_sequence_number(&account.into())
+            .await?;
         println!(
             "{}: nonce {}, all_final {:?}",
             account, next_nonce.nonce, next_nonce.all_final

--- a/src/v2/generated.rs
+++ b/src/v2/generated.rs
@@ -35,10 +35,10 @@ impl TryFrom<AccountAddress> for super::AccountAddress {
     }
 }
 
-impl TryFrom<ModuleReference> for super::ModuleRef {
+impl TryFrom<ModuleRef> for super::ModuleRef {
     type Error = tonic::Status;
 
-    fn try_from(value: ModuleReference) -> Result<Self, Self::Error> {
+    fn try_from(value: ModuleRef) -> Result<Self, Self::Error> {
         match value.value.try_into() {
             Ok(mod_ref) => Ok(Self::new(mod_ref)),
             Err(_) => Err(tonic::Status::internal(
@@ -46,6 +46,16 @@ impl TryFrom<ModuleReference> for super::ModuleRef {
             )),
         }
     }
+}
+
+impl From<ContractAddress> for super::ContractAddress {
+    fn from(value: ContractAddress) -> Self {
+        super::ContractAddress::new(value.index, value.subindex)
+    }
+}
+
+impl From<ModuleSource> for super::ModuleSource {
+    fn from(value: ModuleSource) -> Self { value.value.into() }
 }
 
 impl TryFrom<BlockHash> for super::BlockHash {

--- a/src/v2/generated.rs
+++ b/src/v2/generated.rs
@@ -35,6 +35,19 @@ impl TryFrom<AccountAddress> for super::AccountAddress {
     }
 }
 
+impl TryFrom<ModuleReference> for super::ModuleRef {
+    type Error = tonic::Status;
+
+    fn try_from(value: ModuleReference) -> Result<Self, Self::Error> {
+        match value.value.try_into() {
+            Ok(mod_ref) => Ok(Self::new(mod_ref)),
+            Err(_) => Err(tonic::Status::internal(
+                "Unexpected module reference format.",
+            )),
+        }
+    }
+}
+
 impl TryFrom<BlockHash> for super::BlockHash {
     type Error = tonic::Status;
 

--- a/src/v2/generated.rs
+++ b/src/v2/generated.rs
@@ -1,5 +1,8 @@
+#![allow(clippy::large_enum_variant, clippy::enum_variant_names)]
 tonic::include_proto!("concordium.v2");
 
+use super::Require;
+use crate::types;
 use crypto_common::{Deserial, Versioned, VERSION_0};
 use id::{
     constants::{ArCurve, AttributeKind},
@@ -8,8 +11,6 @@ use id::{
         InitialCredentialDeploymentValues,
     },
 };
-
-use super::Require;
 
 fn consume<A: Deserial>(bytes: &[u8]) -> Result<A, tonic::Status> {
     let mut cursor = std::io::Cursor::new(bytes);

--- a/src/v2/generated.rs
+++ b/src/v2/generated.rs
@@ -9,6 +9,8 @@ use id::{
     },
 };
 
+use crate::types;
+
 use super::Require;
 
 fn consume<A: Deserial>(bytes: &[u8]) -> Result<A, tonic::Status> {
@@ -620,6 +622,17 @@ impl TryFrom<AccountInfo> for super::types::AccountInfo {
             account_index,
             account_stake,
             account_address,
+        })
+    }
+}
+
+impl TryFrom<NextAccountNonce> for types::queries::AccountNonceResponse {
+    type Error = tonic::Status;
+
+    fn try_from(value: NextAccountNonce) -> Result<Self, Self::Error> {
+        Ok(Self {
+            nonce:     value.nonce.require_owned()?.into(),
+            all_final: value.all_final,
         })
     }
 }

--- a/src/v2/generated.rs
+++ b/src/v2/generated.rs
@@ -56,8 +56,26 @@ impl From<ContractAddress> for super::ContractAddress {
     }
 }
 
-impl From<ModuleSource> for super::ModuleSource {
-    fn from(value: ModuleSource) -> Self { value.value.into() }
+impl TryFrom<VersionedModuleSource> for types::smart_contracts::WasmModule {
+    type Error = tonic::Status;
+
+    fn try_from(versioned_module: VersionedModuleSource) -> Result<Self, Self::Error> {
+        let module = match versioned_module.module.require_owned()? {
+            versioned_module_source::Module::V0(versioned_module_source::ModuleSourceV0 {
+                value,
+            }) => types::smart_contracts::WasmModule {
+                version: types::smart_contracts::WasmVersion::V0,
+                source:  value.into(),
+            },
+            versioned_module_source::Module::V1(versioned_module_source::ModuleSourceV1 {
+                value,
+            }) => types::smart_contracts::WasmModule {
+                version: types::smart_contracts::WasmVersion::V1,
+                source:  value.into(),
+            },
+        };
+        Ok(module)
+    }
 }
 
 impl TryFrom<BlockHash> for super::BlockHash {

--- a/src/v2/generated.rs
+++ b/src/v2/generated.rs
@@ -9,8 +9,6 @@ use id::{
     },
 };
 
-use crate::types;
-
 use super::Require;
 
 fn consume<A: Deserial>(bytes: &[u8]) -> Result<A, tonic::Status> {
@@ -56,21 +54,22 @@ impl From<ContractAddress> for super::ContractAddress {
     }
 }
 
-impl TryFrom<VersionedModuleSource> for types::smart_contracts::WasmModule {
+impl TryFrom<VersionedModuleSource> for super::types::smart_contracts::WasmModule {
     type Error = tonic::Status;
 
     fn try_from(versioned_module: VersionedModuleSource) -> Result<Self, Self::Error> {
+        use super::types::smart_contracts::WasmVersion;
         let module = match versioned_module.module.require()? {
             versioned_module_source::Module::V0(versioned_module_source::ModuleSourceV0 {
                 value,
-            }) => types::smart_contracts::WasmModule {
-                version: types::smart_contracts::WasmVersion::V0,
+            }) => Self {
+                version: WasmVersion::V0,
                 source:  value.into(),
             },
             versioned_module_source::Module::V1(versioned_module_source::ModuleSourceV1 {
                 value,
-            }) => types::smart_contracts::WasmModule {
-                version: types::smart_contracts::WasmVersion::V1,
+            }) => Self {
+                version: WasmVersion::V1,
                 source:  value.into(),
             },
         };
@@ -676,7 +675,7 @@ impl TryFrom<AccountInfo> for super::types::AccountInfo {
     }
 }
 
-impl TryFrom<NextAccountSequenceNumber> for types::queries::AccountNonceResponse {
+impl TryFrom<NextAccountSequenceNumber> for super::types::queries::AccountNonceResponse {
     type Error = tonic::Status;
 
     fn try_from(value: NextAccountSequenceNumber) -> Result<Self, Self::Error> {
@@ -687,7 +686,7 @@ impl TryFrom<NextAccountSequenceNumber> for types::queries::AccountNonceResponse
     }
 }
 
-impl TryFrom<ConsensusInfo> for types::queries::ConsensusInfo {
+impl TryFrom<ConsensusInfo> for super::types::queries::ConsensusInfo {
     type Error = tonic::Status;
 
     fn try_from(value: ConsensusInfo) -> Result<Self, Self::Error> {

--- a/src/v2/mod.rs
+++ b/src/v2/mod.rs
@@ -174,13 +174,13 @@ impl Client {
         })
     }
 
-    pub async fn get_next_account_nonce(
+    pub async fn get_next_account_sequence_number(
         &mut self,
         account_identifier: &AccountIdentifier,
     ) -> endpoints::QueryResult<types::queries::AccountNonceResponse> {
         let response = self
             .client
-            .get_next_account_nonce(account_identifier)
+            .get_next_account_sequence_number(account_identifier)
             .await?;
         let response = types::queries::AccountNonceResponse::try_from(response.into_inner())?;
         Ok(response)

--- a/src/v2/mod.rs
+++ b/src/v2/mod.rs
@@ -1,10 +1,8 @@
 use crate::{
     endpoints,
     types::{
-        self, hashes,
-        hashes::BlockHash,
-        smart_contracts::{ModuleRef, ModuleSource},
-        AbsoluteBlockHeight, AccountInfo, CredentialRegistrationID,
+        self, hashes, hashes::BlockHash, smart_contracts::ModuleRef, AbsoluteBlockHeight,
+        AccountInfo, CredentialRegistrationID,
     },
 };
 use concordium_contracts_common::{AccountAddress, ContractAddress};
@@ -230,10 +228,10 @@ impl Client {
         &mut self,
         module_ref: &ModuleRef,
         bi: &BlockIdentifier,
-    ) -> endpoints::QueryResult<QueryResponse<ModuleSource>> {
+    ) -> endpoints::QueryResult<QueryResponse<types::smart_contracts::WasmModule>> {
         let response = self.client.get_module_source((module_ref, bi)).await?;
         let block_hash = extract_metadata(&response)?;
-        let response = ModuleSource::from(response.into_inner());
+        let response = types::smart_contracts::WasmModule::try_from(response.into_inner())?;
         Ok(QueryResponse {
             block_hash,
             response,

--- a/src/v2/mod.rs
+++ b/src/v2/mod.rs
@@ -186,6 +186,17 @@ impl Client {
         Ok(response)
     }
 
+    pub async fn get_consensus_info(
+        &mut self,
+    ) -> endpoints::QueryResult<types::queries::ConsensusInfo> {
+        let response = self
+            .client
+            .get_consensus_info(generated::Empty::default())
+            .await?;
+        let response = types::queries::ConsensusInfo::try_from(response.into_inner())?;
+        Ok(response)
+    }
+
     pub async fn get_account_list(
         &mut self,
         bi: &BlockIdentifier,

--- a/src/v2/mod.rs
+++ b/src/v2/mod.rs
@@ -1,7 +1,8 @@
 use crate::{
     endpoints,
     types::{
-        self, hashes, hashes::BlockHash, AbsoluteBlockHeight, AccountInfo, CredentialRegistrationID,
+        self, hashes, hashes::BlockHash, smart_contracts::ModuleRef, AbsoluteBlockHeight,
+        AccountInfo, CredentialRegistrationID,
     },
 };
 use concordium_contracts_common::AccountAddress;
@@ -141,6 +142,20 @@ impl Client {
         QueryResponse<impl Stream<Item = Result<AccountAddress, tonic::Status>>>,
     > {
         let response = self.client.get_account_list(bi).await?;
+        let block_hash = extract_metadata(&response)?;
+        let stream = response.into_inner().map(|x| x.and_then(TryFrom::try_from));
+        Ok(QueryResponse {
+            block_hash,
+            response: stream,
+        })
+    }
+
+    pub async fn get_module_list(
+        &mut self,
+        bi: &BlockIdentifier,
+    ) -> endpoints::QueryResult<QueryResponse<impl Stream<Item = Result<ModuleRef, tonic::Status>>>>
+    {
+        let response = self.client.get_module_list(bi).await?;
         let block_hash = extract_metadata(&response)?;
         let stream = response.into_inner().map(|x| x.and_then(TryFrom::try_from));
         Ok(QueryResponse {


### PR DESCRIPTION
## Purpose

Support some of the new gRPC functions.

## Changes

- Implement `get_next_account_sequence_number`, `get_consensus_info`, `get_module_list`, `get_module_source`, `get_instance_list` and `get_ancestors` in v2 client.

## Checklist

- [ ] My code follows the style of this project.
- [ ] The code compiles without warnings.
- [ ] I have performed a self-review of the changes.
- [ ] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [ ] (If necessary) I have updated the CHANGELOG.