### PR TITLE
API v2 Getters for info about election, IP, AR and nonfinal tx

### DIFF
--- a/examples/v2_get_account_non_finalized_transactions.rs
+++ b/examples/v2_get_account_non_finalized_transactions.rs
@@ -1,0 +1,44 @@
+//! Test the `GetAccountNonFinalizedTransactions` endpoint.
+use anyhow::Context;
+use clap::AppSettings;
+use concordium_rust_sdk::{common::types::AccountAddress, endpoints::Endpoint, v2};
+use futures::StreamExt;
+use structopt::StructOpt;
+
+#[derive(StructOpt)]
+struct App {
+    #[structopt(
+        long = "node",
+        help = "GRPC interface of the node.",
+        default_value = "http://localhost:10001"
+    )]
+    endpoint: Endpoint,
+    #[structopt(
+        long = "account",
+        help = "Account address to get non-finalized transactions for.",
+        default_value = "http://localhost:10001"
+    )]
+    account:  AccountAddress,
+}
+
+#[tokio::main(flavor = "multi_thread")]
+async fn main() -> anyhow::Result<()> {
+    let app = {
+        let app = App::clap().global_setting(AppSettings::ColoredHelp);
+        let matches = app.get_matches();
+        App::from_clap(&matches)
+    };
+
+    let mut client = v2::Client::new(app.endpoint)
+        .await
+        .context("Cannot connect.")?;
+    let mut response = client
+        .get_account_non_finalized_transactions(&app.account)
+        .await?;
+
+    println!("Non-finalized transactions for {}:", app.account);
+    while let Some(a) = response.next().await.transpose()? {
+        println!(" - {:?}", &a);
+    }
+    Ok(())
+}

--- a/examples/v2_get_anonymity_revokers.rs
+++ b/examples/v2_get_anonymity_revokers.rs
@@ -1,0 +1,38 @@
+//! Test the `GetAnonymityRevokers` endpoint.
+use anyhow::Context;
+use clap::AppSettings;
+use concordium_rust_sdk::{endpoints::Endpoint, v2};
+use futures::StreamExt;
+use structopt::StructOpt;
+
+#[derive(StructOpt)]
+struct App {
+    #[structopt(
+        long = "node",
+        help = "GRPC interface of the node.",
+        default_value = "http://localhost:10001"
+    )]
+    endpoint: Endpoint,
+}
+
+#[tokio::main(flavor = "multi_thread")]
+async fn main() -> anyhow::Result<()> {
+    let app = {
+        let app = App::clap().global_setting(AppSettings::ColoredHelp);
+        let matches = app.get_matches();
+        App::from_clap(&matches)
+    };
+
+    let mut client = v2::Client::new(app.endpoint)
+        .await
+        .context("Cannot connect.")?;
+    let mut response = client
+        .get_anonymity_revokers(&v2::BlockIdentifier::LastFinal)
+        .await?;
+
+    println!("Blockhash: {}", response.block_hash);
+    while let Some(a) = response.response.next().await.transpose()? {
+        println!(" - {:?}", &a);
+    }
+    Ok(())
+}

--- a/examples/v2_get_election_info.rs
+++ b/examples/v2_get_election_info.rs
@@ -1,0 +1,43 @@
+//! Test the `GetElectionInfo` endpoint.
+use anyhow::Context;
+use clap::AppSettings;
+use structopt::StructOpt;
+
+use concordium_rust_sdk::v2;
+
+#[derive(StructOpt)]
+struct App {
+    #[structopt(
+        long = "node",
+        help = "GRPC interface of the node.",
+        default_value = "http://localhost:10001"
+    )]
+    endpoint: tonic::transport::Endpoint,
+}
+
+#[tokio::main(flavor = "multi_thread")]
+async fn main() -> anyhow::Result<()> {
+    let app = {
+        let app = App::clap().global_setting(AppSettings::ColoredHelp);
+        let matches = app.get_matches();
+        App::from_clap(&matches)
+    };
+
+    let mut client = v2::Client::new(app.endpoint)
+        .await
+        .context("Cannot connect.")?;
+
+    {
+        let ai = client.get_election_info(&v2::BlockIdentifier::Best).await?;
+        println!("Best block {:#?}", ai);
+    }
+
+    {
+        let ai = client
+            .get_election_info(&v2::BlockIdentifier::LastFinal)
+            .await?;
+        println!("Last finalized {:#?}", ai);
+    }
+
+    Ok(())
+}

--- a/examples/v2_get_identity_providers.rs
+++ b/examples/v2_get_identity_providers.rs
@@ -1,0 +1,38 @@
+//! Test the `GetIdentityProviders` endpoint.
+use anyhow::Context;
+use clap::AppSettings;
+use concordium_rust_sdk::{endpoints::Endpoint, v2};
+use futures::StreamExt;
+use structopt::StructOpt;
+
+#[derive(StructOpt)]
+struct App {
+    #[structopt(
+        long = "node",
+        help = "GRPC interface of the node.",
+        default_value = "http://localhost:10001"
+    )]
+    endpoint: Endpoint,
+}
+
+#[tokio::main(flavor = "multi_thread")]
+async fn main() -> anyhow::Result<()> {
+    let app = {
+        let app = App::clap().global_setting(AppSettings::ColoredHelp);
+        let matches = app.get_matches();
+        App::from_clap(&matches)
+    };
+
+    let mut client = v2::Client::new(app.endpoint)
+        .await
+        .context("Cannot connect.")?;
+    let mut response = client
+        .get_identity_providers(&v2::BlockIdentifier::LastFinal)
+        .await?;
+
+    println!("Blockhash: {}", response.block_hash);
+    while let Some(a) = response.response.next().await.transpose()? {
+        println!(" - {:?}", &a);
+    }
+    Ok(())
+}

--- a/src/v2/mod.rs
+++ b/src/v2/mod.rs
@@ -702,7 +702,27 @@ impl Client {
         let response = self.client.get_identity_providers(bi).await?;
         let block_hash = extract_metadata(&response)?;
         let stream = response.into_inner().map(|result| match result {
-            Ok(delegator) => delegator.try_into(),
+            Ok(ip_info) => ip_info.try_into(),
+            Err(err) => Err(err),
+        });
+        Ok(QueryResponse {
+            block_hash,
+            response: stream,
+        })
+    }
+
+    pub async fn get_anonymity_revokers(
+        &mut self,
+        bi: &BlockIdentifier,
+    ) -> endpoints::QueryResult<
+        QueryResponse<
+            impl Stream<Item = Result<id::types::ArInfo<id::constants::ArCurve>, tonic::Status>>,
+        >,
+    > {
+        let response = self.client.get_anonymity_revokers(bi).await?;
+        let block_hash = extract_metadata(&response)?;
+        let stream = response.into_inner().map(|result| match result {
+            Ok(ar_info) => ar_info.try_into(),
             Err(err) => Err(err),
         });
         Ok(QueryResponse {

--- a/src/v2/mod.rs
+++ b/src/v2/mod.rs
@@ -677,6 +677,19 @@ impl Client {
         let response = types::queries::Branch::try_from(response.into_inner())?;
         Ok(response)
     }
+
+    pub async fn get_election_info(
+        &mut self,
+        bi: &BlockIdentifier,
+    ) -> endpoints::QueryResult<QueryResponse<types::BirkParameters>> {
+        let response = self.client.get_election_info(bi).await?;
+        let block_hash = extract_metadata(&response)?;
+        let response = types::BirkParameters::try_from(response.into_inner())?;
+        Ok(QueryResponse {
+            block_hash,
+            response,
+        })
+    }
 }
 
 fn extract_metadata<T>(response: &tonic::Response<T>) -> endpoints::RPCResult<BlockHash> {

--- a/src/v2/mod.rs
+++ b/src/v2/mod.rs
@@ -730,6 +730,21 @@ impl Client {
             response: stream,
         })
     }
+
+    pub async fn get_account_non_finalized_transactions(
+        &mut self,
+        account_address: &AccountAddress,
+    ) -> endpoints::QueryResult<impl Stream<Item = Result<TransactionHash, tonic::Status>>> {
+        let response = self
+            .client
+            .get_account_non_finalized_transactions(account_address)
+            .await?;
+        let stream = response.into_inner().map(|result| match result {
+            Ok(transaction_hash) => transaction_hash.try_into(),
+            Err(err) => Err(err),
+        });
+        Ok(stream)
+    }
 }
 
 fn extract_metadata<T>(response: &tonic::Response<T>) -> endpoints::RPCResult<BlockHash> {


### PR DESCRIPTION
## Purpose

Implement more of API v2.
Related issue https://github.com/Concordium/concordium-node/issues/433.
Depends on https://github.com/Concordium/concordium-node/pull/521.

## Changes

- `GetElectionInfo`, `GetIdentityProvidersV2`, `GetAnonymityRevokers` and `GetAccountNonFinalizedTransactions`.

## Checklist

- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [ ] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [ ] (If necessary) I have updated the CHANGELOG.
