### PR TITLE
Revise block stats so that it will only stop after a designated time.

### DIFF
--- a/examples/block-stats.rs
+++ b/examples/block-stats.rs
@@ -9,32 +9,27 @@
 //! - number of events associated with payday
 //! - whether the block contains a finalization record
 //! - the number of transactions included in the block
-use anyhow::Context;
 use chrono::Utc;
 use clap::AppSettings;
 use concordium_rust_sdk::{
-    endpoints::{self, Endpoint},
-    types::{queries::BlockInfo, AbsoluteBlockHeight, BlockSummary, SpecialTransactionOutcome},
+    types::{AbsoluteBlockHeight, SpecialTransactionOutcome},
+    v2,
+    v2::Endpoint,
 };
+use futures::TryStreamExt;
 use structopt::StructOpt;
 
 #[derive(StructOpt)]
 struct App {
     #[structopt(
         long = "node",
-        help = "GRPC interface of the node.",
-        default_value = "http://localhost:10000"
+        help = "GRPC V2 interface of the node.",
+        default_value = "http://localhost:20000"
     )]
     endpoint: Endpoint,
-    #[structopt(
-        long = "num",
-        help = "How many queries to make in parallel.",
-        default_value = "1"
-    )]
-    num:      u64,
     #[structopt(long = "from", help = "Starting time. Defaults to genesis time.")]
     from:     Option<chrono::DateTime<chrono::Utc>>,
-    #[structopt(long = "to", help = "End time. Defaults to infinity.")]
+    #[structopt(long = "to", help = "End time. Defaults to the time the tool has run.")]
     to:       Option<chrono::DateTime<Utc>>,
 }
 
@@ -46,111 +41,79 @@ async fn main() -> anyhow::Result<()> {
         App::from_clap(&matches)
     };
 
-    let mut client = endpoints::Client::connect(app.endpoint, "rpcadmin".to_string()).await?;
-
-    let cs = client.get_consensus_status().await?;
+    let mut client = v2::Client::new(app.endpoint).await?;
 
     // Find the starting block.
     let mut h = if let Some(start_time) = app.from {
-        let cb = cs.last_finalized_block;
-        let mut bi = client.get_block_info(&cb).await?;
-        anyhow::ensure!(
-            bi.block_slot_time >= start_time,
-            "Last finalized block is not after the requested start time ({})",
-            bi.block_slot_time.to_rfc3339()
-        );
-        let mut end: u64 = bi.block_height.into();
-        let mut start = 0;
-        while start < end {
-            let mid = (start + end) / 2;
-            let bh = client
-                .get_blocks_at_height(AbsoluteBlockHeight::from(mid).into())
-                .await?[0];
-            bi = client.get_block_info(&bh).await?;
-            if bi.block_slot_time < start_time {
-                start = mid + 1;
-            } else {
-                end = mid;
+        let b = client
+            .find_earliest_finalized(.., |mut client, _, bh| async move {
+                let bi = client.get_block_info(&bh).await?.response;
+                Ok(if bi.block_slot_time >= start_time {
+                    Some(bi)
+                } else {
+                    None
+                })
+            })
+            .await;
+        match b {
+            Ok(bi) => bi.block_height,
+            Err(e) if e.is_not_found() => {
+                anyhow::bail!("Last finalized block is not after the requested start time.")
             }
+            Err(e) => anyhow::bail!("An error occurred: {e:#}"),
         }
-        start.into()
     } else {
         AbsoluteBlockHeight::from(0u64)
     };
     let mut block_count: u32 = 0;
     let mut finalization_count: u32 = 0;
-    loop {
-        let mut handles = Vec::with_capacity(app.num as usize);
-        for height in u64::from(h)..u64::from(h) + app.num {
-            let cc = client.clone();
-            handles.push(tokio::spawn(async move {
-                let h: AbsoluteBlockHeight = height.into();
-                let mut cc = cc.clone();
-                let blocks = cc
-                    .get_blocks_at_height(h.into())
-                    .await
-                    .context("Blocks at height.")?;
-                if blocks.is_empty() {
-                    return Ok::<Option<(BlockInfo, BlockSummary)>, anyhow::Error>(None);
-                }
-                let bi = cc.get_block_info(&blocks[0]).await.context("Block info.")?;
-                if !bi.finalized {
-                    return Ok::<_, anyhow::Error>(None);
-                }
-                let summary = cc
-                    .get_block_summary(&blocks[0])
-                    .await
-                    .context("Block summary.")?;
-                Ok(Some((bi, summary)))
-            }))
-        }
-        let mut success = true;
-        for res in futures::future::join_all(handles).await {
-            if let Some((bi, summary)) = res?? {
-                if let Some(end) = app.to.as_ref() {
-                    if end <= &bi.block_slot_time {
-                        return Ok(());
-                    }
-                }
-                let payday_block = summary
-                    .special_events()
-                    .iter()
-                    .map(|ev| match ev {
-                        SpecialTransactionOutcome::PaydayFoundationReward { .. } => 1u32,
-                        SpecialTransactionOutcome::PaydayAccountReward { .. } => 1u32,
-                        SpecialTransactionOutcome::PaydayPoolReward { .. } => 1u32,
-                        _ => 0u32,
-                    })
-                    .sum::<u32>();
-                h = h.next();
-                println!(
-                    "{}, {}, {}, {}, {}ms, {}ms, {}, {}, {}",
-                    bi.block_hash,
-                    bi.block_slot_time.format("%H:%M:%S%.3f"),
-                    bi.block_receive_time.format("%H:%M:%S%.3f"),
-                    bi.block_arrive_time.format("%H:%M:%S%.3f"),
-                    bi.block_receive_time
-                        .signed_duration_since(bi.block_slot_time)
-                        .num_milliseconds(),
-                    bi.block_arrive_time
-                        .signed_duration_since(bi.block_slot_time)
-                        .num_milliseconds(),
-                    payday_block,
-                    summary.finalization_data().is_some(),
-                    bi.transaction_count
-                );
-                if summary.finalization_data().is_some() {
-                    finalization_count += 1
-                };
-                block_count += 1;
-            } else {
-                success = false;
-                break;
-            }
-        }
-        if !success {
+    let mut blocks = client.get_finalized_blocks_from(h).await?;
+    let end_time = app.to.unwrap_or_else(chrono::Utc::now);
+    while let Some(block) = blocks.next().await {
+        let bi = client.get_block_info(block.block_hash).await?.response;
+        if bi.block_slot_time > end_time {
             break;
         }
+        let payday_block = client
+            .get_block_special_events(bi.block_hash)
+            .await?
+            .response
+            .try_fold(0, |count, ev| async move {
+                let add = match ev {
+                    SpecialTransactionOutcome::PaydayFoundationReward { .. } => 1u32,
+                    SpecialTransactionOutcome::PaydayAccountReward { .. } => 1u32,
+                    SpecialTransactionOutcome::PaydayPoolReward { .. } => 1u32,
+                    _ => 0u32,
+                };
+                Ok(count + add)
+            })
+            .await?;
+        h = h.next();
+        let has_finalization_data = client
+            .get_block_finalization_summary(bi.block_hash)
+            .await?
+            .response
+            .is_some();
+        println!(
+            "{}, {}, {}, {}, {}ms, {}ms, {}, {}, {}",
+            bi.block_hash,
+            bi.block_slot_time.format("%H:%M:%S%.3f"),
+            bi.block_receive_time.format("%H:%M:%S%.3f"),
+            bi.block_arrive_time.format("%H:%M:%S%.3f"),
+            bi.block_receive_time
+                .signed_duration_since(bi.block_slot_time)
+                .num_milliseconds(),
+            bi.block_arrive_time
+                .signed_duration_since(bi.block_slot_time)
+                .num_milliseconds(),
+            payday_block,
+            has_finalization_data,
+            bi.transaction_count
+        );
+        if has_finalization_data {
+            finalization_count += 1
+        };
+        block_count += 1;
     }
     println!("Block count = {}", block_count);
     println!("Finalization record count = {}", finalization_count);


### PR DESCRIPTION
## Purpose

Change the block-stats script so that it stops only after reaching the given time.

Also migrates the block stats to V2 interface.

Additionally make the conversion of timestamp to datetime fallible.

## Checklist

- [ ] My code follows the style of this project.
- [ ] The code compiles without warnings.
- [ ] I have performed a self-review of the changes.
- [ ] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [ ] (If necessary) I have updated the CHANGELOG.