### PR TITLE
Add method to v2 client for identifying payday blocks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
   `Cis2Contract`. These dry-run `update_operator` and `transfer` transactions
   using `invoke_instance`. They can be used to estimate transaction costs, and
   check whether the call will succeed.
+- Add `is_payday_block` helper function to `v2::Client` to identify whether a specific block is one that includes payday events.
 
 ## 2.1.0
 

--- a/src/v2/mod.rs
+++ b/src/v2/mod.rs
@@ -1359,12 +1359,12 @@ impl Client {
         let block_hash = special_events.block_hash;
 
         while let Some(event) = special_events.response.next().await.transpose()? {
-            let has_payday_event = match event {
-                SpecialTransactionOutcome::PaydayPoolReward { .. } => true,
-                SpecialTransactionOutcome::PaydayAccountReward { .. } => true,
-                SpecialTransactionOutcome::PaydayFoundationReward { .. } => true,
-                _ => false,
-            };
+            let has_payday_event = matches!(
+                event,
+                SpecialTransactionOutcome::PaydayPoolReward { .. }
+                    | SpecialTransactionOutcome::PaydayAccountReward { .. }
+                    | SpecialTransactionOutcome::PaydayFoundationReward { .. }
+            );
 
             if has_payday_event {
                 return Ok(QueryResponse {


### PR DESCRIPTION
## Purpose

On suggestion from @abizjak , this adds a method to `v2::Client` which checks if a block is a payday block or not.

## Checklist

- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [x] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [x] (If necessary) I have updated the CHANGELOG.
