### PR TITLE
Add getters for delegators in client v2

### DIFF
--- a/examples/v2_get_branches.rs
+++ b/examples/v2_get_branches.rs
@@ -1,0 +1,32 @@
+//! Test the `GetBranches` endpoint.
+use anyhow::Context;
+use clap::AppSettings;
+use concordium_rust_sdk::v2;
+use structopt::StructOpt;
+
+#[derive(StructOpt)]
+struct App {
+    #[structopt(
+        long = "node",
+        help = "GRPC interface of the node.",
+        default_value = "http://localhost:10001"
+    )]
+    endpoint: tonic::transport::Endpoint,
+}
+
+#[tokio::main(flavor = "multi_thread")]
+async fn main() -> anyhow::Result<()> {
+    let app = {
+        let app = App::clap().global_setting(AppSettings::ColoredHelp);
+        let matches = app.get_matches();
+        App::from_clap(&matches)
+    };
+
+    let mut client = v2::Client::new(app.endpoint)
+        .await
+        .context("Cannot connect.")?;
+    let branches = client.get_branches().await?;
+
+    println!("Branches: {:?}", branches);
+    Ok(())
+}

--- a/examples/v2_get_branches.rs
+++ b/examples/v2_get_branches.rs
@@ -1,7 +1,7 @@
 //! Test the `GetBranches` endpoint.
 use anyhow::Context;
 use clap::AppSettings;
-use concordium_rust_sdk::v2;
+use concordium_rust_sdk::{endpoints::Endpoint, v2};
 use structopt::StructOpt;
 
 #[derive(StructOpt)]
@@ -11,7 +11,7 @@ struct App {
         help = "GRPC interface of the node.",
         default_value = "http://localhost:10001"
     )]
-    endpoint: tonic::transport::Endpoint,
+    endpoint: Endpoint,
 }
 
 #[tokio::main(flavor = "multi_thread")]

--- a/examples/v2_get_passive_delegators.rs
+++ b/examples/v2_get_passive_delegators.rs
@@ -1,7 +1,7 @@
 //! Test the `GetPassiveDelegators` endpoint.
 use anyhow::Context;
 use clap::AppSettings;
-use concordium_rust_sdk::v2;
+use concordium_rust_sdk::{endpoints::Endpoint, v2};
 use futures::StreamExt;
 use structopt::StructOpt;
 
@@ -12,7 +12,7 @@ struct App {
         help = "GRPC interface of the node.",
         default_value = "http://localhost:10001"
     )]
-    endpoint: tonic::transport::Endpoint,
+    endpoint: Endpoint,
 }
 
 #[tokio::main(flavor = "multi_thread")]

--- a/examples/v2_get_passive_delegators.rs
+++ b/examples/v2_get_passive_delegators.rs
@@ -1,0 +1,38 @@
+//! Test the `GetPassiveDelegators` endpoint.
+use anyhow::Context;
+use clap::AppSettings;
+use concordium_rust_sdk::v2;
+use futures::StreamExt;
+use structopt::StructOpt;
+
+#[derive(StructOpt)]
+struct App {
+    #[structopt(
+        long = "node",
+        help = "GRPC interface of the node.",
+        default_value = "http://localhost:10001"
+    )]
+    endpoint: tonic::transport::Endpoint,
+}
+
+#[tokio::main(flavor = "multi_thread")]
+async fn main() -> anyhow::Result<()> {
+    let app = {
+        let app = App::clap().global_setting(AppSettings::ColoredHelp);
+        let matches = app.get_matches();
+        App::from_clap(&matches)
+    };
+
+    let mut client = v2::Client::new(app.endpoint)
+        .await
+        .context("Cannot connect.")?;
+    let mut response_delegators = client
+        .get_passive_delegators(&v2::BlockIdentifier::LastFinal)
+        .await?;
+
+    println!("Blockhash: {}", response_delegators.block_hash);
+    while let Some(a) = response_delegators.response.next().await.transpose()? {
+        println!(" - {:?}", &a);
+    }
+    Ok(())
+}

--- a/examples/v2_get_passive_delegators_reward_period.rs
+++ b/examples/v2_get_passive_delegators_reward_period.rs
@@ -1,7 +1,7 @@
 //! Test the `GetPassiveDelegatorsRewardPeriod` endpoint.
 use anyhow::Context;
 use clap::AppSettings;
-use concordium_rust_sdk::v2;
+use concordium_rust_sdk::{endpoints::Endpoint, v2};
 use futures::StreamExt;
 use structopt::StructOpt;
 
@@ -12,7 +12,7 @@ struct App {
         help = "GRPC interface of the node.",
         default_value = "http://localhost:10001"
     )]
-    endpoint: tonic::transport::Endpoint,
+    endpoint: Endpoint,
 }
 
 #[tokio::main(flavor = "multi_thread")]

--- a/examples/v2_get_passive_delegators_reward_period.rs
+++ b/examples/v2_get_passive_delegators_reward_period.rs
@@ -1,0 +1,38 @@
+//! Test the `GetPassiveDelegatorsRewardPeriod` endpoint.
+use anyhow::Context;
+use clap::AppSettings;
+use concordium_rust_sdk::v2;
+use futures::StreamExt;
+use structopt::StructOpt;
+
+#[derive(StructOpt)]
+struct App {
+    #[structopt(
+        long = "node",
+        help = "GRPC interface of the node.",
+        default_value = "http://localhost:10001"
+    )]
+    endpoint: tonic::transport::Endpoint,
+}
+
+#[tokio::main(flavor = "multi_thread")]
+async fn main() -> anyhow::Result<()> {
+    let app = {
+        let app = App::clap().global_setting(AppSettings::ColoredHelp);
+        let matches = app.get_matches();
+        App::from_clap(&matches)
+    };
+
+    let mut client = v2::Client::new(app.endpoint)
+        .await
+        .context("Cannot connect.")?;
+    let mut response_delegators = client
+        .get_passive_delegators_reward_period(&v2::BlockIdentifier::LastFinal)
+        .await?;
+
+    println!("Blockhash: {}", response_delegators.block_hash);
+    while let Some(a) = response_delegators.response.next().await.transpose()? {
+        println!(" - {:?}", &a);
+    }
+    Ok(())
+}

--- a/examples/v2_get_pool_delegators.rs
+++ b/examples/v2_get_pool_delegators.rs
@@ -1,0 +1,44 @@
+//! Test the `GetPoolDelegators` endpoint.
+use anyhow::Context;
+use clap::AppSettings;
+use concordium_rust_sdk::v2;
+use futures::StreamExt;
+use structopt::StructOpt;
+
+#[derive(StructOpt)]
+struct App {
+    #[structopt(
+        long = "node",
+        help = "GRPC interface of the node.",
+        default_value = "http://localhost:10001"
+    )]
+    endpoint: tonic::transport::Endpoint,
+}
+
+#[tokio::main(flavor = "multi_thread")]
+async fn main() -> anyhow::Result<()> {
+    let app = {
+        let app = App::clap().global_setting(AppSettings::ColoredHelp);
+        let matches = app.get_matches();
+        App::from_clap(&matches)
+    };
+
+    let mut client = v2::Client::new(app.endpoint)
+        .await
+        .context("Cannot connect.")?;
+    let mut res = client
+        .get_baker_list(&v2::BlockIdentifier::LastFinal)
+        .await?;
+    println!("Blockhash: {}", res.block_hash);
+    while let Some(a) = res.response.next().await.transpose()? {
+        let mut response_delegators = client
+            .get_pool_delegators(&v2::BlockIdentifier::Given(res.block_hash), a)
+            .await?;
+        println!("Baker {:?}", &a);
+
+        while let Some(a) = response_delegators.response.next().await.transpose()? {
+            println!(" - {:?}", &a);
+        }
+    }
+    Ok(())
+}

--- a/examples/v2_get_pool_delegators.rs
+++ b/examples/v2_get_pool_delegators.rs
@@ -1,7 +1,7 @@
 //! Test the `GetPoolDelegators` endpoint.
 use anyhow::Context;
 use clap::AppSettings;
-use concordium_rust_sdk::v2;
+use concordium_rust_sdk::{endpoints::Endpoint, v2};
 use futures::StreamExt;
 use structopt::StructOpt;
 
@@ -12,7 +12,7 @@ struct App {
         help = "GRPC interface of the node.",
         default_value = "http://localhost:10001"
     )]
-    endpoint: tonic::transport::Endpoint,
+    endpoint: Endpoint,
 }
 
 #[tokio::main(flavor = "multi_thread")]

--- a/examples/v2_get_pool_delegators_reward_period.rs
+++ b/examples/v2_get_pool_delegators_reward_period.rs
@@ -1,0 +1,44 @@
+//! Test the `GetPoolDelegatorsRewardPeriod` endpoint.
+use anyhow::Context;
+use clap::AppSettings;
+use concordium_rust_sdk::v2;
+use futures::StreamExt;
+use structopt::StructOpt;
+
+#[derive(StructOpt)]
+struct App {
+    #[structopt(
+        long = "node",
+        help = "GRPC interface of the node.",
+        default_value = "http://localhost:10001"
+    )]
+    endpoint: tonic::transport::Endpoint,
+}
+
+#[tokio::main(flavor = "multi_thread")]
+async fn main() -> anyhow::Result<()> {
+    let app = {
+        let app = App::clap().global_setting(AppSettings::ColoredHelp);
+        let matches = app.get_matches();
+        App::from_clap(&matches)
+    };
+
+    let mut client = v2::Client::new(app.endpoint)
+        .await
+        .context("Cannot connect.")?;
+    let mut res = client
+        .get_baker_list(&v2::BlockIdentifier::LastFinal)
+        .await?;
+    println!("Blockhash: {}", res.block_hash);
+    while let Some(a) = res.response.next().await.transpose()? {
+        let mut response_delegators = client
+            .get_pool_delegators_reward_period(&v2::BlockIdentifier::Given(res.block_hash), a)
+            .await?;
+        println!("Baker {:?}", &a);
+
+        while let Some(a) = response_delegators.response.next().await.transpose()? {
+            println!(" - {:?}", &a);
+        }
+    }
+    Ok(())
+}

--- a/src/types/mod.rs
+++ b/src/types/mod.rs
@@ -239,6 +239,26 @@ impl StakePendingChange {
     }
 }
 
+#[derive(Debug, Clone, Copy)]
+/// Stream item for `GetPoolDelegators`.
+pub struct PoolDelegator {
+    /// The delegator account address.
+    pub account:        AccountAddress,
+    /// The amount of stake currently staked to the pool.
+    pub stake:          Amount,
+    /// Pending change to the current stake of the delegator.
+    pub pending_change: Option<StakePendingChange>,
+}
+
+#[derive(Debug, Clone, Copy)]
+/// Stream item for `GetPoolDelegatorsRewardPeriod`.
+pub struct PoolDelegatorRewardPeriod {
+    /// The delegator account address.
+    pub account: AccountAddress,
+    /// The amount of stake currently staked to the pool.
+    pub stake:   Amount,
+}
+
 #[derive(SerdeSerialize, SerdeDeserialize, Debug, Clone, Copy)]
 #[serde(
     rename_all = "camelCase",

--- a/src/types/mod.rs
+++ b/src/types/mod.rs
@@ -240,8 +240,8 @@ impl StakePendingChange {
 }
 
 #[derive(Debug, Clone, Copy)]
-/// Stream item for `GetPoolDelegators`.
-pub struct PoolDelegator {
+/// Information about a registered passive or pool delegator.
+pub struct DelegatorInfo {
     /// The delegator account address.
     pub account:        AccountAddress,
     /// The amount of stake currently staked to the pool.
@@ -251,8 +251,8 @@ pub struct PoolDelegator {
 }
 
 #[derive(Debug, Clone, Copy)]
-/// Stream item for `GetPoolDelegatorsRewardPeriod`.
-pub struct PoolDelegatorRewardPeriod {
+/// Information about a passive or pool delegator fixed in a reward period.
+pub struct DelegatorRewardPeriodInfo {
     /// The delegator account address.
     pub account: AccountAddress,
     /// The amount of stake currently staked to the pool.

--- a/src/types/queries.rs
+++ b/src/types/queries.rs
@@ -147,7 +147,7 @@ pub struct ConsensusInfo {
     pub current_era_genesis_time:       chrono::DateTime<chrono::Utc>,
 }
 
-#[derive(Debug, SerdeSerialize, SerdeDeserialize)]
+#[derive(Debug, SerdeSerialize, SerdeDeserialize, PartialEq, Eq)]
 #[serde(rename_all = "camelCase")]
 /// Branches of the tree. This is the part of the tree above the last finalized
 /// block.

--- a/src/v2/generated.rs
+++ b/src/v2/generated.rs
@@ -780,10 +780,10 @@ impl From<Timestamp> for chrono::DateTime<chrono::Utc> {
     }
 }
 
-impl TryFrom<PoolDelegator> for super::types::PoolDelegator {
+impl TryFrom<DelegatorInfo> for super::types::DelegatorInfo {
     type Error = tonic::Status;
 
-    fn try_from(delegator: PoolDelegator) -> Result<Self, Self::Error> {
+    fn try_from(delegator: DelegatorInfo) -> Result<Self, Self::Error> {
         Ok(Self {
             account:        delegator.account.require()?.try_into()?,
             stake:          delegator.stake.require()?.into(),
@@ -795,10 +795,10 @@ impl TryFrom<PoolDelegator> for super::types::PoolDelegator {
     }
 }
 
-impl TryFrom<PoolDelegatorRewardPeriod> for super::types::PoolDelegatorRewardPeriod {
+impl TryFrom<DelegatorRewardPeriodInfo> for super::types::DelegatorRewardPeriodInfo {
     type Error = tonic::Status;
 
-    fn try_from(delegator: PoolDelegatorRewardPeriod) -> Result<Self, Self::Error> {
+    fn try_from(delegator: DelegatorRewardPeriodInfo) -> Result<Self, Self::Error> {
         Ok(Self {
             account: delegator.account.require()?.try_into()?,
             stake:   delegator.stake.require()?.into(),
@@ -2207,13 +2207,93 @@ impl TryFrom<Branch> for super::types::queries::Branch {
     type Error = tonic::Status;
 
     fn try_from(value: Branch) -> Result<Self, Self::Error> {
-        Ok(Self {
-            block_hash: value.block_hash.require()?.try_into()?,
-            children:   value
-                .children
-                .into_iter()
-                .map(|c| c.try_into())
-                .collect::<Result<_, _>>()?,
-        })
+        // Tracking the branches which to visit next.
+        let mut next = Vec::new();
+        // For building a depth first search order of the tree.
+        let mut dfs = Vec::new();
+
+        // First we build a depth first search order of the tree.
+        next.extend(value.children.iter());
+        dfs.push(&value);
+        while let Some(value) = next.pop() {
+            dfs.push(value);
+            next.extend(value.children.iter());
+        }
+
+        // Using depth first we build the new tree.
+        let mut nodes = Vec::new();
+        while let Some(value) = dfs.pop() {
+            let mut children = Vec::new();
+            for _ in 0..value.children.len() {
+                // If a node have children, they should already be pushed and this is safe.
+                children.push(nodes.pop().require()?);
+            }
+
+            let node = Self {
+                block_hash: value.block_hash.clone().require()?.try_into()?,
+                children,
+            };
+            nodes.push(node)
+        }
+
+        // Only one node should be left and is the root of the tree.
+        let root = nodes.pop().require()?;
+        Ok(root)
+    }
+}
+
+#[cfg(test)]
+mod test {
+
+    use super::*;
+
+    #[test]
+    fn test_try_from_branch() {
+        use crate::types::queries::Branch as QBranch;
+
+        let from = Branch {
+            block_hash: Some(BlockHash {
+                value: vec![0u8; 32],
+            }),
+            children:   vec![
+                Branch {
+                    block_hash: Some(BlockHash {
+                        value: vec![1u8; 32],
+                    }),
+                    children:   vec![],
+                },
+                Branch {
+                    block_hash: Some(BlockHash {
+                        value: vec![2u8; 32],
+                    }),
+                    children:   vec![Branch {
+                        block_hash: Some(BlockHash {
+                            value: vec![3u8; 32],
+                        }),
+                        children:   vec![],
+                    }],
+                },
+            ],
+        };
+
+        let to_target = QBranch {
+            block_hash: [0u8; 32].into(),
+            children:   vec![
+                QBranch {
+                    block_hash: [2u8; 32].into(),
+                    children:   vec![QBranch {
+                        block_hash: [3u8; 32].into(),
+                        children:   vec![],
+                    }],
+                },
+                QBranch {
+                    block_hash: [1u8; 32].into(),
+                    children:   vec![],
+                },
+            ],
+        };
+        let to = QBranch::try_from(from).expect("Failed to convert branch");
+
+        assert_eq!(to, to_target);
     }
 }

--- a/src/v2/generated.rs
+++ b/src/v2/generated.rs
@@ -2202,3 +2202,18 @@ impl TryFrom<TokenomicsInfo> for super::types::RewardsOverview {
         }
     }
 }
+
+impl TryFrom<Branch> for super::types::queries::Branch {
+    type Error = tonic::Status;
+
+    fn try_from(value: Branch) -> Result<Self, Self::Error> {
+        Ok(Self {
+            block_hash: value.block_hash.require()?.try_into()?,
+            children:   value
+                .children
+                .into_iter()
+                .map(|c| c.try_into())
+                .collect::<Result<_, _>>()?,
+        })
+    }
+}

--- a/src/v2/generated.rs
+++ b/src/v2/generated.rs
@@ -780,6 +780,32 @@ impl From<Timestamp> for chrono::DateTime<chrono::Utc> {
     }
 }
 
+impl TryFrom<PoolDelegator> for super::types::PoolDelegator {
+    type Error = tonic::Status;
+
+    fn try_from(delegator: PoolDelegator) -> Result<Self, Self::Error> {
+        Ok(Self {
+            account:        delegator.account.require()?.try_into()?,
+            stake:          delegator.stake.require()?.into(),
+            pending_change: delegator
+                .pending_change
+                .map(TryFrom::try_from)
+                .transpose()?,
+        })
+    }
+}
+
+impl TryFrom<PoolDelegatorRewardPeriod> for super::types::PoolDelegatorRewardPeriod {
+    type Error = tonic::Status;
+
+    fn try_from(delegator: PoolDelegatorRewardPeriod) -> Result<Self, Self::Error> {
+        Ok(Self {
+            account: delegator.account.require()?.try_into()?,
+            stake:   delegator.stake.require()?.into(),
+        })
+    }
+}
+
 impl TryFrom<AccountInfo> for super::types::AccountInfo {
     type Error = tonic::Status;
 

--- a/src/v2/mod.rs
+++ b/src/v2/mod.rs
@@ -284,18 +284,6 @@ impl IntoRequest<generated::GetPoolDelegatorsRequest> for (&BlockIdentifier, typ
     }
 }
 
-impl IntoRequest<generated::GetPoolDelegatorsRewardPeriodRequest>
-    for (&BlockIdentifier, types::BakerId)
-{
-    fn into_request(self) -> tonic::Request<generated::GetPoolDelegatorsRewardPeriodRequest> {
-        let req = generated::GetPoolDelegatorsRewardPeriodRequest {
-            block_hash: Some(self.0.into()),
-            baker:      Some(self.1.into()),
-        };
-        tonic::Request::new(req)
-    }
-}
-
 impl Client {
     pub async fn new<E: Into<tonic::transport::Endpoint>>(
         endpoint: E,
@@ -609,7 +597,7 @@ impl Client {
         bi: &BlockIdentifier,
         baker_id: types::BakerId,
     ) -> endpoints::QueryResult<
-        QueryResponse<impl Stream<Item = Result<types::PoolDelegator, tonic::Status>>>,
+        QueryResponse<impl Stream<Item = Result<types::DelegatorInfo, tonic::Status>>>,
     > {
         let response = self.client.get_pool_delegators((bi, baker_id)).await?;
         let block_hash = extract_metadata(&response)?;
@@ -628,7 +616,7 @@ impl Client {
         bi: &BlockIdentifier,
         baker_id: types::BakerId,
     ) -> endpoints::QueryResult<
-        QueryResponse<impl Stream<Item = Result<types::PoolDelegatorRewardPeriod, tonic::Status>>>,
+        QueryResponse<impl Stream<Item = Result<types::DelegatorRewardPeriodInfo, tonic::Status>>>,
     > {
         let response = self
             .client
@@ -649,7 +637,7 @@ impl Client {
         &mut self,
         bi: &BlockIdentifier,
     ) -> endpoints::QueryResult<
-        QueryResponse<impl Stream<Item = Result<types::PoolDelegator, tonic::Status>>>,
+        QueryResponse<impl Stream<Item = Result<types::DelegatorInfo, tonic::Status>>>,
     > {
         let response = self.client.get_passive_delegators(bi).await?;
         let block_hash = extract_metadata(&response)?;
@@ -667,7 +655,7 @@ impl Client {
         &mut self,
         bi: &BlockIdentifier,
     ) -> endpoints::QueryResult<
-        QueryResponse<impl Stream<Item = Result<types::PoolDelegatorRewardPeriod, tonic::Status>>>,
+        QueryResponse<impl Stream<Item = Result<types::DelegatorRewardPeriodInfo, tonic::Status>>>,
     > {
         let response = self.client.get_passive_delegators_reward_period(bi).await?;
         let block_hash = extract_metadata(&response)?;

--- a/src/v2/mod.rs
+++ b/src/v2/mod.rs
@@ -680,6 +680,15 @@ impl Client {
             response: stream,
         })
     }
+
+    pub async fn get_branches(&mut self) -> endpoints::QueryResult<types::queries::Branch> {
+        let response = self
+            .client
+            .get_branches(generated::Empty::default())
+            .await?;
+        let response = types::queries::Branch::try_from(response.into_inner())?;
+        Ok(response)
+    }
 }
 
 fn extract_metadata<T>(response: &tonic::Response<T>) -> endpoints::RPCResult<BlockHash> {


### PR DESCRIPTION
## Purpose

Depends on https://github.com/Concordium/concordium-grpc-api/pull/17
Related to https://github.com/Concordium/concordium-node/issues/433

## Changes

- Support `GetPoolDelegators`, `GetPoolDelegatorsRewardPeriod`, `GetPassiveDelegators`, `GetPassiveDelegatorsRewardPeriod` and `GetBranches` in gRPC API v2.

## Checklist

- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [ ] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [ ] (If necessary) I have updated the CHANGELOG.
