### PR TITLE
Document errors happening due to block protocol version

### DIFF
--- a/src/v2/mod.rs
+++ b/src/v2/mod.rs
@@ -38,7 +38,7 @@ pub use endpoints::{QueryError, QueryResult, RPCError, RPCResult};
 use futures::{Stream, StreamExt};
 use std::collections::HashMap;
 use tonic::IntoRequest;
-pub use tonic::{transport::Endpoint, Status};
+pub use tonic::{transport::Endpoint, Code, Status};
 
 mod conversions;
 mod generated;
@@ -1447,8 +1447,9 @@ impl Client {
     /// block.
     /// If the block or baker ID does not exist [`QueryError::NotFound`] is
     /// returned, and if the block is baked prior to protocol version 4
-    /// [`QueryError::RPCError`] is returned. The stream will end when all
-    /// the delegators have been returned for the given block.
+    /// [`QueryError::RPCError`] with status [`Code::InvalidArgument`] is
+    /// returned. The stream will end when all the delegators have been
+    /// returned for the given block.
     ///
     /// In contrast to the [Client::get_pool_delegators_reward_period] which
     /// returns delegators that are fixed for the reward period of the
@@ -1481,8 +1482,9 @@ impl Client {
     /// given block.
     /// If the block or baker ID does not exist [`QueryError::NotFound`] is
     /// returned, and if the block is baked prior to protocol version 4
-    /// [`QueryError::RPCError`] is returned. The stream will end when all
-    /// the delegators have been returned.
+    /// [`QueryError::RPCError`] with status [`Code::InvalidArgument`] is
+    /// returned. The stream will end when all the delegators have been
+    /// returned.
     ///
     /// In contrast to the [Client::get_pool_delegators] which
     /// returns delegators registered for the given block, this endpoint
@@ -1513,8 +1515,8 @@ impl Client {
     /// Get the registered passive delegators at the end of a given block.
     /// If the block does not exist [`QueryError::NotFound`] is returned, and if
     /// the block is baked prior to protocol version 4 [`QueryError::
-    /// RPCError`] is returned. The stream will end when all the delegators
-    /// have been returned.
+    /// RPCError`] with status [`Code::InvalidArgument`] is returned. The stream
+    /// will end when all the delegators have been returned.
     ///
     /// In contrast to the [`Client::get_passive_delegators_reward_period`]
     /// which returns delegators that are fixed for the reward period of the
@@ -1546,8 +1548,9 @@ impl Client {
     /// block.
     /// If the block does not exist [`QueryError::NotFound`] is returned.
     /// If the block is baked prior to protocol version 4,
-    /// [`QueryError::RPCError`] is returned. The stream will end when all
-    /// the delegators have been returned.
+    /// [`QueryError::RPCError`] with status [`Code::InvalidArgument`] is
+    /// returned. The stream will end when all the delegators have been
+    /// returned.
     ///
     /// In contrast to the `GetPassiveDelegators` which returns delegators
     /// registered for the given block, this endpoint returns the fixed

--- a/src/v2/mod.rs
+++ b/src/v2/mod.rs
@@ -1368,9 +1368,7 @@ impl Client {
     }
 
     /// Get information about a given pool at the end of a given block.
-    /// If the block or baker ID does not exist [`QueryError::NotFound`] is
-    /// returned.
-    /// If the block is baked prior to protocol version 4,
+    /// If the block does not exist or is prior to protocol version 4 then
     /// [`QueryError::NotFound`] is returned.
     pub async fn get_pool_info(
         &mut self,
@@ -1391,8 +1389,7 @@ impl Client {
 
     /// Get information about the passive delegators at the end of a given
     /// block.
-    /// If the block does not exist [`QueryError::NotFound`] is returned.
-    /// If the block is baked prior to protocol version 4,
+    /// If the block does not exist or is prior to protocol version 4 then
     /// [`QueryError::NotFound`] is returned.
     pub async fn get_passive_delegation_info(
         &mut self,
@@ -1449,7 +1446,7 @@ impl Client {
     /// Get the registered delegators of a given pool at the end of a given
     /// block.
     /// If the block or baker ID does not exist [`QueryError::NotFound`] is
-    /// returned. If the block is baked prior to protocol version 4,
+    /// returned, and if the block is baked prior to protocol version 4
     /// [`QueryError::RPCError`] is returned. The stream will end when all
     /// the delegators have been returned for the given block.
     ///
@@ -1483,7 +1480,7 @@ impl Client {
     /// Get the fixed delegators of a given pool for the reward period of the
     /// given block.
     /// If the block or baker ID does not exist [`QueryError::NotFound`] is
-    /// returned. If the block is baked prior to protocol version 4,
+    /// returned, and if the block is baked prior to protocol version 4
     /// [`QueryError::RPCError`] is returned. The stream will end when all
     /// the delegators have been returned.
     ///
@@ -1514,10 +1511,10 @@ impl Client {
     }
 
     /// Get the registered passive delegators at the end of a given block.
-    /// If the block does not exist [`QueryError::NotFound`] is returned.
-    /// If the block is baked prior to protocol version 4,
-    /// [`QueryError::RPCError`] is returned. The stream will end when all
-    /// the delegators have been returned.
+    /// If the block does not exist [`QueryError::NotFound`] is returned, and if
+    /// the block is baked prior to protocol version 4 [`QueryError::
+    /// RPCError`] is returned. The stream will end when all the delegators
+    /// have been returned.
     ///
     /// In contrast to the [`Client::get_passive_delegators_reward_period`]
     /// which returns delegators that are fixed for the reward period of the

--- a/src/v2/mod.rs
+++ b/src/v2/mod.rs
@@ -1370,6 +1370,8 @@ impl Client {
     /// Get information about a given pool at the end of a given block.
     /// If the block or baker ID does not exist [`QueryError::NotFound`] is
     /// returned.
+    /// If the block is baked prior to protocol version 4,
+    /// [`QueryError::NotFound`] is returned.
     pub async fn get_pool_info(
         &mut self,
         block_id: impl IntoBlockIdentifier,
@@ -1388,8 +1390,10 @@ impl Client {
     }
 
     /// Get information about the passive delegators at the end of a given
-    /// block. If the block does not exist [`QueryError::NotFound`] is
-    /// returned.
+    /// block.
+    /// If the block does not exist [`QueryError::NotFound`] is returned.
+    /// If the block is baked prior to protocol version 4,
+    /// [`QueryError::NotFound`] is returned.
     pub async fn get_passive_delegation_info(
         &mut self,
         block_id: impl IntoBlockIdentifier,
@@ -1443,9 +1447,11 @@ impl Client {
     }
 
     /// Get the registered delegators of a given pool at the end of a given
-    /// block. If the block or baker ID does not exist [`QueryError::NotFound`]
-    /// is returned. The stream will end when all the delegators have been
-    /// returned for the given block.
+    /// block.
+    /// If the block or baker ID does not exist [`QueryError::NotFound`] is
+    /// returned. If the block is baked prior to protocol version 4,
+    /// [`QueryError::RPCError`] is returned. The stream will end when all
+    /// the delegators have been returned for the given block.
     ///
     /// In contrast to the [Client::get_pool_delegators_reward_period] which
     /// returns delegators that are fixed for the reward period of the
@@ -1475,11 +1481,13 @@ impl Client {
     }
 
     /// Get the fixed delegators of a given pool for the reward period of the
-    /// given block. If the block or baker ID does not exist
-    /// [`QueryError::NotFound`] is returned. The stream will end when all the
-    /// delegators have been returned.
+    /// given block.
+    /// If the block or baker ID does not exist [`QueryError::NotFound`] is
+    /// returned. If the block is baked prior to protocol version 4,
+    /// [`QueryError::RPCError`] is returned. The stream will end when all
+    /// the delegators have been returned.
     ///
-    /// In contracts to the [Client::get_pool_delegators] which
+    /// In contrast to the [Client::get_pool_delegators] which
     /// returns delegators registered for the given block, this endpoint
     /// returns the fixed delegators contributing stake in the reward period
     /// containing the given block.
@@ -1505,9 +1513,11 @@ impl Client {
         })
     }
 
-    /// Get the registered passive delegators at the end of a given block. If
-    /// the block does not exist [`QueryError::NotFound`] is returned. The
-    /// stream will end when all the delegators have been returned.
+    /// Get the registered passive delegators at the end of a given block.
+    /// If the block does not exist [`QueryError::NotFound`] is returned.
+    /// If the block is baked prior to protocol version 4,
+    /// [`QueryError::RPCError`] is returned. The stream will end when all
+    /// the delegators have been returned.
     ///
     /// In contrast to the [`Client::get_passive_delegators_reward_period`]
     /// which returns delegators that are fixed for the reward period of the
@@ -1536,11 +1546,13 @@ impl Client {
     }
 
     /// Get the fixed passive delegators for the reward period of the given
-    /// block. If the block does not exist [`QueryError::NotFound`] is
-    /// returned. The stream will end when all the delegators have been
-    /// returned.
+    /// block.
+    /// If the block does not exist [`QueryError::NotFound`] is returned.
+    /// If the block is baked prior to protocol version 4,
+    /// [`QueryError::RPCError`] is returned. The stream will end when all
+    /// the delegators have been returned.
     ///
-    /// In contracts to the `GetPassiveDelegators` which returns delegators
+    /// In contrast to the `GetPassiveDelegators` which returns delegators
     /// registered for the given block, this endpoint returns the fixed
     /// delegators contributing stake in the reward period containing the
     /// given block.


### PR DESCRIPTION
## Purpose

When querying a node for anything related to protocol version 4 baking/delegation state, the corresponding client methods return undocumented errors for blocks produced prior to protocol version 4.

## Checklist

- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [x] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [ ] (If necessary) I have updated the CHANGELOG.
