### PR TITLE
Update Rust fmt to `2023-04-01`

### DIFF
--- a/.github/workflows/build-and-test.yaml
+++ b/.github/workflows/build-and-test.yaml
@@ -15,7 +15,7 @@ on:
   workflow_dispatch: # allows manual trigger
 
 env:
-  RUST_FMT: nightly-2022-06-09-x86_64-unknown-linux-gnu
+  RUST_FMT: nightly-2023-04-01-x86_64-unknown-linux-gnu
   RUST_VERSION: "1.64"
 
 jobs:

--- a/src/types/mod.rs
+++ b/src/types/mod.rs
@@ -874,7 +874,7 @@ mod block_summary_parser {
         protocol_version: super::ProtocolVersion,
         #[serde(flatten)]
         // parse first into a value
-        data:             super::BlockSummaryData<serde_json::Value>,
+        data: super::BlockSummaryData<serde_json::Value>,
     }
 
     impl std::convert::TryFrom<BlockSummaryRaw> for super::BlockSummary {


### PR DESCRIPTION
## Purpose

Update Rust fmt to `2023-04-01` to match other Rust repos.

Depends on: https://github.com/Concordium/concordium-base/pull/369

## Changes

- Update version in CI jobs
- Update base dependency
- Fix minor formatting issues

## Checklist

- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [x] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [ ] (If necessary) I have updated the CHANGELOG.