### PR TITLE
Another round of gRPC v2 api functions

### DIFF
--- a/examples/v2_get_baker_list.rs
+++ b/examples/v2_get_baker_list.rs
@@ -1,0 +1,37 @@
+/// Test the `GetInstanceList` endpoint.
+use anyhow::Context;
+use clap::AppSettings;
+use concordium_rust_sdk::v2;
+use futures::StreamExt;
+use structopt::StructOpt;
+
+#[derive(StructOpt)]
+struct App {
+    #[structopt(
+        long = "node",
+        help = "GRPC interface of the node.",
+        default_value = "http://localhost:10001"
+    )]
+    endpoint: tonic::transport::Endpoint,
+}
+
+#[tokio::main(flavor = "multi_thread")]
+async fn main() -> anyhow::Result<()> {
+    let app = {
+        let app = App::clap().global_setting(AppSettings::ColoredHelp);
+        let matches = app.get_matches();
+        App::from_clap(&matches)
+    };
+
+    let mut client = v2::Client::new(app.endpoint)
+        .await
+        .context("Cannot connect.")?;
+    let mut res = client
+        .get_baker_list(&v2::BlockIdentifier::LastFinal)
+        .await?;
+    println!("Blockhash: {}", res.block_hash);
+    while let Some(a) = res.response.next().await {
+        println!("{}", a?);
+    }
+    Ok(())
+}

--- a/examples/v2_get_block_info.rs
+++ b/examples/v2_get_block_info.rs
@@ -1,0 +1,43 @@
+/// Test the `GetAccountInfo` endpoint.
+use anyhow::Context;
+use clap::AppSettings;
+use structopt::StructOpt;
+
+use concordium_rust_sdk::v2;
+
+#[derive(StructOpt)]
+struct App {
+    #[structopt(
+        long = "node",
+        help = "GRPC interface of the node.",
+        default_value = "http://localhost:10001"
+    )]
+    endpoint: tonic::transport::Endpoint,
+}
+
+#[tokio::main(flavor = "multi_thread")]
+async fn main() -> anyhow::Result<()> {
+    let app = {
+        let app = App::clap().global_setting(AppSettings::ColoredHelp);
+        let matches = app.get_matches();
+        App::from_clap(&matches)
+    };
+
+    let mut client = v2::Client::new(app.endpoint)
+        .await
+        .context("Cannot connect.")?;
+
+    {
+        let ai = client.get_block_info(&v2::BlockIdentifier::Best).await?;
+        println!("Best block {:#?}", ai);
+    }
+
+    {
+        let ai = client
+            .get_block_info(&v2::BlockIdentifier::LastFinal)
+            .await?;
+        println!("Last finalized {:#?}", ai);
+    }
+
+    Ok(())
+}

--- a/examples/v2_get_blocks_at_height.rs
+++ b/examples/v2_get_blocks_at_height.rs
@@ -1,0 +1,46 @@
+/// Test the `GetInstanceList` endpoint.
+use anyhow::Context;
+use clap::AppSettings;
+use concordium_rust_sdk::{endpoints::BlocksAtHeightInput, v2};
+use futures::StreamExt;
+use structopt::StructOpt;
+
+#[derive(StructOpt)]
+struct App {
+    #[structopt(
+        long = "node",
+        help = "GRPC interface of the node.",
+        default_value = "http://localhost:10001"
+    )]
+    endpoint: tonic::transport::Endpoint,
+}
+
+#[tokio::main(flavor = "multi_thread")]
+async fn main() -> anyhow::Result<()> {
+    let app = {
+        let app = App::clap().global_setting(AppSettings::ColoredHelp);
+        let matches = app.get_matches();
+        App::from_clap(&matches)
+    };
+
+    let mut client = v2::Client::new(app.endpoint)
+        .await
+        .context("Cannot connect.")?;
+
+    let info = client.get_consensus_info().await?;
+
+    let mut response = client
+        .get_blocks_at_height(&BlocksAtHeightInput::Absolute {
+            height: info.best_block_height,
+        })
+        .await?;
+    println!(
+        "Blocks at best block {} ({}):",
+        info.best_block, info.best_block_height
+    );
+    while let Some(a) = response.next().await {
+        println!("{}", a?);
+    }
+
+    Ok(())
+}

--- a/examples/v2_get_cryptographic_parameters.rs
+++ b/examples/v2_get_cryptographic_parameters.rs
@@ -1,0 +1,35 @@
+/// Test the `GetAccountInfo` endpoint.
+use anyhow::Context;
+use clap::AppSettings;
+use concordium_rust_sdk::v2::{self, BlockIdentifier};
+use structopt::StructOpt;
+
+#[derive(StructOpt)]
+struct App {
+    #[structopt(
+        long = "node",
+        help = "GRPC interface of the node.",
+        default_value = "http://localhost:10001"
+    )]
+    endpoint: tonic::transport::Endpoint,
+}
+
+#[tokio::main(flavor = "multi_thread")]
+async fn main() -> anyhow::Result<()> {
+    let app = {
+        let app = App::clap().global_setting(AppSettings::ColoredHelp);
+        let matches = app.get_matches();
+        App::from_clap(&matches)
+    };
+
+    let mut client = v2::Client::new(app.endpoint)
+        .await
+        .context("Cannot connect.")?;
+
+    let info = client
+        .get_cryptographic_parameters(&BlockIdentifier::Best)
+        .await?;
+
+    println!("{:#?}", info);
+    Ok(())
+}

--- a/examples/v2_get_passive_delegation_info.rs
+++ b/examples/v2_get_passive_delegation_info.rs
@@ -1,4 +1,4 @@
-/// Test the `GetTokenomicsStatus` endpoint.
+/// Test the `GetPassiveDelegationInfo` endpoint.
 use anyhow::Context;
 use clap::AppSettings;
 use structopt::StructOpt;
@@ -29,14 +29,14 @@ async fn main() -> anyhow::Result<()> {
 
     {
         let ai = client
-            .get_tokenomics_status(&v2::BlockIdentifier::Best)
+            .get_passive_delegation_info(&v2::BlockIdentifier::Best)
             .await?;
         println!("Best block {:#?}", ai);
     }
 
     {
         let ai = client
-            .get_tokenomics_status(&v2::BlockIdentifier::LastFinal)
+            .get_passive_delegation_info(&v2::BlockIdentifier::LastFinal)
             .await?;
         println!("Last finalized {:#?}", ai);
     }

--- a/examples/v2_get_passive_delegation_status.rs
+++ b/examples/v2_get_passive_delegation_status.rs
@@ -1,0 +1,45 @@
+/// Test the `GetPassiveDelegationStatus` endpoint.
+use anyhow::Context;
+use clap::AppSettings;
+use structopt::StructOpt;
+
+use concordium_rust_sdk::v2;
+
+#[derive(StructOpt)]
+struct App {
+    #[structopt(
+        long = "node",
+        help = "GRPC interface of the node.",
+        default_value = "http://localhost:10001"
+    )]
+    endpoint: tonic::transport::Endpoint,
+}
+
+#[tokio::main(flavor = "multi_thread")]
+async fn main() -> anyhow::Result<()> {
+    let app = {
+        let app = App::clap().global_setting(AppSettings::ColoredHelp);
+        let matches = app.get_matches();
+        App::from_clap(&matches)
+    };
+
+    let mut client = v2::Client::new(app.endpoint)
+        .await
+        .context("Cannot connect.")?;
+
+    {
+        let ai = client
+            .get_passive_delegation_status(&v2::BlockIdentifier::Best)
+            .await?;
+        println!("Best block {:#?}", ai);
+    }
+
+    {
+        let ai = client
+            .get_passive_delegation_status(&v2::BlockIdentifier::LastFinal)
+            .await?;
+        println!("Last finalized {:#?}", ai);
+    }
+
+    Ok(())
+}

--- a/examples/v2_get_pool_info.rs
+++ b/examples/v2_get_pool_info.rs
@@ -1,4 +1,4 @@
-/// Test the `GetPoolStatus` endpoint.
+/// Test the `GetPoolInfo` endpoint.
 use anyhow::Context;
 use clap::AppSettings;
 use concordium_rust_sdk::v2;
@@ -32,7 +32,7 @@ async fn main() -> anyhow::Result<()> {
     while let Some(a) = res.response.next().await {
         let baker_id = a?;
         let status = client
-            .get_pool_status(&v2::BlockIdentifier::Best, baker_id)
+            .get_pool_info(&v2::BlockIdentifier::Best, baker_id)
             .await?;
         println!("Baker {:#?}: {:#?}", baker_id, status);
     }

--- a/examples/v2_get_pool_status.rs
+++ b/examples/v2_get_pool_status.rs
@@ -1,0 +1,41 @@
+/// Test the `GetPoolStatus` endpoint.
+use anyhow::Context;
+use clap::AppSettings;
+use concordium_rust_sdk::v2;
+use futures::StreamExt;
+use structopt::StructOpt;
+
+#[derive(StructOpt)]
+struct App {
+    #[structopt(
+        long = "node",
+        help = "GRPC interface of the node.",
+        default_value = "http://localhost:10001"
+    )]
+    endpoint: tonic::transport::Endpoint,
+}
+
+#[tokio::main(flavor = "multi_thread")]
+async fn main() -> anyhow::Result<()> {
+    let app = {
+        let app = App::clap().global_setting(AppSettings::ColoredHelp);
+        let matches = app.get_matches();
+        App::from_clap(&matches)
+    };
+
+    let mut client = v2::Client::new(app.endpoint)
+        .await
+        .context("Cannot connect.")?;
+
+    let mut res = client.get_baker_list(&v2::BlockIdentifier::Best).await?;
+    println!("Best block {:#?}:", res.block_hash);
+    while let Some(a) = res.response.next().await {
+        let baker_id = a?;
+        let status = client
+            .get_pool_status(&v2::BlockIdentifier::Best, baker_id)
+            .await?;
+        println!("Baker {:#?}: {:#?}", baker_id, status);
+    }
+
+    Ok(())
+}

--- a/examples/v2_get_tokenomics_info.rs
+++ b/examples/v2_get_tokenomics_info.rs
@@ -1,4 +1,4 @@
-/// Test the `GetPassiveDelegationStatus` endpoint.
+/// Test the `GetTokenomicsInfo` endpoint.
 use anyhow::Context;
 use clap::AppSettings;
 use structopt::StructOpt;
@@ -29,14 +29,14 @@ async fn main() -> anyhow::Result<()> {
 
     {
         let ai = client
-            .get_passive_delegation_status(&v2::BlockIdentifier::Best)
+            .get_tokenomics_info(&v2::BlockIdentifier::Best)
             .await?;
         println!("Best block {:#?}", ai);
     }
 
     {
         let ai = client
-            .get_passive_delegation_status(&v2::BlockIdentifier::LastFinal)
+            .get_tokenomics_info(&v2::BlockIdentifier::LastFinal)
             .await?;
         println!("Last finalized {:#?}", ai);
     }

--- a/examples/v2_get_tokenomics_status.rs
+++ b/examples/v2_get_tokenomics_status.rs
@@ -1,0 +1,45 @@
+/// Test the `GetTokenomicsStatus` endpoint.
+use anyhow::Context;
+use clap::AppSettings;
+use structopt::StructOpt;
+
+use concordium_rust_sdk::v2;
+
+#[derive(StructOpt)]
+struct App {
+    #[structopt(
+        long = "node",
+        help = "GRPC interface of the node.",
+        default_value = "http://localhost:10001"
+    )]
+    endpoint: tonic::transport::Endpoint,
+}
+
+#[tokio::main(flavor = "multi_thread")]
+async fn main() -> anyhow::Result<()> {
+    let app = {
+        let app = App::clap().global_setting(AppSettings::ColoredHelp);
+        let matches = app.get_matches();
+        App::from_clap(&matches)
+    };
+
+    let mut client = v2::Client::new(app.endpoint)
+        .await
+        .context("Cannot connect.")?;
+
+    {
+        let ai = client
+            .get_tokenomics_status(&v2::BlockIdentifier::Best)
+            .await?;
+        println!("Best block {:#?}", ai);
+    }
+
+    {
+        let ai = client
+            .get_tokenomics_status(&v2::BlockIdentifier::LastFinal)
+            .await?;
+        println!("Last finalized {:#?}", ai);
+    }
+
+    Ok(())
+}

--- a/src/types/mod.rs
+++ b/src/types/mod.rs
@@ -391,46 +391,60 @@ mod lottery_power_parser {
 }
 
 #[derive(SerdeSerialize, SerdeDeserialize, Debug, Clone)]
+#[serde(rename_all = "camelCase")]
+pub struct BakerPoolStatus {
+    /// The 'BakerId' of the pool owner.
+    pub baker_id:                   BakerId,
+    /// The account address of the pool owner.
+    pub baker_address:              AccountAddress,
+    /// The equity capital provided by the pool owner.
+    pub baker_equity_capital:       Amount,
+    /// The capital delegated to the pool by other accounts.
+    pub delegated_capital:          Amount,
+    /// The maximum amount that may be delegated to the pool, accounting for
+    /// leverage and stake limits.
+    pub delegated_capital_cap:      Amount,
+    /// The pool info associated with the pool: open status, metadata URL
+    /// and commission rates.
+    pub pool_info:                  BakerPoolInfo,
+    /// Any pending change to the baker's stake.
+    pub baker_stake_pending_change: PoolPendingChange,
+    /// Status of the pool in the current reward period. This will be [None]
+    /// if the pool is not a
+    pub current_payday_status:      Option<CurrentPaydayBakerPoolStatus>,
+    /// Total capital staked across all pools.
+    pub all_pool_total_capital:     Amount,
+}
+
+#[derive(SerdeSerialize, SerdeDeserialize, Debug, Clone)]
+#[serde(rename_all = "camelCase")]
+pub struct PassiveDelegationStatus {
+    /// The total capital delegated passively.
+    pub delegated_capital: Amount,
+    /// The passive delegation commission rates.
+    pub commission_rates: CommissionRates,
+    /// The transaction fees accruing to the passive delegators in the
+    /// current reward period.
+    pub current_payday_transaction_fees_earned: Amount,
+    /// The effective delegated capital to the passive delegators for the
+    /// current reward period.
+    pub current_payday_delegated_capital: Amount,
+    /// Total capital staked across all pools, including passive delegation.
+    pub all_pool_total_capital: Amount,
+}
+
+#[derive(SerdeSerialize, SerdeDeserialize, Debug, Clone)]
 #[serde(tag = "poolType")]
 pub enum PoolStatus {
     #[serde(rename_all = "camelCase")]
     BakerPool {
-        /// The 'BakerId' of the pool owner.
-        baker_id:                   BakerId,
-        /// The account address of the pool owner.
-        baker_address:              AccountAddress,
-        /// The equity capital provided by the pool owner.
-        baker_equity_capital:       Amount,
-        /// The capital delegated to the pool by other accounts.
-        delegated_capital:          Amount,
-        /// The maximum amount that may be delegated to the pool, accounting for
-        /// leverage and stake limits.
-        delegated_capital_cap:      Amount,
-        /// The pool info associated with the pool: open status, metadata URL
-        /// and commission rates.
-        pool_info:                  BakerPoolInfo,
-        /// Any pending change to the baker's stake.
-        baker_stake_pending_change: PoolPendingChange,
-        /// Status of the pool in the current reward period. This will be [None]
-        /// if the pool is not a
-        current_payday_status:      Option<CurrentPaydayBakerPoolStatus>,
-        /// Total capital staked across all pools.
-        all_pool_total_capital:     Amount,
+        #[serde(flatten)]
+        status: BakerPoolStatus,
     },
     #[serde(rename_all = "camelCase")]
     PassiveDelegation {
-        /// The total capital delegated passively.
-        delegated_capital: Amount,
-        /// The passive delegation commission rates.
-        commission_rates: CommissionRates,
-        /// The transaction fees accruing to the passive delegators in the
-        /// current reward period.
-        current_payday_transaction_fees_earned: Amount,
-        /// The effective delegated capital to the passive delegators for the
-        /// current reward period.
-        current_payday_delegated_capital: Amount,
-        /// Total capital staked across all pools, including passive delegation.
-        all_pool_total_capital: Amount,
+        #[serde(flatten)]
+        status: PassiveDelegationStatus,
     },
 }
 

--- a/src/types/queries.rs
+++ b/src/types/queries.rs
@@ -52,6 +52,8 @@ pub struct BlockInfo {
     pub block_baker:             Option<BakerId>,
 }
 
+pub type CryptographicParameters = id::types::GlobalContext<id::constants::ArCurve>;
+
 #[derive(Debug, SerdeSerialize, SerdeDeserialize)]
 #[serde(rename_all = "camelCase")]
 /// Summary of the current state of consensus.

--- a/src/v2/generated.rs
+++ b/src/v2/generated.rs
@@ -715,3 +715,22 @@ impl TryFrom<ConsensusInfo> for types::queries::ConsensusInfo {
         })
     }
 }
+
+impl TryFrom<CryptographicParameters> for types::queries::CryptographicParameters {
+    type Error = tonic::Status;
+
+    fn try_from(value: CryptographicParameters) -> Result<Self, Self::Error> {
+        Ok(Self {
+            genesis_string:          value.genesis_string,
+            on_chain_commitment_key: crypto_common::from_bytes(&mut std::io::Cursor::new(
+                &value.on_chain_commitment_key,
+            ))
+            .map_err(|_| tonic::Status::internal("Invalid on_chain_commitment_key received"))?,
+
+            bulletproof_generators: crypto_common::from_bytes(&mut std::io::Cursor::new(
+                &value.bulletproof_generators,
+            ))
+            .map_err(|_| tonic::Status::internal("Invalid bulletproof_generators received"))?,
+        })
+    }
+}

--- a/src/v2/generated.rs
+++ b/src/v2/generated.rs
@@ -56,6 +56,18 @@ impl From<ContractAddress> for super::ContractAddress {
     }
 }
 
+impl From<Energy> for super::types::Energy {
+    fn from(value: Energy) -> Self {
+        super::types::Energy {
+            energy: value.value,
+        }
+    }
+}
+
+impl From<Slot> for super::types::Slot {
+    fn from(value: Slot) -> Self { super::types::Slot { slot: value.value } }
+}
+
 impl TryFrom<VersionedModuleSource> for types::smart_contracts::WasmModule {
     type Error = tonic::Status;
 
@@ -96,6 +108,17 @@ impl TryFrom<TransactionHash> for super::hashes::TransactionHash {
         match value.value.try_into() {
             Ok(hash) => Ok(Self::new(hash)),
             Err(_) => Err(tonic::Status::internal("Unexpected block hash format.")),
+        }
+    }
+}
+
+impl TryFrom<StateHash> for super::hashes::StateHash {
+    type Error = tonic::Status;
+
+    fn try_from(value: StateHash) -> Result<Self, Self::Error> {
+        match value.value.try_into() {
+            Ok(hash) => Ok(Self::new(hash)),
+            Err(_) => Err(tonic::Status::internal("Unexpected state hash format.")),
         }
     }
 }
@@ -749,6 +772,31 @@ impl TryFrom<CryptographicParameters> for types::queries::CryptographicParameter
                 &value.bulletproof_generators,
             ))
             .map_err(|_| tonic::Status::internal("Invalid bulletproof_generators received"))?,
+        })
+    }
+}
+
+impl TryFrom<BlockInfo> for types::queries::BlockInfo {
+    type Error = tonic::Status;
+
+    fn try_from(value: BlockInfo) -> Result<Self, Self::Error> {
+        Ok(Self {
+            transactions_size:       value.transactions_size.into(),
+            block_parent:            value.parent_block.require_owned()?.try_into()?,
+            block_hash:              value.hash.require_owned()?.try_into()?,
+            finalized:               value.finalized,
+            block_state_hash:        value.state_hash.require_owned()?.try_into()?,
+            block_arrive_time:       value.arrive_time.require_owned()?.into(),
+            block_receive_time:      value.receive_time.require_owned()?.into(),
+            transaction_count:       value.transaction_count.into(),
+            transaction_energy_cost: value.transactions_energy_cost.require_owned()?.into(),
+            block_slot:              value.slot_number.require_owned()?.into(),
+            block_last_finalized:    value.last_finalized_block.require_owned()?.try_into()?,
+            block_slot_time:         value.slot_time.require_owned()?.into(),
+            block_height:            value.height.require_owned()?.into(),
+            era_block_height:        value.era_block_height.require_owned()?.into(),
+            genesis_index:           value.genesis_index.require_owned()?.into(),
+            block_baker:             value.baker.map(|b| b.into()),
         })
     }
 }

--- a/src/v2/generated.rs
+++ b/src/v2/generated.rs
@@ -835,10 +835,10 @@ impl TryFrom<BlockInfo> for types::queries::BlockInfo {
     }
 }
 
-impl TryFrom<PoolStatus> for types::BakerPoolStatus {
+impl TryFrom<PoolInfoResponse> for types::BakerPoolStatus {
     type Error = tonic::Status;
 
-    fn try_from(value: PoolStatus) -> Result<Self, Self::Error> {
+    fn try_from(value: PoolInfoResponse) -> Result<Self, Self::Error> {
         Ok(Self {
             baker_id:                   value.baker.require_owned()?.into(),
             baker_address:              value.address.require_owned()?.try_into()?,
@@ -847,7 +847,7 @@ impl TryFrom<PoolStatus> for types::BakerPoolStatus {
             delegated_capital_cap:      value.delegated_capital_cap.require_owned()?.into(),
             pool_info:                  value.pool_info.require_owned()?.try_into()?,
             baker_stake_pending_change: value.equity_pending_change.try_into()?,
-            current_payday_status:      if let Some(v) = value.current_payday_status {
+            current_payday_status:      if let Some(v) = value.current_payday_info {
                 Some(v.try_into()?)
             } else {
                 None
@@ -877,10 +877,10 @@ impl TryFrom<Option<PoolPendingChange>> for super::types::PoolPendingChange {
     }
 }
 
-impl TryFrom<PoolCurrentPaydayStatus> for super::types::CurrentPaydayBakerPoolStatus {
+impl TryFrom<PoolCurrentPaydayInfo> for super::types::CurrentPaydayBakerPoolStatus {
     type Error = tonic::Status;
 
-    fn try_from(value: PoolCurrentPaydayStatus) -> Result<Self, Self::Error> {
+    fn try_from(value: PoolCurrentPaydayInfo) -> Result<Self, Self::Error> {
         Ok(Self {
             blocks_baked:            value.blocks_baked,
             finalization_live:       value.finalization_live,
@@ -893,10 +893,10 @@ impl TryFrom<PoolCurrentPaydayStatus> for super::types::CurrentPaydayBakerPoolSt
     }
 }
 
-impl TryFrom<PassiveDelegationStatus> for super::types::PassiveDelegationStatus {
+impl TryFrom<PassiveDelegationInfo> for super::types::PassiveDelegationStatus {
     type Error = tonic::Status;
 
-    fn try_from(value: PassiveDelegationStatus) -> Result<Self, Self::Error> {
+    fn try_from(value: PassiveDelegationInfo) -> Result<Self, Self::Error> {
         Ok(Self {
             delegated_capital: value.delegated_capital.require_owned()?.into(),
             commission_rates: value.commission_rates.require_owned()?.try_into()?,
@@ -942,12 +942,12 @@ impl From<&super::endpoints::BlocksAtHeightInput> for BlocksAtHeightRequest {
     }
 }
 
-impl TryFrom<TokenomicsStatus> for super::types::RewardsOverview {
+impl TryFrom<TokenomicsInfo> for super::types::RewardsOverview {
     type Error = tonic::Status;
 
-    fn try_from(value: TokenomicsStatus) -> Result<Self, Self::Error> {
+    fn try_from(value: TokenomicsInfo) -> Result<Self, Self::Error> {
         match value.tokenomics.require_owned()? {
-            tokenomics_status::Tokenomics::V0(value) => Ok(Self::V0 {
+            tokenomics_info::Tokenomics::V0(value) => Ok(Self::V0 {
                 data: super::types::CommonRewardData {
                     protocol_version:            ProtocolVersion::from_i32(value.protocol_version)
                         .require_owned()?
@@ -968,7 +968,7 @@ impl TryFrom<TokenomicsStatus> for super::types::RewardsOverview {
                     gas_account:                 value.gas_account.require_owned()?.into(),
                 },
             }),
-            tokenomics_status::Tokenomics::V1(value) => Ok(Self::V1 {
+            tokenomics_info::Tokenomics::V1(value) => Ok(Self::V1 {
                 common: super::types::CommonRewardData {
                     protocol_version:            ProtocolVersion::from_i32(value.protocol_version)
                         .require_owned()?

--- a/src/v2/generated.rs
+++ b/src/v2/generated.rs
@@ -131,6 +131,14 @@ impl From<BlockHeight> for super::types::BlockHeight {
     fn from(bh: BlockHeight) -> Self { Self { height: bh.value } }
 }
 
+impl From<super::AbsoluteBlockHeight> for AbsoluteBlockHeight {
+    fn from(abh: super::AbsoluteBlockHeight) -> Self { Self { value: abh.height } }
+}
+
+impl From<super::types::BlockHeight> for BlockHeight {
+    fn from(bh: super::types::BlockHeight) -> Self { Self { value: bh.height } }
+}
+
 impl From<SequenceNumber> for super::types::Nonce {
     fn from(n: SequenceNumber) -> Self { Self { nonce: n.value } }
 }
@@ -266,6 +274,14 @@ impl From<Duration> for super::types::SlotDuration {
 
 impl From<GenesisIndex> for super::types::GenesisIndex {
     fn from(value: GenesisIndex) -> Self { value.value.into() }
+}
+
+impl From<super::types::GenesisIndex> for GenesisIndex {
+    fn from(value: super::types::GenesisIndex) -> Self {
+        GenesisIndex {
+            value: value.into(),
+        }
+    }
 }
 
 impl From<ProtocolVersion> for super::types::ProtocolVersion {
@@ -880,5 +896,34 @@ impl TryFrom<PassiveDelegationStatus> for super::types::PassiveDelegationStatus 
                 .into(),
             all_pool_total_capital: value.all_pool_total_capital.require_owned()?.into(),
         })
+    }
+}
+
+impl From<&super::endpoints::BlocksAtHeightInput> for BlocksAtHeightRequest {
+    fn from(&input: &super::endpoints::BlocksAtHeightInput) -> Self {
+        let blocks_at_height = match input {
+            super::endpoints::BlocksAtHeightInput::Absolute { height } => {
+                blocks_at_height_request::BlocksAtHeight::Absolute(
+                    blocks_at_height_request::Absolute {
+                        height: Some(height.into()),
+                    },
+                )
+            }
+
+            super::endpoints::BlocksAtHeightInput::Relative {
+                height,
+                genesis_index,
+                restrict,
+            } => blocks_at_height_request::BlocksAtHeight::Relative(
+                blocks_at_height_request::Relative {
+                    height: Some(height.into()),
+                    genesis_index: Some(genesis_index.into()),
+                    restrict,
+                },
+            ),
+        };
+        BlocksAtHeightRequest {
+            blocks_at_height: Some(blocks_at_height),
+        }
     }
 }

--- a/src/v2/mod.rs
+++ b/src/v2/mod.rs
@@ -171,6 +171,12 @@ impl IntoRequest<generated::PoolStatusRequest> for (&BlockIdentifier, types::Bak
     }
 }
 
+impl IntoRequest<generated::BlocksAtHeightRequest> for &endpoints::BlocksAtHeightInput {
+    fn into_request(self) -> tonic::Request<generated::BlocksAtHeightRequest> {
+        tonic::Request::new(self.into())
+    }
+}
+
 impl Client {
     pub async fn new<E: Into<tonic::transport::Endpoint>>(
         endpoint: E,
@@ -373,6 +379,18 @@ impl Client {
             block_hash,
             response,
         })
+    }
+
+    pub async fn get_blocks_at_height(
+        &mut self,
+        blocks_at_height_input: &endpoints::BlocksAtHeightInput,
+    ) -> endpoints::QueryResult<impl Stream<Item = Result<BlockHash, tonic::Status>>> {
+        let response = self
+            .client
+            .get_blocks_at_height(blocks_at_height_input)
+            .await?;
+        let stream = response.into_inner().map(|x| x.and_then(TryFrom::try_from));
+        Ok(stream)
     }
 }
 

--- a/src/v2/mod.rs
+++ b/src/v2/mod.rs
@@ -197,6 +197,19 @@ impl Client {
         Ok(response)
     }
 
+    pub async fn get_cryptographic_parameters(
+        &mut self,
+        bi: &BlockIdentifier,
+    ) -> endpoints::QueryResult<QueryResponse<types::queries::CryptographicParameters>> {
+        let response = self.client.get_cryptographic_parameters(bi).await?;
+        let block_hash = extract_metadata(&response)?;
+        let response = types::queries::CryptographicParameters::try_from(response.into_inner())?;
+        Ok(QueryResponse {
+            block_hash,
+            response,
+        })
+    }
+
     pub async fn get_account_list(
         &mut self,
         bi: &BlockIdentifier,

--- a/src/v2/mod.rs
+++ b/src/v2/mod.rs
@@ -322,6 +322,21 @@ impl Client {
             response,
         })
     }
+
+    pub async fn get_baker_list(
+        &mut self,
+        bi: &BlockIdentifier,
+    ) -> endpoints::QueryResult<
+        QueryResponse<impl Stream<Item = Result<types::BakerId, tonic::Status>>>,
+    > {
+        let response = self.client.get_baker_list(bi).await?;
+        let block_hash = extract_metadata(&response)?;
+        let stream = response.into_inner().map(|x| x.map(From::from));
+        Ok(QueryResponse {
+            block_hash,
+            response: stream,
+        })
+    }
 }
 
 fn extract_metadata<T>(response: &tonic::Response<T>) -> endpoints::RPCResult<BlockHash> {

--- a/src/v2/mod.rs
+++ b/src/v2/mod.rs
@@ -309,6 +309,19 @@ impl Client {
         });
         Ok(stream)
     }
+
+    pub async fn get_block_info(
+        &mut self,
+        bi: &BlockIdentifier,
+    ) -> endpoints::QueryResult<QueryResponse<types::queries::BlockInfo>> {
+        let response = self.client.get_block_info(bi).await?;
+        let block_hash = extract_metadata(&response)?;
+        let response = types::queries::BlockInfo::try_from(response.into_inner())?;
+        Ok(QueryResponse {
+            block_hash,
+            response,
+        })
+    }
 }
 
 fn extract_metadata<T>(response: &tonic::Response<T>) -> endpoints::RPCResult<BlockHash> {

--- a/src/v2/mod.rs
+++ b/src/v2/mod.rs
@@ -392,6 +392,19 @@ impl Client {
         let stream = response.into_inner().map(|x| x.and_then(TryFrom::try_from));
         Ok(stream)
     }
+
+    pub async fn get_tokenomics_status(
+        &mut self,
+        block_id: &BlockIdentifier,
+    ) -> endpoints::QueryResult<QueryResponse<types::RewardsOverview>> {
+        let response = self.client.get_tokenomics_status(block_id).await?;
+        let block_hash = extract_metadata(&response)?;
+        let response = types::RewardsOverview::try_from(response.into_inner())?;
+        Ok(QueryResponse {
+            block_hash,
+            response,
+        })
+    }
 }
 
 fn extract_metadata<T>(response: &tonic::Response<T>) -> endpoints::RPCResult<BlockHash> {


### PR DESCRIPTION
## Purpose

Adding more functions to gRPC api v2 client.

## Changes

- Implement `get_cryptographic_parameters`, `get_block_info`, `get_baker_list`, `get_pool_info`, `get_passive_delegation_info`, `get_blocks_at_height` and `get_tokenomics_info` in client v2.

## Checklist

- [ ] My code follows the style of this project.
- [ ] The code compiles without warnings.
- [ ] I have performed a self-review of the changes.
- [ ] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [ ] (If necessary) I have updated the CHANGELOG.
