### PR TITLE
Propagate changes to rust-src/concordium-base restructuring.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,6 +3,7 @@ name = "concordium-rust-sdk"
 version = "2.2.0"
 authors = ["Concordium <developers@concordium.com>"]
 edition = "2021"
+rust-version = "1.60"
 license-file = "LICENSE"
 include = ["README.md", "CHANGELOG.md"]
 
@@ -43,7 +44,7 @@ generate-protos = ["tonic-build", "git2"]
 [dev-dependencies]
 structopt = "0.3"
 clap = "2.34"
-csv = "=1.1" # Fixed to 1.1. until we update to Rust 1.60+.
+csv = "1.1"
 tokio = { version = "1.21", features = ["full"] }
 tokio-test = { version = "0.4" }
 

--- a/examples/protocol-updates.rs
+++ b/examples/protocol-updates.rs
@@ -3,11 +3,9 @@ use anyhow::Context;
 use clap::AppSettings;
 use concordium_rust_sdk::{
     common::{
-        base16_encode_string,
-        derive::Serialize,
-        to_bytes,
+        base16_encode_string, to_bytes,
         types::{Amount, TransactionTime},
-        Buffer, Deserial, ParseResult, ReadBytesExt, SerdeDeserialize, SerdeSerialize, Serial,
+        SerdeDeserialize, SerdeSerialize, Serialize,
     },
     endpoints::{self, Client, Endpoint},
     types::{

--- a/src/types/mod.rs
+++ b/src/types/mod.rs
@@ -14,7 +14,6 @@ pub use concordium_base::base::*;
 use concordium_base::{
     common::{
         self,
-        derive::Serialize,
         types::{Amount, CredentialIndex, Timestamp, TransactionTime},
         Buffer, Deserial, Get, ParseResult, ReadBytesExt, SerdeDeserialize, SerdeSerialize, Serial,
         Versioned,
@@ -1798,7 +1797,7 @@ impl<Auths: Deserial> Deserial for UpdateKeysCollectionSkeleton<Auths> {
 
 pub type UpdateKeysCollection<CPV> = UpdateKeysCollectionSkeleton<Authorizations<CPV>>;
 
-#[derive(Serialize, Debug, SerdeSerialize, SerdeDeserialize)]
+#[derive(common::Serialize, Debug, SerdeSerialize, SerdeDeserialize)]
 #[serde(rename_all = "camelCase")]
 /// Values of chain parameters that can be updated via chain updates.
 pub struct ChainParametersV0 {
@@ -1822,7 +1821,7 @@ pub struct ChainParametersV0 {
     pub minimum_threshold_for_baking: Amount,
 }
 
-#[derive(Serialize, Debug, SerdeSerialize, SerdeDeserialize)]
+#[derive(common::Serialize, Debug, SerdeSerialize, SerdeDeserialize)]
 #[serde(rename_all = "camelCase")]
 /// Values of chain parameters that can be updated via chain updates.
 pub struct ChainParametersV1 {


### PR DESCRIPTION
## Purpose

Propagate changes from https://github.com/Concordium/concordium-base/pull/337

Remove obsolete comment from Cargo.toml file. MSRV is now 1.60.

## Checklist

- [ ] My code follows the style of this project.
- [ ] The code compiles without warnings.
- [ ] I have performed a self-review of the changes.
- [ ] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [ ] (If necessary) I have updated the CHANGELOG.
