### PR TITLE
Updated example's default values

### DIFF
--- a/examples/v2_banpeers.rs
+++ b/examples/v2_banpeers.rs
@@ -11,7 +11,7 @@ struct App {
     #[structopt(
         long = "node",
         help = "GRPC interface of the node.",
-        default_value = "http://localhost:10001"
+        default_value = "http://localhost:20000"
     )]
     endpoint: v2::Endpoint,
 }

--- a/examples/v2_contract_deploy_init_update.rs
+++ b/examples/v2_contract_deploy_init_update.rs
@@ -28,7 +28,7 @@ struct App {
     #[structopt(
         long = "node",
         help = "GRPC interface of the node.",
-        default_value = "http://localhost:10001"
+        default_value = "http://localhost:20000"
     )]
     endpoint:  v2::Endpoint,
     #[structopt(long = "account", help = "Path to the account key file.")]

--- a/examples/v2_create_initial_accounts.rs
+++ b/examples/v2_create_initial_accounts.rs
@@ -37,7 +37,7 @@ struct App {
     #[structopt(
         long = "node",
         help = "GRPC interface of the node.",
-        default_value = "http://localhost:10001"
+        default_value = "http://localhost:20000"
     )]
     endpoint: v2::Endpoint,
     #[structopt(long = "identity-provider")]

--- a/examples/v2_get_account_info.rs
+++ b/examples/v2_get_account_info.rs
@@ -10,7 +10,7 @@ struct App {
     #[structopt(
         long = "node",
         help = "GRPC interface of the node.",
-        default_value = "http://localhost:10001"
+        default_value = "http://localhost:20000"
     )]
     endpoint: v2::Endpoint,
     #[structopt(long = "address", help = "Account address to query.")]

--- a/examples/v2_get_account_list.rs
+++ b/examples/v2_get_account_list.rs
@@ -10,7 +10,7 @@ struct App {
     #[structopt(
         long = "node",
         help = "GRPC interface of the node.",
-        default_value = "http://localhost:10001"
+        default_value = "http://localhost:20000"
     )]
     endpoint: v2::Endpoint,
 }

--- a/examples/v2_get_account_non_finalized_transactions.rs
+++ b/examples/v2_get_account_non_finalized_transactions.rs
@@ -10,13 +10,12 @@ struct App {
     #[structopt(
         long = "node",
         help = "GRPC interface of the node.",
-        default_value = "http://localhost:10001"
+        default_value = "http://localhost:20000"
     )]
     endpoint: v2::Endpoint,
     #[structopt(
         long = "account",
-        help = "Account address to get non-finalized transactions for.",
-        default_value = "http://localhost:10001"
+        help = "Account address to get non-finalized transactions for."
     )]
     account:  AccountAddress,
 }

--- a/examples/v2_get_ancestors.rs
+++ b/examples/v2_get_ancestors.rs
@@ -10,7 +10,7 @@ struct App {
     #[structopt(
         long = "node",
         help = "GRPC interface of the node.",
-        default_value = "http://localhost:10001"
+        default_value = "http://localhost:20000"
     )]
     endpoint: v2::Endpoint,
     #[structopt(

--- a/examples/v2_get_anonymity_revokers.rs
+++ b/examples/v2_get_anonymity_revokers.rs
@@ -10,7 +10,7 @@ struct App {
     #[structopt(
         long = "node",
         help = "GRPC interface of the node.",
-        default_value = "http://localhost:10001"
+        default_value = "http://localhost:20000"
     )]
     endpoint: v2::Endpoint,
 }

--- a/examples/v2_get_baker_list.rs
+++ b/examples/v2_get_baker_list.rs
@@ -10,7 +10,7 @@ struct App {
     #[structopt(
         long = "node",
         help = "GRPC interface of the node.",
-        default_value = "http://localhost:10001"
+        default_value = "http://localhost:20000"
     )]
     endpoint: v2::Endpoint,
 }

--- a/examples/v2_get_block_chain_parameters.rs
+++ b/examples/v2_get_block_chain_parameters.rs
@@ -10,7 +10,7 @@ struct App {
     #[structopt(
         long = "node",
         help = "GRPC interface of the node.",
-        default_value = "http://localhost:10001"
+        default_value = "http://localhost:20000"
     )]
     endpoint: v2::Endpoint,
 }

--- a/examples/v2_get_block_finalization_summary.rs
+++ b/examples/v2_get_block_finalization_summary.rs
@@ -12,7 +12,7 @@ struct App {
     #[structopt(
         long = "node",
         help = "GRPC interface of the node.",
-        default_value = "http://localhost:10001"
+        default_value = "http://localhost:20000"
     )]
     endpoint: v2::Endpoint,
 }

--- a/examples/v2_get_block_info.rs
+++ b/examples/v2_get_block_info.rs
@@ -10,7 +10,7 @@ struct App {
     #[structopt(
         long = "node",
         help = "GRPC interface of the node.",
-        default_value = "http://localhost:10001"
+        default_value = "http://localhost:20000"
     )]
     endpoint: v2::Endpoint,
 }

--- a/examples/v2_get_block_item_status.rs
+++ b/examples/v2_get_block_item_status.rs
@@ -11,7 +11,7 @@ struct App {
     #[structopt(
         long = "node",
         help = "GRPC interface of the node.",
-        default_value = "http://localhost:10001"
+        default_value = "http://localhost:20000"
     )]
     endpoint:    v2::Endpoint,
     #[structopt(long = "transaction", help = "Transaction hash to query.")]

--- a/examples/v2_get_block_items.rs
+++ b/examples/v2_get_block_items.rs
@@ -10,7 +10,7 @@ struct App {
     #[structopt(
         long = "node",
         help = "GRPC interface of the node.",
-        default_value = "http://localhost:10001"
+        default_value = "http://localhost:20000"
     )]
     endpoint: v2::Endpoint,
 }

--- a/examples/v2_get_block_special_events.rs
+++ b/examples/v2_get_block_special_events.rs
@@ -10,7 +10,7 @@ struct App {
     #[structopt(
         long = "node",
         help = "GRPC interface of the node.",
-        default_value = "http://localhost:10001"
+        default_value = "http://localhost:20000"
     )]
     endpoint: v2::Endpoint,
 }

--- a/examples/v2_get_blocks_at_height.rs
+++ b/examples/v2_get_blocks_at_height.rs
@@ -9,7 +9,7 @@ struct App {
     #[structopt(
         long = "node",
         help = "GRPC interface of the node.",
-        default_value = "http://localhost:10001"
+        default_value = "http://localhost:20000"
     )]
     endpoint: v2::Endpoint,
 }

--- a/examples/v2_get_branches.rs
+++ b/examples/v2_get_branches.rs
@@ -9,7 +9,7 @@ struct App {
     #[structopt(
         long = "node",
         help = "GRPC interface of the node.",
-        default_value = "http://localhost:10001"
+        default_value = "http://localhost:20000"
     )]
     endpoint: v2::Endpoint,
 }

--- a/examples/v2_get_consensus_info.rs
+++ b/examples/v2_get_consensus_info.rs
@@ -9,7 +9,7 @@ struct App {
     #[structopt(
         long = "node",
         help = "GRPC interface of the node.",
-        default_value = "http://localhost:10001"
+        default_value = "http://localhost:20000"
     )]
     endpoint: v2::Endpoint,
 }

--- a/examples/v2_get_cryptographic_parameters.rs
+++ b/examples/v2_get_cryptographic_parameters.rs
@@ -9,7 +9,7 @@ struct App {
     #[structopt(
         long = "node",
         help = "GRPC interface of the node.",
-        default_value = "http://localhost:10001"
+        default_value = "http://localhost:20000"
     )]
     endpoint: v2::Endpoint,
 }

--- a/examples/v2_get_election_info.rs
+++ b/examples/v2_get_election_info.rs
@@ -10,7 +10,7 @@ struct App {
     #[structopt(
         long = "node",
         help = "GRPC interface of the node.",
-        default_value = "http://localhost:10001"
+        default_value = "http://localhost:20000"
     )]
     endpoint: v2::Endpoint,
 }

--- a/examples/v2_get_finalized_blocks.rs
+++ b/examples/v2_get_finalized_blocks.rs
@@ -10,7 +10,7 @@ struct App {
     #[structopt(
         long = "node",
         help = "GRPC interface of the node.",
-        default_value = "http://localhost:10001"
+        default_value = "http://localhost:20000"
     )]
     endpoint: v2::Endpoint,
 }

--- a/examples/v2_get_identity_providers.rs
+++ b/examples/v2_get_identity_providers.rs
@@ -10,7 +10,7 @@ struct App {
     #[structopt(
         long = "node",
         help = "GRPC interface of the node.",
-        default_value = "http://localhost:10001"
+        default_value = "http://localhost:20000"
     )]
     endpoint: v2::Endpoint,
 }

--- a/examples/v2_get_instance_info.rs
+++ b/examples/v2_get_instance_info.rs
@@ -9,7 +9,7 @@ struct App {
     #[structopt(
         long = "node",
         help = "GRPC interface of the node.",
-        default_value = "http://localhost:10001"
+        default_value = "http://localhost:20000"
     )]
     endpoint: v2::Endpoint,
     #[structopt(long = "address", help = "Contract address to query.")]

--- a/examples/v2_get_instance_list.rs
+++ b/examples/v2_get_instance_list.rs
@@ -10,7 +10,7 @@ struct App {
     #[structopt(
         long = "node",
         help = "GRPC interface of the node.",
-        default_value = "http://localhost:10001"
+        default_value = "http://localhost:20000"
     )]
     endpoint: v2::Endpoint,
 }

--- a/examples/v2_get_instance_state.rs
+++ b/examples/v2_get_instance_state.rs
@@ -13,7 +13,7 @@ struct App {
     #[structopt(
         long = "node",
         help = "GRPC interface of the node.",
-        default_value = "http://localhost:10001"
+        default_value = "http://localhost:20000"
     )]
     endpoint: v2::Endpoint,
     #[structopt(long = "index", help = "Index of the smart contract to query.")]

--- a/examples/v2_get_instances_stats.rs
+++ b/examples/v2_get_instances_stats.rs
@@ -18,7 +18,7 @@ struct App {
     #[structopt(
         long = "node",
         help = "GRPC interface of the node.",
-        default_value = "http://localhost:10001"
+        default_value = "http://localhost:20000"
     )]
     endpoint: v2::Endpoint,
     #[structopt(

--- a/examples/v2_get_module_list.rs
+++ b/examples/v2_get_module_list.rs
@@ -10,7 +10,7 @@ struct App {
     #[structopt(
         long = "node",
         help = "GRPC interface of the node.",
-        default_value = "http://localhost:10001"
+        default_value = "http://localhost:20000"
     )]
     endpoint: v2::Endpoint,
 }

--- a/examples/v2_get_module_source.rs
+++ b/examples/v2_get_module_source.rs
@@ -10,7 +10,7 @@ struct App {
     #[structopt(
         long = "node",
         help = "GRPC interface of the node.",
-        default_value = "http://localhost:10001"
+        default_value = "http://localhost:20000"
     )]
     endpoint: v2::Endpoint,
     #[structopt(long = "module", help = "Module reference to query.")]

--- a/examples/v2_get_next_account_sequence_number.rs
+++ b/examples/v2_get_next_account_sequence_number.rs
@@ -9,7 +9,7 @@ struct App {
     #[structopt(
         long = "node",
         help = "GRPC interface of the node.",
-        default_value = "http://localhost:10001"
+        default_value = "http://localhost:20000"
     )]
     endpoint: v2::Endpoint,
     #[structopt(long = "account", help = "Address of the account to query.")]

--- a/examples/v2_get_next_update_sequence_numbers.rs
+++ b/examples/v2_get_next_update_sequence_numbers.rs
@@ -10,7 +10,7 @@ struct App {
     #[structopt(
         long = "node",
         help = "GRPC interface of the node.",
-        default_value = "http://localhost:10001"
+        default_value = "http://localhost:20000"
     )]
     endpoint: v2::Endpoint,
 }

--- a/examples/v2_get_node_info.rs
+++ b/examples/v2_get_node_info.rs
@@ -9,7 +9,7 @@ struct App {
     #[structopt(
         long = "node",
         help = "GRPC interface of the node.",
-        default_value = "http://localhost:10001"
+        default_value = "http://localhost:20000"
     )]
     endpoint: v2::Endpoint,
 }

--- a/examples/v2_get_passive_delegation_info.rs
+++ b/examples/v2_get_passive_delegation_info.rs
@@ -10,7 +10,7 @@ struct App {
     #[structopt(
         long = "node",
         help = "GRPC interface of the node.",
-        default_value = "http://localhost:10001"
+        default_value = "http://localhost:20000"
     )]
     endpoint: v2::Endpoint,
 }

--- a/examples/v2_get_passive_delegators.rs
+++ b/examples/v2_get_passive_delegators.rs
@@ -10,7 +10,7 @@ struct App {
     #[structopt(
         long = "node",
         help = "GRPC interface of the node.",
-        default_value = "http://localhost:10001"
+        default_value = "http://localhost:20000"
     )]
     endpoint: v2::Endpoint,
 }

--- a/examples/v2_get_passive_delegators_reward_period.rs
+++ b/examples/v2_get_passive_delegators_reward_period.rs
@@ -10,7 +10,7 @@ struct App {
     #[structopt(
         long = "node",
         help = "GRPC interface of the node.",
-        default_value = "http://localhost:10001"
+        default_value = "http://localhost:20000"
     )]
     endpoint: v2::Endpoint,
 }

--- a/examples/v2_get_peers_info.rs
+++ b/examples/v2_get_peers_info.rs
@@ -9,7 +9,7 @@ struct App {
     #[structopt(
         long = "node",
         help = "GRPC interface of the node.",
-        default_value = "http://localhost:10001"
+        default_value = "http://localhost:20000"
     )]
     endpoint: v2::Endpoint,
 }

--- a/examples/v2_get_pool_delegators.rs
+++ b/examples/v2_get_pool_delegators.rs
@@ -10,7 +10,7 @@ struct App {
     #[structopt(
         long = "node",
         help = "GRPC interface of the node.",
-        default_value = "http://localhost:10001"
+        default_value = "http://localhost:20000"
     )]
     endpoint: v2::Endpoint,
 }

--- a/examples/v2_get_pool_delegators_reward_period.rs
+++ b/examples/v2_get_pool_delegators_reward_period.rs
@@ -11,7 +11,7 @@ struct App {
     #[structopt(
         long = "node",
         help = "GRPC interface of the node.",
-        default_value = "http://localhost:10001"
+        default_value = "http://localhost:20000"
     )]
     endpoint: v2::Endpoint,
     #[structopt(long = "block", help = "Block to query delegators in.")]

--- a/examples/v2_get_pool_info.rs
+++ b/examples/v2_get_pool_info.rs
@@ -10,7 +10,7 @@ struct App {
     #[structopt(
         long = "node",
         help = "GRPC interface of the node.",
-        default_value = "http://localhost:10001"
+        default_value = "http://localhost:20000"
     )]
     endpoint: v2::Endpoint,
     #[structopt(long = "block", help = "Block to query in.")]

--- a/examples/v2_get_tokenomics_info.rs
+++ b/examples/v2_get_tokenomics_info.rs
@@ -10,7 +10,7 @@ struct App {
     #[structopt(
         long = "node",
         help = "GRPC interface of the node.",
-        default_value = "http://localhost:10001"
+        default_value = "http://localhost:20000"
     )]
     endpoint: v2::Endpoint,
 }

--- a/examples/v2_instance_state_lookup.rs
+++ b/examples/v2_instance_state_lookup.rs
@@ -10,7 +10,7 @@ struct App {
     #[structopt(
         long = "node",
         help = "GRPC interface of the node.",
-        default_value = "http://localhost:10001"
+        default_value = "http://localhost:20000"
     )]
     endpoint: v2::Endpoint,
     #[structopt(long = "index", help = "Index of the smart contract to query.")]

--- a/examples/v2_invoke_instance.rs
+++ b/examples/v2_invoke_instance.rs
@@ -13,7 +13,7 @@ struct App {
     #[structopt(
         long = "node",
         help = "GRPC interface of the node.",
-        default_value = "http://localhost:10001"
+        default_value = "http://localhost:20000"
     )]
     endpoint:     v2::Endpoint,
     #[structopt(long = "contract", help = "The address of the contract to invoke")]

--- a/examples/v2_list_cis2_contracts.rs
+++ b/examples/v2_list_cis2_contracts.rs
@@ -14,7 +14,7 @@ struct App {
     #[structopt(
         long = "node",
         help = "GRPC interface of the node.",
-        default_value = "http://localhost:10000"
+        default_value = "http://localhost:20000"
     )]
     endpoint: v2::Endpoint,
     #[structopt(

--- a/examples/v2_list_instances.rs
+++ b/examples/v2_list_instances.rs
@@ -15,7 +15,7 @@ struct App {
     #[structopt(
         long = "node",
         help = "GRPC interface of the node.",
-        default_value = "http://localhost:10000"
+        default_value = "http://localhost:20000"
     )]
     endpoint: v2::Endpoint,
     #[structopt(

--- a/examples/v2_networkdumps.rs
+++ b/examples/v2_networkdumps.rs
@@ -9,7 +9,7 @@ struct App {
     #[structopt(
         long = "node",
         help = "GRPC interface of the node.",
-        default_value = "http://localhost:10001"
+        default_value = "http://localhost:20000"
     )]
     endpoint: v2::Endpoint,
 }

--- a/examples/v2_peer_connect.rs
+++ b/examples/v2_peer_connect.rs
@@ -11,7 +11,7 @@ struct App {
     #[structopt(
         long = "node",
         help = "GRPC interface of the node.",
-        default_value = "http://localhost:10001"
+        default_value = "http://localhost:20000"
     )]
     endpoint: v2::Endpoint,
     #[structopt(long = "peer", help = "peer to connect to")]

--- a/examples/v2_register_data.rs
+++ b/examples/v2_register_data.rs
@@ -17,7 +17,7 @@ struct App {
     #[structopt(
         long = "node",
         help = "GRPC interface of the node.",
-        default_value = "http://localhost:10001"
+        default_value = "http://localhost:20000"
     )]
     endpoint:  v2::Endpoint,
     #[structopt(long = "account", help = "Path to the account key file.")]

--- a/examples/v2_send_encrypted_transfer.rs
+++ b/examples/v2_send_encrypted_transfer.rs
@@ -48,7 +48,7 @@ struct App {
     #[structopt(
         long = "node",
         help = "GRPC interface of the node.",
-        default_value = "http://localhost:10001"
+        default_value = "http://localhost:20000"
     )]
     endpoint:  v2::Endpoint,
     #[structopt(long = "account", help = "Path to the account key file.")]

--- a/examples/v2_send_transfer.rs
+++ b/examples/v2_send_transfer.rs
@@ -18,7 +18,7 @@ struct App {
     #[structopt(
         long = "node",
         help = "GRPC interface of the node.",
-        default_value = "http://localhost:10001"
+        default_value = "http://localhost:20000"
     )]
     endpoint:  v2::Endpoint,
     #[structopt(long = "account", help = "Path to the account key file.")]

--- a/examples/v2_shutdown.rs
+++ b/examples/v2_shutdown.rs
@@ -9,7 +9,7 @@ struct App {
     #[structopt(
         long = "node",
         help = "GRPC interface of the node.",
-        default_value = "http://localhost:10001"
+        default_value = "http://localhost:20000"
     )]
     endpoint: v2::Endpoint,
 }

--- a/examples/v2_traverse_all_transactions.rs
+++ b/examples/v2_traverse_all_transactions.rs
@@ -20,7 +20,7 @@ struct App {
     #[structopt(
         long = "node-v2",
         help = "GRPC2 interface of the node.",
-        default_value = "http://localhost:10001"
+        default_value = "http://localhost:20000"
     )]
     endpoint_v2: Endpoint,
     #[structopt(long = "block")]

--- a/examples/v2_update_exchange_rate.rs
+++ b/examples/v2_update_exchange_rate.rs
@@ -18,7 +18,7 @@ struct App {
     #[structopt(
         long = "node",
         help = "GRPC interface of the node.",
-        default_value = "http://localhost:10001"
+        default_value = "http://localhost:20000"
     )]
     endpoint: v2::Endpoint,
     #[structopt(long = "key", help = "Path to update keys to use.")]


### PR DESCRIPTION
## Purpose

`localhost:10001` -> `localhost:20000` for all GRPCv2 examples. Also removed wrong default for account parameter in `v2_get_account_non_finalized_transactions.rs`