### PR TITLE
Types for P6 GenesisData

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## Unreleased changes
 
+- Extend enum `PendingUpdateEffect` with variants for protocol version 6.
 - Introduce `ChainParametersV2` struct for protocol version 6.
 - Introduce generic `gas_reward` in `RewardParametersSkeleton` for supporting different versions of GASRewards.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## Unreleased changes
 
+- Introduce `ChainParametersV2` struct for protocol version 6.
+- Introduce generic `gas_reward` in `RewardParametersSkeleton` for supporting different versions of GASRewards.
+
 ## 2.4.0
 
 - Re-export `concordium_base` to enable use of `concordium_base_derive`

--- a/examples/v2_update_exchange_rate.rs
+++ b/examples/v2_update_exchange_rate.rs
@@ -72,6 +72,7 @@ async fn main() -> anyhow::Result<()> {
     let exchange_rate = match &params.response {
         v2::ChainParameters::V0(v0) => v0.micro_ccd_per_euro,
         v2::ChainParameters::V1(v1) => v1.micro_ccd_per_euro,
+        v2::ChainParameters::V2(v2) => v2.micro_ccd_per_euro,
     };
 
     let effective_time = 0.into(); // immediate effect

--- a/src/types/mod.rs
+++ b/src/types/mod.rs
@@ -1879,7 +1879,7 @@ impl<MD: common::Deserial, GR: common::Deserial> common::Deserial
 ///
 /// The concrete types for some of the fields depends on the version of chain
 /// parameters. See implementations of [`MintDistribution`] and
-/// [`GasRewardsFor`] for concrete types.
+/// [`GASRewardsFor`] for concrete types.
 pub type RewardParameters<CPV> =
     RewardParametersSkeleton<MintDistribution<CPV>, GASRewardsFor<CPV>>;
 

--- a/src/types/mod.rs
+++ b/src/types/mod.rs
@@ -1792,6 +1792,33 @@ pub struct ChainParametersV1 {
     pub pool_parameters:          PoolParameters,
 }
 
+#[derive(common::Serial, Debug)]
+/// Values of chain parameters that can be updated via chain updates.
+pub struct ChainParametersV2 {
+    /// Consensus protocol version 2 timeout parameters.
+    pub timeout_parameters:                TimeoutParameters,
+    /// Minimum time interval between blocks.
+    pub min_block_time:                    SlotDuration,
+    /// Maximum energy allowed per block.
+    pub block_energy_limit:                Energy,
+    /// Euro per energy exchange rate.
+    pub euro_per_energy:                   ExchangeRate,
+    /// Micro ccd per euro exchange rate.
+    pub micro_gtu_per_euro:                ExchangeRate,
+    pub cooldown_parameters:               CooldownParameters,
+    pub time_parameters:                   TimeParameters,
+    /// The limit for the number of account creations in a block.
+    pub account_creation_limit:            CredentialsPerBlockLimit,
+    /// Current reward parameters.
+    pub reward_parameters:                 RewardParameters<ChainParameterVersion2>,
+    /// Index of the foundation account.
+    pub foundation_account_index:          AccountIndex,
+    /// Parameters for baker pools.
+    pub pool_parameters:                   PoolParameters,
+    /// The finalization committee parameters.
+    pub finalization_committee_parameters: FinalizationCommitteeParameters,
+}
+
 pub trait ChainParametersFamily {
     type Output: std::fmt::Debug;
 }
@@ -1804,19 +1831,23 @@ impl ChainParametersFamily for ChainParameterVersion1 {
     type Output = ChainParametersV1;
 }
 
+impl ChainParametersFamily for ChainParameterVersion2 {
+    type Output = ChainParametersV2;
+}
+
 pub type ChainParameters<CPV> = <CPV as ChainParametersFamily>::Output;
 
 #[derive(Debug, SerdeSerialize, SerdeDeserialize)]
 #[serde(rename_all = "camelCase")]
 /// Values of reward parameters.
-pub struct RewardParametersSkeleton<MD> {
+pub struct RewardParametersSkeleton<MD, GR> {
     pub mint_distribution:            MD,
     pub transaction_fee_distribution: TransactionFeeDistribution,
     #[serde(rename = "gASRewards")]
-    pub gas_rewards:                  GASRewards,
+    pub gas_rewards:                  GR,
 }
 
-impl<MD: common::Serial> common::Serial for RewardParametersSkeleton<MD> {
+impl<MD: common::Serial, GR: common::Serial> common::Serial for RewardParametersSkeleton<MD, GR> {
     fn serial<B: Buffer>(&self, out: &mut B) {
         self.mint_distribution.serial(out);
         self.transaction_fee_distribution.serial(out);
@@ -1824,7 +1855,9 @@ impl<MD: common::Serial> common::Serial for RewardParametersSkeleton<MD> {
     }
 }
 
-impl<MD: common::Deserial> common::Deserial for RewardParametersSkeleton<MD> {
+impl<MD: common::Deserial, GR: common::Deserial> common::Deserial
+    for RewardParametersSkeleton<MD, GR>
+{
     fn deserial<R: ReadBytesExt>(source: &mut R) -> ParseResult<Self> {
         let mint_distribution = source.get()?;
         let transaction_fee_distribution = source.get()?;
@@ -1837,7 +1870,8 @@ impl<MD: common::Deserial> common::Deserial for RewardParametersSkeleton<MD> {
     }
 }
 
-pub type RewardParameters<CPV> = RewardParametersSkeleton<MintDistribution<CPV>>;
+pub type RewardParameters<CPV> =
+    RewardParametersSkeleton<MintDistribution<CPV>, GASRewardsFor<CPV>>;
 
 #[derive(Debug, SerdeSerialize, SerdeDeserialize, Clone, Copy)]
 #[serde(rename_all = "camelCase")]

--- a/src/types/queries.rs
+++ b/src/types/queries.rs
@@ -284,6 +284,16 @@ pub enum PendingUpdateEffect {
     CooldownParameters(CooldownParameters),
     #[serde(rename = "timeParametersV1")]
     TimeParameters(TimeParameters),
+    #[serde(rename = "gasRewardsV1")]
+    GasRewardsV1(GASRewardsV1),
+    #[serde(rename = "timeoutParameters")]
+    TimeoutParameters(TimeoutParameters),
+    #[serde(rename = "minBlockTime")]
+    MinBlockTime(Duration),
+    #[serde(rename = "blockEnergyLimit")]
+    BlockEnergyLimit(Energy),
+    #[serde(rename = "finalizationCommitteeParameters")]
+    FinalizationCommitteeParameters(FinalizationCommitteeParameters),
 }
 
 #[derive(Debug, Copy, Clone)]

--- a/src/v1/generated/concordium.rs
+++ b/src/v1/generated/concordium.rs
@@ -1,19 +1,23 @@
 /// An empty message.
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct Empty {}
 /// A numeric response.
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct NumberResponse {
     #[prost(uint64, tag = "1")]
     pub value: u64,
 }
 /// A response consisting of a boolean.
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct BoolResponse {
     #[prost(bool, tag = "1")]
     pub value: bool,
 }
 /// A response in string format.
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct StringResponse {
     #[prost(string, tag = "1")]
@@ -21,6 +25,7 @@ pub struct StringResponse {
 }
 /// A response that is encoded in JSON.
 /// JSON schemas are available at <https://developer.concordium.software/en/mainnet/net/references/grpc.html.>
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct JsonResponse {
     #[prost(string, tag = "1")]
@@ -28,67 +33,75 @@ pub struct JsonResponse {
 }
 /// A response in binary format.
 /// The encoding of the data is dependent on the endpoint.
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct BytesResponse {
     #[prost(bytes = "vec", tag = "1")]
     pub value: ::prost::alloc::vec::Vec<u8>,
 }
 /// A request that suggests the node to connect to the specified peer.
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct PeerConnectRequest {
     /// The IP of the peer.
     #[prost(message, optional, tag = "1")]
-    pub ip:   ::core::option::Option<::prost::alloc::string::String>,
+    pub ip: ::core::option::Option<::prost::alloc::string::String>,
     /// The port of the peer.
     #[prost(message, optional, tag = "2")]
     pub port: ::core::option::Option<i32>,
 }
 /// A peer node.
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct PeerElement {
     /// The id of the node.
     #[prost(message, optional, tag = "1")]
-    pub node_id:        ::core::option::Option<::prost::alloc::string::String>,
+    pub node_id: ::core::option::Option<::prost::alloc::string::String>,
     /// The port of the node.
     #[prost(message, optional, tag = "2")]
-    pub port:           ::core::option::Option<u32>,
+    pub port: ::core::option::Option<u32>,
     /// The IP of the node.
     #[prost(message, optional, tag = "3")]
-    pub ip:             ::core::option::Option<::prost::alloc::string::String>,
+    pub ip: ::core::option::Option<::prost::alloc::string::String>,
     /// The current status of the peer.
     #[prost(enumeration = "peer_element::CatchupStatus", tag = "4")]
     pub catchup_status: i32,
 }
 /// Nested message and enum types in `PeerElement`.
 pub mod peer_element {
-    #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, ::prost::Enumeration)]
+    #[derive(
+        Clone,
+        Copy,
+        Debug,
+        PartialEq,
+        Eq,
+        Hash,
+        PartialOrd,
+        Ord,
+        ::prost::Enumeration
+    )]
     #[repr(i32)]
     pub enum CatchupStatus {
-        /// The peer does not have any data unknown to us. If we receive a
-        /// message from the peer that refers to unknown data (e.g., an
-        /// unknown block) the peer is marked as pending.
-        Uptodate   = 0,
-        /// The peer might have some data unknown to us. A peer can be in this
-        /// state either because it sent a message that refers to data
-        /// unknown to us, or before we have established a baseline with it.
-        /// The latter happens during node startup, as well as upon protocol
-        /// updates until the initial catchup handshake completes.
-        Pending    = 1,
-        /// The node is currently catching up by requesting blocks from this
-        /// peer. There will be at most one peer with this status at a
-        /// time. Once the peer has responded to the request, its status
-        /// will be changed to:
+        /// The peer does not have any data unknown to us. If we receive a message from the
+        /// peer that refers to unknown data (e.g., an unknown block) the peer is marked as pending.
+        Uptodate = 0,
+        /// The peer might have some data unknown to us. A peer can be in this state either because
+        /// it sent a message that refers to data unknown to us, or before we have established a baseline with it.
+        /// The latter happens during node startup, as well as upon protocol updates until the initial catchup handshake
+        /// completes.
+        Pending = 1,
+        /// The node is currently catching up by requesting blocks from this peer.
+        /// There will be at most one peer with this status at a time.
+        /// Once the peer has responded to the request, its status will be changed to:
         /// - 'UPTODATE' if the peer has no more data that is not known to us
         /// - 'PENDING' if the node has more data that is unknown to us.
         Catchingup = 2,
     }
     impl CatchupStatus {
-        /// String value of the enum field names used in the ProtoBuf
-        /// definition.
+        /// String value of the enum field names used in the ProtoBuf definition.
         ///
-        /// The values are not transformed in any way and thus are considered
-        /// stable (if the ProtoBuf definition does not change) and safe
-        /// for programmatic use.
+        /// The values are not transformed in any way and thus are considered stable
+        /// (if the ProtoBuf definition does not change) and safe for programmatic use.
         pub fn as_str_name(&self) -> &'static str {
             match self {
                 CatchupStatus::Uptodate => "UPTODATE",
@@ -96,9 +109,19 @@ pub mod peer_element {
                 CatchupStatus::Catchingup => "CATCHINGUP",
             }
         }
+        /// Creates an enum from field names used in the ProtoBuf definition.
+        pub fn from_str_name(value: &str) -> ::core::option::Option<Self> {
+            match value {
+                "UPTODATE" => Some(Self::Uptodate),
+                "PENDING" => Some(Self::Pending),
+                "CATCHINGUP" => Some(Self::Catchingup),
+                _ => None,
+            }
+        }
     }
 }
 /// A response containing a list of peers.
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct PeerListResponse {
     /// The type of the queried node.
@@ -107,40 +130,43 @@ pub struct PeerListResponse {
     pub peer_type: ::prost::alloc::string::String,
     /// A list of peers.
     #[prost(message, repeated, tag = "2")]
-    pub peers:     ::prost::alloc::vec::Vec<PeerElement>,
+    pub peers: ::prost::alloc::vec::Vec<PeerElement>,
 }
 /// A response containing information about a peer.
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct PeerStatsResponse {
     /// A list of stats for the peers.
     #[prost(message, repeated, tag = "1")]
-    pub peerstats:   ::prost::alloc::vec::Vec<peer_stats_response::PeerStats>,
+    pub peerstats: ::prost::alloc::vec::Vec<peer_stats_response::PeerStats>,
     /// Average outbound throughput in bytes per second.
     #[prost(uint64, tag = "2")]
-    pub avg_bps_in:  u64,
+    pub avg_bps_in: u64,
     /// Average inbound throughput in bytes per second.
     #[prost(uint64, tag = "3")]
     pub avg_bps_out: u64,
 }
 /// Nested message and enum types in `PeerStatsResponse`.
 pub mod peer_stats_response {
+    #[allow(clippy::derive_partial_eq_without_eq)]
     #[derive(Clone, PartialEq, ::prost::Message)]
     pub struct PeerStats {
         /// The node id.
         #[prost(string, tag = "1")]
-        pub node_id:          ::prost::alloc::string::String,
+        pub node_id: ::prost::alloc::string::String,
         /// The number of messages sent to the peer.
         #[prost(uint64, tag = "2")]
-        pub packets_sent:     u64,
+        pub packets_sent: u64,
         /// The number of messages received from the peer.
         #[prost(uint64, tag = "3")]
         pub packets_received: u64,
         /// The connection latency (i.e., ping time) in milliseconds.
         #[prost(uint64, tag = "4")]
-        pub latency:          u64,
+        pub latency: u64,
     }
 }
 /// A request to change the network.
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct NetworkChangeRequest {
     /// The identifier for the network.
@@ -148,6 +174,7 @@ pub struct NetworkChangeRequest {
     pub network_id: ::core::option::Option<i32>,
 }
 /// A response containing information about the node.
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct NodeInfoResponse {
     /// The unique node identifier.
@@ -163,15 +190,12 @@ pub struct NodeInfoResponse {
     #[prost(bool, tag = "4")]
     pub consensus_baker_running: bool,
     /// Whether consensus is running.
-    /// This is only false if the protocol was updated to a version which the
-    /// node software does not support.
+    /// This is only false if the protocol was updated to a version which the node software does not support.
     #[prost(bool, tag = "5")]
     pub consensus_running: bool,
     /// Whether the node is "Active" or "Passive".
-    /// - "Active": the node has baker credentials and can thus potentially
-    ///   participate in baking and finalization.
-    /// - "Passive": the node has no baker credentials is thus only an observer
-    ///   of the consensus protocol.
+    /// - "Active": the node has baker credentials and can thus potentially participate in baking and finalization.
+    /// - "Passive": the node has no baker credentials is thus only an observer of the consensus protocol.
     #[prost(string, tag = "6")]
     pub consensus_type: ::prost::alloc::string::String,
     /// The baking status of the node.
@@ -190,27 +214,33 @@ pub struct NodeInfoResponse {
 }
 /// Nested message and enum types in `NodeInfoResponse`.
 pub mod node_info_response {
-    #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, ::prost::Enumeration)]
+    #[derive(
+        Clone,
+        Copy,
+        Debug,
+        PartialEq,
+        Eq,
+        Hash,
+        PartialOrd,
+        Ord,
+        ::prost::Enumeration
+    )]
     #[repr(i32)]
     pub enum IsInBakingCommittee {
         /// The node is not the baking committee.
-        NotInCommittee    = 0,
-        /// The node has baker keys, but the account is not currently a baker
-        /// (and possibly never will be).
+        NotInCommittee = 0,
+        /// The node has baker keys, but the account is not currently a baker (and possibly never will be).
         AddedButNotActiveInCommittee = 1,
-        /// The node has baker keys, but they don't match the current keys on
-        /// the baker account.
+        /// The node has baker keys, but they don't match the current keys on the baker account.
         AddedButWrongKeys = 2,
         /// The node has valid baker keys and is active in the baker committee.
         ActiveInCommittee = 3,
     }
     impl IsInBakingCommittee {
-        /// String value of the enum field names used in the ProtoBuf
-        /// definition.
+        /// String value of the enum field names used in the ProtoBuf definition.
         ///
-        /// The values are not transformed in any way and thus are considered
-        /// stable (if the ProtoBuf definition does not change) and safe
-        /// for programmatic use.
+        /// The values are not transformed in any way and thus are considered stable
+        /// (if the ProtoBuf definition does not change) and safe for programmatic use.
         pub fn as_str_name(&self) -> &'static str {
             match self {
                 IsInBakingCommittee::NotInCommittee => "NOT_IN_COMMITTEE",
@@ -221,18 +251,31 @@ pub mod node_info_response {
                 IsInBakingCommittee::ActiveInCommittee => "ACTIVE_IN_COMMITTEE",
             }
         }
+        /// Creates an enum from field names used in the ProtoBuf definition.
+        pub fn from_str_name(value: &str) -> ::core::option::Option<Self> {
+            match value {
+                "NOT_IN_COMMITTEE" => Some(Self::NotInCommittee),
+                "ADDED_BUT_NOT_ACTIVE_IN_COMMITTEE" => {
+                    Some(Self::AddedButNotActiveInCommittee)
+                }
+                "ADDED_BUT_WRONG_KEYS" => Some(Self::AddedButWrongKeys),
+                "ACTIVE_IN_COMMITTEE" => Some(Self::ActiveInCommittee),
+                _ => None,
+            }
+        }
     }
 }
 /// Hash of a block (encoded in hex). Is always 64 characters long.
 /// Example: "987d6c06256fbf874d6ba14f19baee4390a31c6ee58edd9cc4efef62e89d22d7"
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct BlockHash {
     #[prost(string, tag = "1")]
     pub block_hash: ::prost::alloc::string::String,
 }
-/// An account address. Uses a base58-check encoding with a version byte set to
-/// 1. Is always 50 characters long.
+/// An account address. Uses a base58-check encoding with a version byte set to 1. Is always 50 characters long.
 /// Example: "3DJoe7aUwMwVmdFdRU2QsnJfsBbCmQu1QHvEg7YtWFZWmsoBXe"
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct AccountAddress {
     #[prost(string, tag = "1")]
@@ -240,12 +283,14 @@ pub struct AccountAddress {
 }
 /// Hash of a transaction (encoded in hex). Is always 64 characters long.
 /// Example: "987d6c06256fbf874d6ba14f19baee4390a31c6ee58edd9cc4efef62e89d22d7"
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct TransactionHash {
     #[prost(string, tag = "1")]
     pub transaction_hash: ::prost::alloc::string::String,
 }
 /// Request for getting the ancestors of a block.
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct BlockHashAndAmount {
     /// The block to get ancestors of.
@@ -253,33 +298,35 @@ pub struct BlockHashAndAmount {
     pub block_hash: ::prost::alloc::string::String,
     /// The maximum amount of ancestors that will be returned.
     #[prost(uint64, tag = "2")]
-    pub amount:     u64,
+    pub amount: u64,
 }
-/// Submit a transaction to the node. The transaction is subject to basic
-/// validation and is then relayed to all the peers.
+/// Submit a transaction to the node. The transaction is subject to basic validation
+/// and is then relayed to all the peers.
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct SendTransactionRequest {
     /// The network id (currently not used in this request).
     #[prost(uint32, tag = "1")]
     pub network_id: u32,
     /// The transaction payload in binary encoding.
-    /// The encoding of certain transaction types, along with the general
-    /// payload structure, is described at: <https://developer.concordium.software/en/mainnet/net/references/grpc.html.>
+    /// The encoding of certain transaction types, along with the general payload structure,
+    /// is described at: <https://developer.concordium.software/en/mainnet/net/references/grpc.html.>
     #[prost(bytes = "vec", tag = "2")]
-    pub payload:    ::prost::alloc::vec::Vec<u8>,
+    pub payload: ::prost::alloc::vec::Vec<u8>,
 }
 /// Request for getting information about an account address.
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct GetAddressInfoRequest {
-    /// Hash of the block (encoded in hex) at which the information should be
-    /// gathered.
+    /// Hash of the block (encoded in hex) at which the information should be gathered.
     #[prost(string, tag = "1")]
     pub block_hash: ::prost::alloc::string::String,
     /// The account address to request information about.
     #[prost(string, tag = "2")]
-    pub address:    ::prost::alloc::string::String,
+    pub address: ::prost::alloc::string::String,
 }
 /// Request for invoking a contract without a transaction.
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct InvokeContractRequest {
     /// Hash of the block (encoded in hex) at which to invoke the contract.
@@ -288,9 +335,10 @@ pub struct InvokeContractRequest {
     /// A JSON object that specifies which contract to invoke, and how.
     /// A JSON schema for the context is provided at: <https://developer.concordium.software/en/mainnet/net/references/grpc.html.>
     #[prost(string, tag = "2")]
-    pub context:    ::prost::alloc::string::String,
+    pub context: ::prost::alloc::string::String,
 }
 /// Request for getting the source of a smart contract module.
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct GetModuleSourceRequest {
     /// The block to be used for the query.
@@ -301,6 +349,7 @@ pub struct GetModuleSourceRequest {
     pub module_ref: ::prost::alloc::string::String,
 }
 /// Request to enable dumping of network packages.
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct DumpRequest {
     /// Which file to dump the packages into.
@@ -308,9 +357,10 @@ pub struct DumpRequest {
     pub file: ::prost::alloc::string::String,
     /// Whether the node should dump raw packages.
     #[prost(bool, tag = "2")]
-    pub raw:  bool,
+    pub raw: bool,
 }
 /// Request for getting (information about) the peers.
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct PeersRequest {
     /// Whether bootstrapper nodes should be included in the result.
@@ -318,6 +368,7 @@ pub struct PeersRequest {
     pub include_bootstrappers: bool,
 }
 /// Request for getting the status of a transaction in a given block.
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct GetTransactionStatusInBlockRequest {
     /// The transaction hash.
@@ -325,31 +376,32 @@ pub struct GetTransactionStatusInBlockRequest {
     pub transaction_hash: ::prost::alloc::string::String,
     /// The block hash.
     #[prost(string, tag = "2")]
-    pub block_hash:       ::prost::alloc::string::String,
+    pub block_hash: ::prost::alloc::string::String,
 }
 /// Request for getting the status of a pool.
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct GetPoolStatusRequest {
     /// The block from which the query should be processed.
     #[prost(string, tag = "1")]
-    pub block_hash:         ::prost::alloc::string::String,
+    pub block_hash: ::prost::alloc::string::String,
     /// Whether the request is for passive delegation or a specific baker.
     #[prost(bool, tag = "2")]
     pub passive_delegation: bool,
-    /// The baker id to get the status of. This will be ignored if
-    /// 'passive_delegation' is 'true'.
+    /// The baker id to get the status of. This will be ignored if 'passive_delegation' is 'true'.
     #[prost(uint64, tag = "3")]
-    pub baker_id:           u64,
+    pub baker_id: u64,
 }
 /// Request for gettings the blocks at a specific height.
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct BlockHeight {
     /// The block height.
     #[prost(uint64, tag = "1")]
-    pub block_height:              u64,
+    pub block_height: u64,
     /// The block height is relative to the genesis block at this index.
     #[prost(uint32, tag = "2")]
-    pub from_genesis_index:        u32,
+    pub from_genesis_index: u32,
     /// If true, only return results from the specified genesis index.
     #[prost(bool, tag = "3")]
     pub restrict_to_genesis_index: bool,
@@ -357,7 +409,8 @@ pub struct BlockHeight {
 /// Generated client implementations.
 pub mod p2p_client {
     #![allow(unused_variables, dead_code, missing_docs, clippy::let_unit_value)]
-    use tonic::codegen::{http::Uri, *};
+    use tonic::codegen::*;
+    use tonic::codegen::http::Uri;
     #[derive(Debug, Clone)]
     pub struct P2pClient<T> {
         inner: tonic::client::Grpc<T>,
@@ -367,7 +420,8 @@ pub mod p2p_client {
         pub async fn connect<D>(dst: D) -> Result<Self, tonic::transport::Error>
         where
             D: std::convert::TryInto<tonic::transport::Endpoint>,
-            D::Error: Into<StdError>, {
+            D::Error: Into<StdError>,
+        {
             let conn = tonic::transport::Endpoint::new(dst)?.connect().await?;
             Ok(Self::new(conn))
         }
@@ -383,12 +437,10 @@ pub mod p2p_client {
             let inner = tonic::client::Grpc::new(inner);
             Self { inner }
         }
-
         pub fn with_origin(inner: T, origin: Uri) -> Self {
             let inner = tonic::client::Grpc::with_origin(inner, origin);
             Self { inner }
         }
-
         pub fn with_interceptor<F>(
             inner: T,
             interceptor: F,
@@ -402,763 +454,916 @@ pub mod p2p_client {
                     <T as tonic::client::GrpcService<tonic::body::BoxBody>>::ResponseBody,
                 >,
             >,
-            <T as tonic::codegen::Service<http::Request<tonic::body::BoxBody>>>::Error:
-                Into<StdError> + Send + Sync, {
+            <T as tonic::codegen::Service<
+                http::Request<tonic::body::BoxBody>,
+            >>::Error: Into<StdError> + Send + Sync,
+        {
             P2pClient::new(InterceptedService::new(inner, interceptor))
         }
-
         /// Compress requests with the given encoding.
         ///
-        /// This requires the server to support it otherwise it might respond
-        /// with an error.
+        /// This requires the server to support it otherwise it might respond with an
+        /// error.
         #[must_use]
         pub fn send_compressed(mut self, encoding: CompressionEncoding) -> Self {
             self.inner = self.inner.send_compressed(encoding);
             self
         }
-
         /// Enable decompressing responses.
         #[must_use]
         pub fn accept_compressed(mut self, encoding: CompressionEncoding) -> Self {
             self.inner = self.inner.accept_compressed(encoding);
             self
         }
-
         /// Suggest to a peer to connect to the submitted peer details.
         /// This, if successful, adds the peer to the list of given addresses.
         pub async fn peer_connect(
             &mut self,
             request: impl tonic::IntoRequest<super::PeerConnectRequest>,
         ) -> Result<tonic::Response<super::BoolResponse>, tonic::Status> {
-            self.inner.ready().await.map_err(|e| {
-                tonic::Status::new(
-                    tonic::Code::Unknown,
-                    format!("Service was not ready: {}", e.into()),
-                )
-            })?;
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::new(
+                        tonic::Code::Unknown,
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
             let codec = tonic::codec::ProstCodec::default();
-            let path = http::uri::PathAndQuery::from_static("/concordium.P2P/PeerConnect");
+            let path = http::uri::PathAndQuery::from_static(
+                "/concordium.P2P/PeerConnect",
+            );
             self.inner.unary(request.into_request(), path, codec).await
         }
-
-        /// Disconnect from the peer and remove them from the given addresses
-        /// list if they are on it. Return if the request was processed
-        /// successfully.
+        /// Disconnect from the peer and remove them from the given addresses list
+        /// if they are on it. Return if the request was processed successfully.
         pub async fn peer_disconnect(
             &mut self,
             request: impl tonic::IntoRequest<super::PeerConnectRequest>,
         ) -> Result<tonic::Response<super::BoolResponse>, tonic::Status> {
-            self.inner.ready().await.map_err(|e| {
-                tonic::Status::new(
-                    tonic::Code::Unknown,
-                    format!("Service was not ready: {}", e.into()),
-                )
-            })?;
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::new(
+                        tonic::Code::Unknown,
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
             let codec = tonic::codec::ProstCodec::default();
-            let path = http::uri::PathAndQuery::from_static("/concordium.P2P/PeerDisconnect");
+            let path = http::uri::PathAndQuery::from_static(
+                "/concordium.P2P/PeerDisconnect",
+            );
             self.inner.unary(request.into_request(), path, codec).await
         }
-
         /// Uptime of the *node* in milliseconds.
         pub async fn peer_uptime(
             &mut self,
             request: impl tonic::IntoRequest<super::Empty>,
         ) -> Result<tonic::Response<super::NumberResponse>, tonic::Status> {
-            self.inner.ready().await.map_err(|e| {
-                tonic::Status::new(
-                    tonic::Code::Unknown,
-                    format!("Service was not ready: {}", e.into()),
-                )
-            })?;
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::new(
+                        tonic::Code::Unknown,
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
             let codec = tonic::codec::ProstCodec::default();
-            let path = http::uri::PathAndQuery::from_static("/concordium.P2P/PeerUptime");
+            let path = http::uri::PathAndQuery::from_static(
+                "/concordium.P2P/PeerUptime",
+            );
             self.inner.unary(request.into_request(), path, codec).await
         }
-
         /// Total number of sent packets by the node.
         pub async fn peer_total_sent(
             &mut self,
             request: impl tonic::IntoRequest<super::Empty>,
         ) -> Result<tonic::Response<super::NumberResponse>, tonic::Status> {
-            self.inner.ready().await.map_err(|e| {
-                tonic::Status::new(
-                    tonic::Code::Unknown,
-                    format!("Service was not ready: {}", e.into()),
-                )
-            })?;
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::new(
+                        tonic::Code::Unknown,
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
             let codec = tonic::codec::ProstCodec::default();
-            let path = http::uri::PathAndQuery::from_static("/concordium.P2P/PeerTotalSent");
+            let path = http::uri::PathAndQuery::from_static(
+                "/concordium.P2P/PeerTotalSent",
+            );
             self.inner.unary(request.into_request(), path, codec).await
         }
-
         /// Total number of received packets by the node.
         pub async fn peer_total_received(
             &mut self,
             request: impl tonic::IntoRequest<super::Empty>,
         ) -> Result<tonic::Response<super::NumberResponse>, tonic::Status> {
-            self.inner.ready().await.map_err(|e| {
-                tonic::Status::new(
-                    tonic::Code::Unknown,
-                    format!("Service was not ready: {}", e.into()),
-                )
-            })?;
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::new(
+                        tonic::Code::Unknown,
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
             let codec = tonic::codec::ProstCodec::default();
-            let path = http::uri::PathAndQuery::from_static("/concordium.P2P/PeerTotalReceived");
+            let path = http::uri::PathAndQuery::from_static(
+                "/concordium.P2P/PeerTotalReceived",
+            );
             self.inner.unary(request.into_request(), path, codec).await
         }
-
         /// Node software version.
         pub async fn peer_version(
             &mut self,
             request: impl tonic::IntoRequest<super::Empty>,
         ) -> Result<tonic::Response<super::StringResponse>, tonic::Status> {
-            self.inner.ready().await.map_err(|e| {
-                tonic::Status::new(
-                    tonic::Code::Unknown,
-                    format!("Service was not ready: {}", e.into()),
-                )
-            })?;
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::new(
+                        tonic::Code::Unknown,
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
             let codec = tonic::codec::ProstCodec::default();
-            let path = http::uri::PathAndQuery::from_static("/concordium.P2P/PeerVersion");
+            let path = http::uri::PathAndQuery::from_static(
+                "/concordium.P2P/PeerVersion",
+            );
             self.inner.unary(request.into_request(), path, codec).await
         }
-
         /// Stats for connected peers.
         pub async fn peer_stats(
             &mut self,
             request: impl tonic::IntoRequest<super::PeersRequest>,
         ) -> Result<tonic::Response<super::PeerStatsResponse>, tonic::Status> {
-            self.inner.ready().await.map_err(|e| {
-                tonic::Status::new(
-                    tonic::Code::Unknown,
-                    format!("Service was not ready: {}", e.into()),
-                )
-            })?;
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::new(
+                        tonic::Code::Unknown,
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
             let codec = tonic::codec::ProstCodec::default();
             let path = http::uri::PathAndQuery::from_static("/concordium.P2P/PeerStats");
             self.inner.unary(request.into_request(), path, codec).await
         }
-
         /// List of connected peers.
         pub async fn peer_list(
             &mut self,
             request: impl tonic::IntoRequest<super::PeersRequest>,
         ) -> Result<tonic::Response<super::PeerListResponse>, tonic::Status> {
-            self.inner.ready().await.map_err(|e| {
-                tonic::Status::new(
-                    tonic::Code::Unknown,
-                    format!("Service was not ready: {}", e.into()),
-                )
-            })?;
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::new(
+                        tonic::Code::Unknown,
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
             let codec = tonic::codec::ProstCodec::default();
             let path = http::uri::PathAndQuery::from_static("/concordium.P2P/PeerList");
             self.inner.unary(request.into_request(), path, codec).await
         }
-
         /// Ban a the given peer.
         pub async fn ban_node(
             &mut self,
             request: impl tonic::IntoRequest<super::PeerElement>,
         ) -> Result<tonic::Response<super::BoolResponse>, tonic::Status> {
-            self.inner.ready().await.map_err(|e| {
-                tonic::Status::new(
-                    tonic::Code::Unknown,
-                    format!("Service was not ready: {}", e.into()),
-                )
-            })?;
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::new(
+                        tonic::Code::Unknown,
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
             let codec = tonic::codec::ProstCodec::default();
             let path = http::uri::PathAndQuery::from_static("/concordium.P2P/BanNode");
             self.inner.unary(request.into_request(), path, codec).await
         }
-
         /// Unban the given peer.
         pub async fn unban_node(
             &mut self,
             request: impl tonic::IntoRequest<super::PeerElement>,
         ) -> Result<tonic::Response<super::BoolResponse>, tonic::Status> {
-            self.inner.ready().await.map_err(|e| {
-                tonic::Status::new(
-                    tonic::Code::Unknown,
-                    format!("Service was not ready: {}", e.into()),
-                )
-            })?;
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::new(
+                        tonic::Code::Unknown,
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
             let codec = tonic::codec::ProstCodec::default();
             let path = http::uri::PathAndQuery::from_static("/concordium.P2P/UnbanNode");
             self.inner.unary(request.into_request(), path, codec).await
         }
-
         /// Join the provided network.
         pub async fn join_network(
             &mut self,
             request: impl tonic::IntoRequest<super::NetworkChangeRequest>,
         ) -> Result<tonic::Response<super::BoolResponse>, tonic::Status> {
-            self.inner.ready().await.map_err(|e| {
-                tonic::Status::new(
-                    tonic::Code::Unknown,
-                    format!("Service was not ready: {}", e.into()),
-                )
-            })?;
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::new(
+                        tonic::Code::Unknown,
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
             let codec = tonic::codec::ProstCodec::default();
-            let path = http::uri::PathAndQuery::from_static("/concordium.P2P/JoinNetwork");
+            let path = http::uri::PathAndQuery::from_static(
+                "/concordium.P2P/JoinNetwork",
+            );
             self.inner.unary(request.into_request(), path, codec).await
         }
-
         /// Leave the provided network.
         pub async fn leave_network(
             &mut self,
             request: impl tonic::IntoRequest<super::NetworkChangeRequest>,
         ) -> Result<tonic::Response<super::BoolResponse>, tonic::Status> {
-            self.inner.ready().await.map_err(|e| {
-                tonic::Status::new(
-                    tonic::Code::Unknown,
-                    format!("Service was not ready: {}", e.into()),
-                )
-            })?;
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::new(
+                        tonic::Code::Unknown,
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
             let codec = tonic::codec::ProstCodec::default();
-            let path = http::uri::PathAndQuery::from_static("/concordium.P2P/LeaveNetwork");
+            let path = http::uri::PathAndQuery::from_static(
+                "/concordium.P2P/LeaveNetwork",
+            );
             self.inner.unary(request.into_request(), path, codec).await
         }
-
         /// Get information about the running node.
         pub async fn node_info(
             &mut self,
             request: impl tonic::IntoRequest<super::Empty>,
         ) -> Result<tonic::Response<super::NodeInfoResponse>, tonic::Status> {
-            self.inner.ready().await.map_err(|e| {
-                tonic::Status::new(
-                    tonic::Code::Unknown,
-                    format!("Service was not ready: {}", e.into()),
-                )
-            })?;
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::new(
+                        tonic::Code::Unknown,
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
             let codec = tonic::codec::ProstCodec::default();
             let path = http::uri::PathAndQuery::from_static("/concordium.P2P/NodeInfo");
             self.inner.unary(request.into_request(), path, codec).await
         }
-
         /// Get information about the consensus.
         /// A JSON schema for the return type is provided at: https://developer.concordium.software/en/mainnet/net/references/grpc.html.
         pub async fn get_consensus_status(
             &mut self,
             request: impl tonic::IntoRequest<super::Empty>,
         ) -> Result<tonic::Response<super::JsonResponse>, tonic::Status> {
-            self.inner.ready().await.map_err(|e| {
-                tonic::Status::new(
-                    tonic::Code::Unknown,
-                    format!("Service was not ready: {}", e.into()),
-                )
-            })?;
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::new(
+                        tonic::Code::Unknown,
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
             let codec = tonic::codec::ProstCodec::default();
-            let path = http::uri::PathAndQuery::from_static("/concordium.P2P/GetConsensusStatus");
+            let path = http::uri::PathAndQuery::from_static(
+                "/concordium.P2P/GetConsensusStatus",
+            );
             self.inner.unary(request.into_request(), path, codec).await
         }
-
         /// Get information about the block.
         /// A JSON schema for the return type is provided at: https://developer.concordium.software/en/mainnet/net/references/grpc.html.
         pub async fn get_block_info(
             &mut self,
             request: impl tonic::IntoRequest<super::BlockHash>,
         ) -> Result<tonic::Response<super::JsonResponse>, tonic::Status> {
-            self.inner.ready().await.map_err(|e| {
-                tonic::Status::new(
-                    tonic::Code::Unknown,
-                    format!("Service was not ready: {}", e.into()),
-                )
-            })?;
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::new(
+                        tonic::Code::Unknown,
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
             let codec = tonic::codec::ProstCodec::default();
-            let path = http::uri::PathAndQuery::from_static("/concordium.P2P/GetBlockInfo");
+            let path = http::uri::PathAndQuery::from_static(
+                "/concordium.P2P/GetBlockInfo",
+            );
             self.inner.unary(request.into_request(), path, codec).await
         }
-
         /// Get ancestors for the provided block.
         /// A JSON schema for the return type is provided at: https://developer.concordium.software/en/mainnet/net/references/grpc.html.
         pub async fn get_ancestors(
             &mut self,
             request: impl tonic::IntoRequest<super::BlockHashAndAmount>,
         ) -> Result<tonic::Response<super::JsonResponse>, tonic::Status> {
-            self.inner.ready().await.map_err(|e| {
-                tonic::Status::new(
-                    tonic::Code::Unknown,
-                    format!("Service was not ready: {}", e.into()),
-                )
-            })?;
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::new(
+                        tonic::Code::Unknown,
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
             let codec = tonic::codec::ProstCodec::default();
-            let path = http::uri::PathAndQuery::from_static("/concordium.P2P/GetAncestors");
+            let path = http::uri::PathAndQuery::from_static(
+                "/concordium.P2P/GetAncestors",
+            );
             self.inner.unary(request.into_request(), path, codec).await
         }
-
         /// Get the current branches.
         /// A JSON schema for the return type is provided at: https://developer.concordium.software/en/mainnet/net/references/grpc.html.
         pub async fn get_branches(
             &mut self,
             request: impl tonic::IntoRequest<super::Empty>,
         ) -> Result<tonic::Response<super::JsonResponse>, tonic::Status> {
-            self.inner.ready().await.map_err(|e| {
-                tonic::Status::new(
-                    tonic::Code::Unknown,
-                    format!("Service was not ready: {}", e.into()),
-                )
-            })?;
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::new(
+                        tonic::Code::Unknown,
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
             let codec = tonic::codec::ProstCodec::default();
-            let path = http::uri::PathAndQuery::from_static("/concordium.P2P/GetBranches");
+            let path = http::uri::PathAndQuery::from_static(
+                "/concordium.P2P/GetBranches",
+            );
             self.inner.unary(request.into_request(), path, codec).await
         }
-
         /// Get the blocks at the given height.
         /// A JSON schema for the return type is provided at: https://developer.concordium.software/en/mainnet/net/references/grpc.html.
         pub async fn get_blocks_at_height(
             &mut self,
             request: impl tonic::IntoRequest<super::BlockHeight>,
         ) -> Result<tonic::Response<super::JsonResponse>, tonic::Status> {
-            self.inner.ready().await.map_err(|e| {
-                tonic::Status::new(
-                    tonic::Code::Unknown,
-                    format!("Service was not ready: {}", e.into()),
-                )
-            })?;
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::new(
+                        tonic::Code::Unknown,
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
             let codec = tonic::codec::ProstCodec::default();
-            let path = http::uri::PathAndQuery::from_static("/concordium.P2P/GetBlocksAtHeight");
+            let path = http::uri::PathAndQuery::from_static(
+                "/concordium.P2P/GetBlocksAtHeight",
+            );
             self.inner.unary(request.into_request(), path, codec).await
         }
-
         /// Submit a transaction.
         pub async fn send_transaction(
             &mut self,
             request: impl tonic::IntoRequest<super::SendTransactionRequest>,
         ) -> Result<tonic::Response<super::BoolResponse>, tonic::Status> {
-            self.inner.ready().await.map_err(|e| {
-                tonic::Status::new(
-                    tonic::Code::Unknown,
-                    format!("Service was not ready: {}", e.into()),
-                )
-            })?;
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::new(
+                        tonic::Code::Unknown,
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
             let codec = tonic::codec::ProstCodec::default();
-            let path = http::uri::PathAndQuery::from_static("/concordium.P2P/SendTransaction");
+            let path = http::uri::PathAndQuery::from_static(
+                "/concordium.P2P/SendTransaction",
+            );
             self.inner.unary(request.into_request(), path, codec).await
         }
-
         /// Start the baker in the consensus module.
         pub async fn start_baker(
             &mut self,
             request: impl tonic::IntoRequest<super::Empty>,
         ) -> Result<tonic::Response<super::BoolResponse>, tonic::Status> {
-            self.inner.ready().await.map_err(|e| {
-                tonic::Status::new(
-                    tonic::Code::Unknown,
-                    format!("Service was not ready: {}", e.into()),
-                )
-            })?;
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::new(
+                        tonic::Code::Unknown,
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
             let codec = tonic::codec::ProstCodec::default();
-            let path = http::uri::PathAndQuery::from_static("/concordium.P2P/StartBaker");
+            let path = http::uri::PathAndQuery::from_static(
+                "/concordium.P2P/StartBaker",
+            );
             self.inner.unary(request.into_request(), path, codec).await
         }
-
         /// Stop the baker in the consensus module.
         pub async fn stop_baker(
             &mut self,
             request: impl tonic::IntoRequest<super::Empty>,
         ) -> Result<tonic::Response<super::BoolResponse>, tonic::Status> {
-            self.inner.ready().await.map_err(|e| {
-                tonic::Status::new(
-                    tonic::Code::Unknown,
-                    format!("Service was not ready: {}", e.into()),
-                )
-            })?;
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::new(
+                        tonic::Code::Unknown,
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
             let codec = tonic::codec::ProstCodec::default();
             let path = http::uri::PathAndQuery::from_static("/concordium.P2P/StopBaker");
             self.inner.unary(request.into_request(), path, codec).await
         }
-
-        /// Get a list of accounts that exist in the state after the given
-        /// block. A JSON schema for the return type is provided at: https://developer.concordium.software/en/mainnet/net/references/grpc.html.
+        /// Get a list of accounts that exist in the state after the given block.
+        /// A JSON schema for the return type is provided at: https://developer.concordium.software/en/mainnet/net/references/grpc.html.
         pub async fn get_account_list(
             &mut self,
             request: impl tonic::IntoRequest<super::BlockHash>,
         ) -> Result<tonic::Response<super::JsonResponse>, tonic::Status> {
-            self.inner.ready().await.map_err(|e| {
-                tonic::Status::new(
-                    tonic::Code::Unknown,
-                    format!("Service was not ready: {}", e.into()),
-                )
-            })?;
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::new(
+                        tonic::Code::Unknown,
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
             let codec = tonic::codec::ProstCodec::default();
-            let path = http::uri::PathAndQuery::from_static("/concordium.P2P/GetAccountList");
+            let path = http::uri::PathAndQuery::from_static(
+                "/concordium.P2P/GetAccountList",
+            );
             self.inner.unary(request.into_request(), path, codec).await
         }
-
-        /// Get all smart contract instances that exist in the state after the
-        /// given block. A JSON schema for the return type is provided at: https://developer.concordium.software/en/mainnet/net/references/grpc.html.
+        /// Get all smart contract instances that exist in the state after the given block.
+        /// A JSON schema for the return type is provided at: https://developer.concordium.software/en/mainnet/net/references/grpc.html.
         pub async fn get_instances(
             &mut self,
             request: impl tonic::IntoRequest<super::BlockHash>,
         ) -> Result<tonic::Response<super::JsonResponse>, tonic::Status> {
-            self.inner.ready().await.map_err(|e| {
-                tonic::Status::new(
-                    tonic::Code::Unknown,
-                    format!("Service was not ready: {}", e.into()),
-                )
-            })?;
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::new(
+                        tonic::Code::Unknown,
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
             let codec = tonic::codec::ProstCodec::default();
-            let path = http::uri::PathAndQuery::from_static("/concordium.P2P/GetInstances");
+            let path = http::uri::PathAndQuery::from_static(
+                "/concordium.P2P/GetInstances",
+            );
             self.inner.unary(request.into_request(), path, codec).await
         }
-
         /// Get information about an account.
         /// A JSON schema for the return type is provided at: https://developer.concordium.software/en/mainnet/net/references/grpc.html.
         pub async fn get_account_info(
             &mut self,
             request: impl tonic::IntoRequest<super::GetAddressInfoRequest>,
         ) -> Result<tonic::Response<super::JsonResponse>, tonic::Status> {
-            self.inner.ready().await.map_err(|e| {
-                tonic::Status::new(
-                    tonic::Code::Unknown,
-                    format!("Service was not ready: {}", e.into()),
-                )
-            })?;
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::new(
+                        tonic::Code::Unknown,
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
             let codec = tonic::codec::ProstCodec::default();
-            let path = http::uri::PathAndQuery::from_static("/concordium.P2P/GetAccountInfo");
+            let path = http::uri::PathAndQuery::from_static(
+                "/concordium.P2P/GetAccountInfo",
+            );
             self.inner.unary(request.into_request(), path, codec).await
         }
-
         /// Get information about a smart contract instance.
         /// A JSON schema for the return type is provided at: https://developer.concordium.software/en/mainnet/net/references/grpc.html.
         pub async fn get_instance_info(
             &mut self,
             request: impl tonic::IntoRequest<super::GetAddressInfoRequest>,
         ) -> Result<tonic::Response<super::JsonResponse>, tonic::Status> {
-            self.inner.ready().await.map_err(|e| {
-                tonic::Status::new(
-                    tonic::Code::Unknown,
-                    format!("Service was not ready: {}", e.into()),
-                )
-            })?;
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::new(
+                        tonic::Code::Unknown,
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
             let codec = tonic::codec::ProstCodec::default();
-            let path = http::uri::PathAndQuery::from_static("/concordium.P2P/GetInstanceInfo");
+            let path = http::uri::PathAndQuery::from_static(
+                "/concordium.P2P/GetInstanceInfo",
+            );
             self.inner.unary(request.into_request(), path, codec).await
         }
-
-        /// Invoke a smart contract instance and view the result *as if* it had
-        /// been updated at the end of the provided block. This is *not*
-        /// a transaction. A JSON schema for the return type is provided at: https://developer.concordium.software/en/mainnet/net/references/grpc.html.
+        /// Invoke a smart contract instance and view the result *as if* it had been updated at the end of the provided block.
+        /// This is *not* a transaction.
+        /// A JSON schema for the return type is provided at: https://developer.concordium.software/en/mainnet/net/references/grpc.html.
         pub async fn invoke_contract(
             &mut self,
             request: impl tonic::IntoRequest<super::InvokeContractRequest>,
         ) -> Result<tonic::Response<super::JsonResponse>, tonic::Status> {
-            self.inner.ready().await.map_err(|e| {
-                tonic::Status::new(
-                    tonic::Code::Unknown,
-                    format!("Service was not ready: {}", e.into()),
-                )
-            })?;
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::new(
+                        tonic::Code::Unknown,
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
             let codec = tonic::codec::ProstCodec::default();
-            let path = http::uri::PathAndQuery::from_static("/concordium.P2P/InvokeContract");
+            let path = http::uri::PathAndQuery::from_static(
+                "/concordium.P2P/InvokeContract",
+            );
             self.inner.unary(request.into_request(), path, codec).await
         }
-
-        /// Get an overview of the balance of special accounts in the given
-        /// block. A JSON schema for the return type is provided at: https://developer.concordium.software/en/mainnet/net/references/grpc.html.
+        /// Get an overview of the balance of special accounts in the given block.
+        /// A JSON schema for the return type is provided at: https://developer.concordium.software/en/mainnet/net/references/grpc.html.
         pub async fn get_reward_status(
             &mut self,
             request: impl tonic::IntoRequest<super::BlockHash>,
         ) -> Result<tonic::Response<super::JsonResponse>, tonic::Status> {
-            self.inner.ready().await.map_err(|e| {
-                tonic::Status::new(
-                    tonic::Code::Unknown,
-                    format!("Service was not ready: {}", e.into()),
-                )
-            })?;
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::new(
+                        tonic::Code::Unknown,
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
             let codec = tonic::codec::ProstCodec::default();
-            let path = http::uri::PathAndQuery::from_static("/concordium.P2P/GetRewardStatus");
+            let path = http::uri::PathAndQuery::from_static(
+                "/concordium.P2P/GetRewardStatus",
+            );
             self.inner.unary(request.into_request(), path, codec).await
         }
-
         /// Get an overview of the parameters used for baking.
         /// A JSON schema for the return type is provided at: https://developer.concordium.software/en/mainnet/net/references/grpc.html.
         pub async fn get_birk_parameters(
             &mut self,
             request: impl tonic::IntoRequest<super::BlockHash>,
         ) -> Result<tonic::Response<super::JsonResponse>, tonic::Status> {
-            self.inner.ready().await.map_err(|e| {
-                tonic::Status::new(
-                    tonic::Code::Unknown,
-                    format!("Service was not ready: {}", e.into()),
-                )
-            })?;
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::new(
+                        tonic::Code::Unknown,
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
             let codec = tonic::codec::ProstCodec::default();
-            let path = http::uri::PathAndQuery::from_static("/concordium.P2P/GetBirkParameters");
+            let path = http::uri::PathAndQuery::from_static(
+                "/concordium.P2P/GetBirkParameters",
+            );
             self.inner.unary(request.into_request(), path, codec).await
         }
-
-        /// Get a list of smart contract modules that exist in the state after
-        /// the given block. A JSON schema for the return type is provided at: https://developer.concordium.software/en/mainnet/net/references/grpc.html.
+        /// Get a list of smart contract modules that exist in the state after the given block.
+        /// A JSON schema for the return type is provided at: https://developer.concordium.software/en/mainnet/net/references/grpc.html.
         pub async fn get_module_list(
             &mut self,
             request: impl tonic::IntoRequest<super::BlockHash>,
         ) -> Result<tonic::Response<super::JsonResponse>, tonic::Status> {
-            self.inner.ready().await.map_err(|e| {
-                tonic::Status::new(
-                    tonic::Code::Unknown,
-                    format!("Service was not ready: {}", e.into()),
-                )
-            })?;
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::new(
+                        tonic::Code::Unknown,
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
             let codec = tonic::codec::ProstCodec::default();
-            let path = http::uri::PathAndQuery::from_static("/concordium.P2P/GetModuleList");
+            let path = http::uri::PathAndQuery::from_static(
+                "/concordium.P2P/GetModuleList",
+            );
             self.inner.unary(request.into_request(), path, codec).await
         }
-
         /// Get the source of a smart contract module.
         pub async fn get_module_source(
             &mut self,
             request: impl tonic::IntoRequest<super::GetModuleSourceRequest>,
         ) -> Result<tonic::Response<super::BytesResponse>, tonic::Status> {
-            self.inner.ready().await.map_err(|e| {
-                tonic::Status::new(
-                    tonic::Code::Unknown,
-                    format!("Service was not ready: {}", e.into()),
-                )
-            })?;
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::new(
+                        tonic::Code::Unknown,
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
             let codec = tonic::codec::ProstCodec::default();
-            let path = http::uri::PathAndQuery::from_static("/concordium.P2P/GetModuleSource");
+            let path = http::uri::PathAndQuery::from_static(
+                "/concordium.P2P/GetModuleSource",
+            );
             self.inner.unary(request.into_request(), path, codec).await
         }
-
-        /// Get a list of all identity providers that exist in the state after
-        /// the given block. A JSON schema for the return type is provided at: https://developer.concordium.software/en/mainnet/net/references/grpc.html.
+        /// Get a list of all identity providers that exist in the state after the given block.
+        /// A JSON schema for the return type is provided at: https://developer.concordium.software/en/mainnet/net/references/grpc.html.
         pub async fn get_identity_providers(
             &mut self,
             request: impl tonic::IntoRequest<super::BlockHash>,
         ) -> Result<tonic::Response<super::JsonResponse>, tonic::Status> {
-            self.inner.ready().await.map_err(|e| {
-                tonic::Status::new(
-                    tonic::Code::Unknown,
-                    format!("Service was not ready: {}", e.into()),
-                )
-            })?;
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::new(
+                        tonic::Code::Unknown,
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
             let codec = tonic::codec::ProstCodec::default();
-            let path = http::uri::PathAndQuery::from_static("/concordium.P2P/GetIdentityProviders");
+            let path = http::uri::PathAndQuery::from_static(
+                "/concordium.P2P/GetIdentityProviders",
+            );
             self.inner.unary(request.into_request(), path, codec).await
         }
-
-        /// Get a list of all anonymity revokers that exist in the state after
-        /// the given block. A JSON schema for the return type is provided at: https://developer.concordium.software/en/mainnet/net/references/grpc.html.
+        /// Get a list of all anonymity revokers that exist in the state after the given block.
+        /// A JSON schema for the return type is provided at: https://developer.concordium.software/en/mainnet/net/references/grpc.html.
         pub async fn get_anonymity_revokers(
             &mut self,
             request: impl tonic::IntoRequest<super::BlockHash>,
         ) -> Result<tonic::Response<super::JsonResponse>, tonic::Status> {
-            self.inner.ready().await.map_err(|e| {
-                tonic::Status::new(
-                    tonic::Code::Unknown,
-                    format!("Service was not ready: {}", e.into()),
-                )
-            })?;
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::new(
+                        tonic::Code::Unknown,
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
             let codec = tonic::codec::ProstCodec::default();
-            let path = http::uri::PathAndQuery::from_static("/concordium.P2P/GetAnonymityRevokers");
+            let path = http::uri::PathAndQuery::from_static(
+                "/concordium.P2P/GetAnonymityRevokers",
+            );
             self.inner.unary(request.into_request(), path, codec).await
         }
-
         /// Get the cryptographic parameters used in the given block.
         /// A JSON schema for the return type is provided at: https://developer.concordium.software/en/mainnet/net/references/grpc.html.
         pub async fn get_cryptographic_parameters(
             &mut self,
             request: impl tonic::IntoRequest<super::BlockHash>,
         ) -> Result<tonic::Response<super::JsonResponse>, tonic::Status> {
-            self.inner.ready().await.map_err(|e| {
-                tonic::Status::new(
-                    tonic::Code::Unknown,
-                    format!("Service was not ready: {}", e.into()),
-                )
-            })?;
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::new(
+                        tonic::Code::Unknown,
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
             let codec = tonic::codec::ProstCodec::default();
-            let path =
-                http::uri::PathAndQuery::from_static("/concordium.P2P/GetCryptographicParameters");
+            let path = http::uri::PathAndQuery::from_static(
+                "/concordium.P2P/GetCryptographicParameters",
+            );
             self.inner.unary(request.into_request(), path, codec).await
         }
-
-        /// Get a list of all baker IDs registered at that block in ascending
-        /// order. Or null, if the block is invalid. A JSON schema for the return type is provided at: https://developer.concordium.software/en/mainnet/net/references/grpc.html.
+        /// Get a list of all baker IDs registered at that block in ascending order. Or null, if the block is invalid.
+        /// A JSON schema for the return type is provided at: https://developer.concordium.software/en/mainnet/net/references/grpc.html.
         pub async fn get_baker_list(
             &mut self,
             request: impl tonic::IntoRequest<super::BlockHash>,
         ) -> Result<tonic::Response<super::JsonResponse>, tonic::Status> {
-            self.inner.ready().await.map_err(|e| {
-                tonic::Status::new(
-                    tonic::Code::Unknown,
-                    format!("Service was not ready: {}", e.into()),
-                )
-            })?;
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::new(
+                        tonic::Code::Unknown,
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
             let codec = tonic::codec::ProstCodec::default();
-            let path = http::uri::PathAndQuery::from_static("/concordium.P2P/GetBakerList");
+            let path = http::uri::PathAndQuery::from_static(
+                "/concordium.P2P/GetBakerList",
+            );
             self.inner.unary(request.into_request(), path, codec).await
         }
-
-        /// Get the status of a pool. If passiveDelegation == true, this returns
-        /// the status for the passive delegators. Otherwise, it returns
-        /// the status for the baker with the specified ID (if it exists). A JSON schema for the return type is provided at: https://developer.concordium.software/en/mainnet/net/references/grpc.html.
+        /// Get the status of a pool. If passiveDelegation == true, this returns the status for the passive delegators.
+        /// Otherwise, it returns the status for the baker with the specified ID (if it exists).
+        /// A JSON schema for the return type is provided at: https://developer.concordium.software/en/mainnet/net/references/grpc.html.
         pub async fn get_pool_status(
             &mut self,
             request: impl tonic::IntoRequest<super::GetPoolStatusRequest>,
         ) -> Result<tonic::Response<super::JsonResponse>, tonic::Status> {
-            self.inner.ready().await.map_err(|e| {
-                tonic::Status::new(
-                    tonic::Code::Unknown,
-                    format!("Service was not ready: {}", e.into()),
-                )
-            })?;
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::new(
+                        tonic::Code::Unknown,
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
             let codec = tonic::codec::ProstCodec::default();
-            let path = http::uri::PathAndQuery::from_static("/concordium.P2P/GetPoolStatus");
+            let path = http::uri::PathAndQuery::from_static(
+                "/concordium.P2P/GetPoolStatus",
+            );
             self.inner.unary(request.into_request(), path, codec).await
         }
-
         /// Get a list of banned peers.
         pub async fn get_banned_peers(
             &mut self,
             request: impl tonic::IntoRequest<super::Empty>,
         ) -> Result<tonic::Response<super::PeerListResponse>, tonic::Status> {
-            self.inner.ready().await.map_err(|e| {
-                tonic::Status::new(
-                    tonic::Code::Unknown,
-                    format!("Service was not ready: {}", e.into()),
-                )
-            })?;
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::new(
+                        tonic::Code::Unknown,
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
             let codec = tonic::codec::ProstCodec::default();
-            let path = http::uri::PathAndQuery::from_static("/concordium.P2P/GetBannedPeers");
+            let path = http::uri::PathAndQuery::from_static(
+                "/concordium.P2P/GetBannedPeers",
+            );
             self.inner.unary(request.into_request(), path, codec).await
         }
-
         /// Shut down the node.
         pub async fn shutdown(
             &mut self,
             request: impl tonic::IntoRequest<super::Empty>,
         ) -> Result<tonic::Response<super::BoolResponse>, tonic::Status> {
-            self.inner.ready().await.map_err(|e| {
-                tonic::Status::new(
-                    tonic::Code::Unknown,
-                    format!("Service was not ready: {}", e.into()),
-                )
-            })?;
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::new(
+                        tonic::Code::Unknown,
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
             let codec = tonic::codec::ProstCodec::default();
             let path = http::uri::PathAndQuery::from_static("/concordium.P2P/Shutdown");
             self.inner.unary(request.into_request(), path, codec).await
         }
-
         /// Start dumping packages into the specified file.
         /// Only enabled if the node was built with the `network_dump` feature.
         pub async fn dump_start(
             &mut self,
             request: impl tonic::IntoRequest<super::DumpRequest>,
         ) -> Result<tonic::Response<super::BoolResponse>, tonic::Status> {
-            self.inner.ready().await.map_err(|e| {
-                tonic::Status::new(
-                    tonic::Code::Unknown,
-                    format!("Service was not ready: {}", e.into()),
-                )
-            })?;
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::new(
+                        tonic::Code::Unknown,
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
             let codec = tonic::codec::ProstCodec::default();
             let path = http::uri::PathAndQuery::from_static("/concordium.P2P/DumpStart");
             self.inner.unary(request.into_request(), path, codec).await
         }
-
         /// Stop dumping packages.
         /// Only enabled if the node was built with the `network_dump` feature.
         pub async fn dump_stop(
             &mut self,
             request: impl tonic::IntoRequest<super::Empty>,
         ) -> Result<tonic::Response<super::BoolResponse>, tonic::Status> {
-            self.inner.ready().await.map_err(|e| {
-                tonic::Status::new(
-                    tonic::Code::Unknown,
-                    format!("Service was not ready: {}", e.into()),
-                )
-            })?;
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::new(
+                        tonic::Code::Unknown,
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
             let codec = tonic::codec::ProstCodec::default();
             let path = http::uri::PathAndQuery::from_static("/concordium.P2P/DumpStop");
             self.inner.unary(request.into_request(), path, codec).await
         }
-
         /// Query for the status of a transaction by its hash.
         /// A JSON schema for the return type is provided at: https://developer.concordium.software/en/mainnet/net/references/grpc.html.
         pub async fn get_transaction_status(
             &mut self,
             request: impl tonic::IntoRequest<super::TransactionHash>,
         ) -> Result<tonic::Response<super::JsonResponse>, tonic::Status> {
-            self.inner.ready().await.map_err(|e| {
-                tonic::Status::new(
-                    tonic::Code::Unknown,
-                    format!("Service was not ready: {}", e.into()),
-                )
-            })?;
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::new(
+                        tonic::Code::Unknown,
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
             let codec = tonic::codec::ProstCodec::default();
-            let path = http::uri::PathAndQuery::from_static("/concordium.P2P/GetTransactionStatus");
+            let path = http::uri::PathAndQuery::from_static(
+                "/concordium.P2P/GetTransactionStatus",
+            );
             self.inner.unary(request.into_request(), path, codec).await
         }
-
         /// Query for transactions in a block by its hash.
         /// A JSON schema for the return type is provided at: https://developer.concordium.software/en/mainnet/net/references/grpc.html.
         pub async fn get_transaction_status_in_block(
             &mut self,
             request: impl tonic::IntoRequest<super::GetTransactionStatusInBlockRequest>,
         ) -> Result<tonic::Response<super::JsonResponse>, tonic::Status> {
-            self.inner.ready().await.map_err(|e| {
-                tonic::Status::new(
-                    tonic::Code::Unknown,
-                    format!("Service was not ready: {}", e.into()),
-                )
-            })?;
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::new(
+                        tonic::Code::Unknown,
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
             let codec = tonic::codec::ProstCodec::default();
-            let path =
-                http::uri::PathAndQuery::from_static("/concordium.P2P/GetTransactionStatusInBlock");
+            let path = http::uri::PathAndQuery::from_static(
+                "/concordium.P2P/GetTransactionStatusInBlock",
+            );
             self.inner.unary(request.into_request(), path, codec).await
         }
-
-        /// Query for non-finalized transactions present on an account by the
-        /// account address. A JSON schema for the return type is provided at: https://developer.concordium.software/en/mainnet/net/references/grpc.html.
+        /// Query for non-finalized transactions present on an account by the account address.
+        /// A JSON schema for the return type is provided at: https://developer.concordium.software/en/mainnet/net/references/grpc.html.
         pub async fn get_account_non_finalized_transactions(
             &mut self,
             request: impl tonic::IntoRequest<super::AccountAddress>,
         ) -> Result<tonic::Response<super::JsonResponse>, tonic::Status> {
-            self.inner.ready().await.map_err(|e| {
-                tonic::Status::new(
-                    tonic::Code::Unknown,
-                    format!("Service was not ready: {}", e.into()),
-                )
-            })?;
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::new(
+                        tonic::Code::Unknown,
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
             let codec = tonic::codec::ProstCodec::default();
             let path = http::uri::PathAndQuery::from_static(
                 "/concordium.P2P/GetAccountNonFinalizedTransactions",
             );
             self.inner.unary(request.into_request(), path, codec).await
         }
-
         /// Request a summary for a block by its hash.
         /// A JSON schema for the return type is provided at: https://developer.concordium.software/en/mainnet/net/references/grpc.html.
         pub async fn get_block_summary(
             &mut self,
             request: impl tonic::IntoRequest<super::BlockHash>,
         ) -> Result<tonic::Response<super::JsonResponse>, tonic::Status> {
-            self.inner.ready().await.map_err(|e| {
-                tonic::Status::new(
-                    tonic::Code::Unknown,
-                    format!("Service was not ready: {}", e.into()),
-                )
-            })?;
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::new(
+                        tonic::Code::Unknown,
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
             let codec = tonic::codec::ProstCodec::default();
-            let path = http::uri::PathAndQuery::from_static("/concordium.P2P/GetBlockSummary");
+            let path = http::uri::PathAndQuery::from_static(
+                "/concordium.P2P/GetBlockSummary",
+            );
             self.inner.unary(request.into_request(), path, codec).await
         }
-
         /// Request next nonce information for an account.
         /// A JSON schema for the return type is provided at: https://developer.concordium.software/en/mainnet/net/references/grpc.html.
         pub async fn get_next_account_nonce(
             &mut self,
             request: impl tonic::IntoRequest<super::AccountAddress>,
         ) -> Result<tonic::Response<super::JsonResponse>, tonic::Status> {
-            self.inner.ready().await.map_err(|e| {
-                tonic::Status::new(
-                    tonic::Code::Unknown,
-                    format!("Service was not ready: {}", e.into()),
-                )
-            })?;
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::new(
+                        tonic::Code::Unknown,
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
             let codec = tonic::codec::ProstCodec::default();
-            let path = http::uri::PathAndQuery::from_static("/concordium.P2P/GetNextAccountNonce");
+            let path = http::uri::PathAndQuery::from_static(
+                "/concordium.P2P/GetNextAccountNonce",
+            );
             self.inner.unary(request.into_request(), path, codec).await
         }
     }

--- a/src/v1/generated/concordium.rs
+++ b/src/v1/generated/concordium.rs
@@ -45,7 +45,7 @@ pub struct BytesResponse {
 pub struct PeerConnectRequest {
     /// The IP of the peer.
     #[prost(message, optional, tag = "1")]
-    pub ip: ::core::option::Option<::prost::alloc::string::String>,
+    pub ip:   ::core::option::Option<::prost::alloc::string::String>,
     /// The port of the peer.
     #[prost(message, optional, tag = "2")]
     pub port: ::core::option::Option<i32>,
@@ -56,52 +56,47 @@ pub struct PeerConnectRequest {
 pub struct PeerElement {
     /// The id of the node.
     #[prost(message, optional, tag = "1")]
-    pub node_id: ::core::option::Option<::prost::alloc::string::String>,
+    pub node_id:        ::core::option::Option<::prost::alloc::string::String>,
     /// The port of the node.
     #[prost(message, optional, tag = "2")]
-    pub port: ::core::option::Option<u32>,
+    pub port:           ::core::option::Option<u32>,
     /// The IP of the node.
     #[prost(message, optional, tag = "3")]
-    pub ip: ::core::option::Option<::prost::alloc::string::String>,
+    pub ip:             ::core::option::Option<::prost::alloc::string::String>,
     /// The current status of the peer.
     #[prost(enumeration = "peer_element::CatchupStatus", tag = "4")]
     pub catchup_status: i32,
 }
 /// Nested message and enum types in `PeerElement`.
 pub mod peer_element {
-    #[derive(
-        Clone,
-        Copy,
-        Debug,
-        PartialEq,
-        Eq,
-        Hash,
-        PartialOrd,
-        Ord,
-        ::prost::Enumeration
-    )]
+    #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, ::prost::Enumeration)]
     #[repr(i32)]
     pub enum CatchupStatus {
-        /// The peer does not have any data unknown to us. If we receive a message from the
-        /// peer that refers to unknown data (e.g., an unknown block) the peer is marked as pending.
-        Uptodate = 0,
-        /// The peer might have some data unknown to us. A peer can be in this state either because
-        /// it sent a message that refers to data unknown to us, or before we have established a baseline with it.
-        /// The latter happens during node startup, as well as upon protocol updates until the initial catchup handshake
-        /// completes.
-        Pending = 1,
-        /// The node is currently catching up by requesting blocks from this peer.
-        /// There will be at most one peer with this status at a time.
-        /// Once the peer has responded to the request, its status will be changed to:
+        /// The peer does not have any data unknown to us. If we receive a
+        /// message from the peer that refers to unknown data (e.g., an
+        /// unknown block) the peer is marked as pending.
+        Uptodate   = 0,
+        /// The peer might have some data unknown to us. A peer can be in this
+        /// state either because it sent a message that refers to data
+        /// unknown to us, or before we have established a baseline with it.
+        /// The latter happens during node startup, as well as upon protocol
+        /// updates until the initial catchup handshake completes.
+        Pending    = 1,
+        /// The node is currently catching up by requesting blocks from this
+        /// peer. There will be at most one peer with this status at a
+        /// time. Once the peer has responded to the request, its status
+        /// will be changed to:
         /// - 'UPTODATE' if the peer has no more data that is not known to us
         /// - 'PENDING' if the node has more data that is unknown to us.
         Catchingup = 2,
     }
     impl CatchupStatus {
-        /// String value of the enum field names used in the ProtoBuf definition.
+        /// String value of the enum field names used in the ProtoBuf
+        /// definition.
         ///
-        /// The values are not transformed in any way and thus are considered stable
-        /// (if the ProtoBuf definition does not change) and safe for programmatic use.
+        /// The values are not transformed in any way and thus are considered
+        /// stable (if the ProtoBuf definition does not change) and safe
+        /// for programmatic use.
         pub fn as_str_name(&self) -> &'static str {
             match self {
                 CatchupStatus::Uptodate => "UPTODATE",
@@ -109,6 +104,7 @@ pub mod peer_element {
                 CatchupStatus::Catchingup => "CATCHINGUP",
             }
         }
+
         /// Creates an enum from field names used in the ProtoBuf definition.
         pub fn from_str_name(value: &str) -> ::core::option::Option<Self> {
             match value {
@@ -130,7 +126,7 @@ pub struct PeerListResponse {
     pub peer_type: ::prost::alloc::string::String,
     /// A list of peers.
     #[prost(message, repeated, tag = "2")]
-    pub peers: ::prost::alloc::vec::Vec<PeerElement>,
+    pub peers:     ::prost::alloc::vec::Vec<PeerElement>,
 }
 /// A response containing information about a peer.
 #[allow(clippy::derive_partial_eq_without_eq)]
@@ -138,10 +134,10 @@ pub struct PeerListResponse {
 pub struct PeerStatsResponse {
     /// A list of stats for the peers.
     #[prost(message, repeated, tag = "1")]
-    pub peerstats: ::prost::alloc::vec::Vec<peer_stats_response::PeerStats>,
+    pub peerstats:   ::prost::alloc::vec::Vec<peer_stats_response::PeerStats>,
     /// Average outbound throughput in bytes per second.
     #[prost(uint64, tag = "2")]
-    pub avg_bps_in: u64,
+    pub avg_bps_in:  u64,
     /// Average inbound throughput in bytes per second.
     #[prost(uint64, tag = "3")]
     pub avg_bps_out: u64,
@@ -153,16 +149,16 @@ pub mod peer_stats_response {
     pub struct PeerStats {
         /// The node id.
         #[prost(string, tag = "1")]
-        pub node_id: ::prost::alloc::string::String,
+        pub node_id:          ::prost::alloc::string::String,
         /// The number of messages sent to the peer.
         #[prost(uint64, tag = "2")]
-        pub packets_sent: u64,
+        pub packets_sent:     u64,
         /// The number of messages received from the peer.
         #[prost(uint64, tag = "3")]
         pub packets_received: u64,
         /// The connection latency (i.e., ping time) in milliseconds.
         #[prost(uint64, tag = "4")]
-        pub latency: u64,
+        pub latency:          u64,
     }
 }
 /// A request to change the network.
@@ -190,12 +186,15 @@ pub struct NodeInfoResponse {
     #[prost(bool, tag = "4")]
     pub consensus_baker_running: bool,
     /// Whether consensus is running.
-    /// This is only false if the protocol was updated to a version which the node software does not support.
+    /// This is only false if the protocol was updated to a version which the
+    /// node software does not support.
     #[prost(bool, tag = "5")]
     pub consensus_running: bool,
     /// Whether the node is "Active" or "Passive".
-    /// - "Active": the node has baker credentials and can thus potentially participate in baking and finalization.
-    /// - "Passive": the node has no baker credentials is thus only an observer of the consensus protocol.
+    /// - "Active": the node has baker credentials and can thus potentially
+    ///   participate in baking and finalization.
+    /// - "Passive": the node has no baker credentials is thus only an observer
+    ///   of the consensus protocol.
     #[prost(string, tag = "6")]
     pub consensus_type: ::prost::alloc::string::String,
     /// The baking status of the node.
@@ -214,33 +213,27 @@ pub struct NodeInfoResponse {
 }
 /// Nested message and enum types in `NodeInfoResponse`.
 pub mod node_info_response {
-    #[derive(
-        Clone,
-        Copy,
-        Debug,
-        PartialEq,
-        Eq,
-        Hash,
-        PartialOrd,
-        Ord,
-        ::prost::Enumeration
-    )]
+    #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, ::prost::Enumeration)]
     #[repr(i32)]
     pub enum IsInBakingCommittee {
         /// The node is not the baking committee.
-        NotInCommittee = 0,
-        /// The node has baker keys, but the account is not currently a baker (and possibly never will be).
+        NotInCommittee    = 0,
+        /// The node has baker keys, but the account is not currently a baker
+        /// (and possibly never will be).
         AddedButNotActiveInCommittee = 1,
-        /// The node has baker keys, but they don't match the current keys on the baker account.
+        /// The node has baker keys, but they don't match the current keys on
+        /// the baker account.
         AddedButWrongKeys = 2,
         /// The node has valid baker keys and is active in the baker committee.
         ActiveInCommittee = 3,
     }
     impl IsInBakingCommittee {
-        /// String value of the enum field names used in the ProtoBuf definition.
+        /// String value of the enum field names used in the ProtoBuf
+        /// definition.
         ///
-        /// The values are not transformed in any way and thus are considered stable
-        /// (if the ProtoBuf definition does not change) and safe for programmatic use.
+        /// The values are not transformed in any way and thus are considered
+        /// stable (if the ProtoBuf definition does not change) and safe
+        /// for programmatic use.
         pub fn as_str_name(&self) -> &'static str {
             match self {
                 IsInBakingCommittee::NotInCommittee => "NOT_IN_COMMITTEE",
@@ -251,13 +244,12 @@ pub mod node_info_response {
                 IsInBakingCommittee::ActiveInCommittee => "ACTIVE_IN_COMMITTEE",
             }
         }
+
         /// Creates an enum from field names used in the ProtoBuf definition.
         pub fn from_str_name(value: &str) -> ::core::option::Option<Self> {
             match value {
                 "NOT_IN_COMMITTEE" => Some(Self::NotInCommittee),
-                "ADDED_BUT_NOT_ACTIVE_IN_COMMITTEE" => {
-                    Some(Self::AddedButNotActiveInCommittee)
-                }
+                "ADDED_BUT_NOT_ACTIVE_IN_COMMITTEE" => Some(Self::AddedButNotActiveInCommittee),
                 "ADDED_BUT_WRONG_KEYS" => Some(Self::AddedButWrongKeys),
                 "ACTIVE_IN_COMMITTEE" => Some(Self::ActiveInCommittee),
                 _ => None,
@@ -273,7 +265,8 @@ pub struct BlockHash {
     #[prost(string, tag = "1")]
     pub block_hash: ::prost::alloc::string::String,
 }
-/// An account address. Uses a base58-check encoding with a version byte set to 1. Is always 50 characters long.
+/// An account address. Uses a base58-check encoding with a version byte set to
+/// 1. Is always 50 characters long.
 /// Example: "3DJoe7aUwMwVmdFdRU2QsnJfsBbCmQu1QHvEg7YtWFZWmsoBXe"
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
@@ -298,10 +291,10 @@ pub struct BlockHashAndAmount {
     pub block_hash: ::prost::alloc::string::String,
     /// The maximum amount of ancestors that will be returned.
     #[prost(uint64, tag = "2")]
-    pub amount: u64,
+    pub amount:     u64,
 }
-/// Submit a transaction to the node. The transaction is subject to basic validation
-/// and is then relayed to all the peers.
+/// Submit a transaction to the node. The transaction is subject to basic
+/// validation and is then relayed to all the peers.
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct SendTransactionRequest {
@@ -309,21 +302,22 @@ pub struct SendTransactionRequest {
     #[prost(uint32, tag = "1")]
     pub network_id: u32,
     /// The transaction payload in binary encoding.
-    /// The encoding of certain transaction types, along with the general payload structure,
-    /// is described at: <https://developer.concordium.software/en/mainnet/net/references/grpc.html.>
+    /// The encoding of certain transaction types, along with the general
+    /// payload structure, is described at: <https://developer.concordium.software/en/mainnet/net/references/grpc.html.>
     #[prost(bytes = "vec", tag = "2")]
-    pub payload: ::prost::alloc::vec::Vec<u8>,
+    pub payload:    ::prost::alloc::vec::Vec<u8>,
 }
 /// Request for getting information about an account address.
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct GetAddressInfoRequest {
-    /// Hash of the block (encoded in hex) at which the information should be gathered.
+    /// Hash of the block (encoded in hex) at which the information should be
+    /// gathered.
     #[prost(string, tag = "1")]
     pub block_hash: ::prost::alloc::string::String,
     /// The account address to request information about.
     #[prost(string, tag = "2")]
-    pub address: ::prost::alloc::string::String,
+    pub address:    ::prost::alloc::string::String,
 }
 /// Request for invoking a contract without a transaction.
 #[allow(clippy::derive_partial_eq_without_eq)]
@@ -335,7 +329,7 @@ pub struct InvokeContractRequest {
     /// A JSON object that specifies which contract to invoke, and how.
     /// A JSON schema for the context is provided at: <https://developer.concordium.software/en/mainnet/net/references/grpc.html.>
     #[prost(string, tag = "2")]
-    pub context: ::prost::alloc::string::String,
+    pub context:    ::prost::alloc::string::String,
 }
 /// Request for getting the source of a smart contract module.
 #[allow(clippy::derive_partial_eq_without_eq)]
@@ -357,7 +351,7 @@ pub struct DumpRequest {
     pub file: ::prost::alloc::string::String,
     /// Whether the node should dump raw packages.
     #[prost(bool, tag = "2")]
-    pub raw: bool,
+    pub raw:  bool,
 }
 /// Request for getting (information about) the peers.
 #[allow(clippy::derive_partial_eq_without_eq)]
@@ -376,7 +370,7 @@ pub struct GetTransactionStatusInBlockRequest {
     pub transaction_hash: ::prost::alloc::string::String,
     /// The block hash.
     #[prost(string, tag = "2")]
-    pub block_hash: ::prost::alloc::string::String,
+    pub block_hash:       ::prost::alloc::string::String,
 }
 /// Request for getting the status of a pool.
 #[allow(clippy::derive_partial_eq_without_eq)]
@@ -384,13 +378,14 @@ pub struct GetTransactionStatusInBlockRequest {
 pub struct GetPoolStatusRequest {
     /// The block from which the query should be processed.
     #[prost(string, tag = "1")]
-    pub block_hash: ::prost::alloc::string::String,
+    pub block_hash:         ::prost::alloc::string::String,
     /// Whether the request is for passive delegation or a specific baker.
     #[prost(bool, tag = "2")]
     pub passive_delegation: bool,
-    /// The baker id to get the status of. This will be ignored if 'passive_delegation' is 'true'.
+    /// The baker id to get the status of. This will be ignored if
+    /// 'passive_delegation' is 'true'.
     #[prost(uint64, tag = "3")]
-    pub baker_id: u64,
+    pub baker_id:           u64,
 }
 /// Request for gettings the blocks at a specific height.
 #[allow(clippy::derive_partial_eq_without_eq)]
@@ -398,10 +393,10 @@ pub struct GetPoolStatusRequest {
 pub struct BlockHeight {
     /// The block height.
     #[prost(uint64, tag = "1")]
-    pub block_height: u64,
+    pub block_height:              u64,
     /// The block height is relative to the genesis block at this index.
     #[prost(uint32, tag = "2")]
-    pub from_genesis_index: u32,
+    pub from_genesis_index:        u32,
     /// If true, only return results from the specified genesis index.
     #[prost(bool, tag = "3")]
     pub restrict_to_genesis_index: bool,
@@ -409,8 +404,7 @@ pub struct BlockHeight {
 /// Generated client implementations.
 pub mod p2p_client {
     #![allow(unused_variables, dead_code, missing_docs, clippy::let_unit_value)]
-    use tonic::codegen::*;
-    use tonic::codegen::http::Uri;
+    use tonic::codegen::{http::Uri, *};
     #[derive(Debug, Clone)]
     pub struct P2pClient<T> {
         inner: tonic::client::Grpc<T>,
@@ -420,8 +414,7 @@ pub mod p2p_client {
         pub async fn connect<D>(dst: D) -> Result<Self, tonic::transport::Error>
         where
             D: std::convert::TryInto<tonic::transport::Endpoint>,
-            D::Error: Into<StdError>,
-        {
+            D::Error: Into<StdError>, {
             let conn = tonic::transport::Endpoint::new(dst)?.connect().await?;
             Ok(Self::new(conn))
         }
@@ -437,10 +430,12 @@ pub mod p2p_client {
             let inner = tonic::client::Grpc::new(inner);
             Self { inner }
         }
+
         pub fn with_origin(inner: T, origin: Uri) -> Self {
             let inner = tonic::client::Grpc::with_origin(inner, origin);
             Self { inner }
         }
+
         pub fn with_interceptor<F>(
             inner: T,
             interceptor: F,
@@ -454,916 +449,763 @@ pub mod p2p_client {
                     <T as tonic::client::GrpcService<tonic::body::BoxBody>>::ResponseBody,
                 >,
             >,
-            <T as tonic::codegen::Service<
-                http::Request<tonic::body::BoxBody>,
-            >>::Error: Into<StdError> + Send + Sync,
-        {
+            <T as tonic::codegen::Service<http::Request<tonic::body::BoxBody>>>::Error:
+                Into<StdError> + Send + Sync, {
             P2pClient::new(InterceptedService::new(inner, interceptor))
         }
+
         /// Compress requests with the given encoding.
         ///
-        /// This requires the server to support it otherwise it might respond with an
-        /// error.
+        /// This requires the server to support it otherwise it might respond
+        /// with an error.
         #[must_use]
         pub fn send_compressed(mut self, encoding: CompressionEncoding) -> Self {
             self.inner = self.inner.send_compressed(encoding);
             self
         }
+
         /// Enable decompressing responses.
         #[must_use]
         pub fn accept_compressed(mut self, encoding: CompressionEncoding) -> Self {
             self.inner = self.inner.accept_compressed(encoding);
             self
         }
+
         /// Suggest to a peer to connect to the submitted peer details.
         /// This, if successful, adds the peer to the list of given addresses.
         pub async fn peer_connect(
             &mut self,
             request: impl tonic::IntoRequest<super::PeerConnectRequest>,
         ) -> Result<tonic::Response<super::BoolResponse>, tonic::Status> {
-            self.inner
-                .ready()
-                .await
-                .map_err(|e| {
-                    tonic::Status::new(
-                        tonic::Code::Unknown,
-                        format!("Service was not ready: {}", e.into()),
-                    )
-                })?;
+            self.inner.ready().await.map_err(|e| {
+                tonic::Status::new(
+                    tonic::Code::Unknown,
+                    format!("Service was not ready: {}", e.into()),
+                )
+            })?;
             let codec = tonic::codec::ProstCodec::default();
-            let path = http::uri::PathAndQuery::from_static(
-                "/concordium.P2P/PeerConnect",
-            );
+            let path = http::uri::PathAndQuery::from_static("/concordium.P2P/PeerConnect");
             self.inner.unary(request.into_request(), path, codec).await
         }
-        /// Disconnect from the peer and remove them from the given addresses list
-        /// if they are on it. Return if the request was processed successfully.
+
+        /// Disconnect from the peer and remove them from the given addresses
+        /// list if they are on it. Return if the request was processed
+        /// successfully.
         pub async fn peer_disconnect(
             &mut self,
             request: impl tonic::IntoRequest<super::PeerConnectRequest>,
         ) -> Result<tonic::Response<super::BoolResponse>, tonic::Status> {
-            self.inner
-                .ready()
-                .await
-                .map_err(|e| {
-                    tonic::Status::new(
-                        tonic::Code::Unknown,
-                        format!("Service was not ready: {}", e.into()),
-                    )
-                })?;
+            self.inner.ready().await.map_err(|e| {
+                tonic::Status::new(
+                    tonic::Code::Unknown,
+                    format!("Service was not ready: {}", e.into()),
+                )
+            })?;
             let codec = tonic::codec::ProstCodec::default();
-            let path = http::uri::PathAndQuery::from_static(
-                "/concordium.P2P/PeerDisconnect",
-            );
+            let path = http::uri::PathAndQuery::from_static("/concordium.P2P/PeerDisconnect");
             self.inner.unary(request.into_request(), path, codec).await
         }
+
         /// Uptime of the *node* in milliseconds.
         pub async fn peer_uptime(
             &mut self,
             request: impl tonic::IntoRequest<super::Empty>,
         ) -> Result<tonic::Response<super::NumberResponse>, tonic::Status> {
-            self.inner
-                .ready()
-                .await
-                .map_err(|e| {
-                    tonic::Status::new(
-                        tonic::Code::Unknown,
-                        format!("Service was not ready: {}", e.into()),
-                    )
-                })?;
+            self.inner.ready().await.map_err(|e| {
+                tonic::Status::new(
+                    tonic::Code::Unknown,
+                    format!("Service was not ready: {}", e.into()),
+                )
+            })?;
             let codec = tonic::codec::ProstCodec::default();
-            let path = http::uri::PathAndQuery::from_static(
-                "/concordium.P2P/PeerUptime",
-            );
+            let path = http::uri::PathAndQuery::from_static("/concordium.P2P/PeerUptime");
             self.inner.unary(request.into_request(), path, codec).await
         }
+
         /// Total number of sent packets by the node.
         pub async fn peer_total_sent(
             &mut self,
             request: impl tonic::IntoRequest<super::Empty>,
         ) -> Result<tonic::Response<super::NumberResponse>, tonic::Status> {
-            self.inner
-                .ready()
-                .await
-                .map_err(|e| {
-                    tonic::Status::new(
-                        tonic::Code::Unknown,
-                        format!("Service was not ready: {}", e.into()),
-                    )
-                })?;
+            self.inner.ready().await.map_err(|e| {
+                tonic::Status::new(
+                    tonic::Code::Unknown,
+                    format!("Service was not ready: {}", e.into()),
+                )
+            })?;
             let codec = tonic::codec::ProstCodec::default();
-            let path = http::uri::PathAndQuery::from_static(
-                "/concordium.P2P/PeerTotalSent",
-            );
+            let path = http::uri::PathAndQuery::from_static("/concordium.P2P/PeerTotalSent");
             self.inner.unary(request.into_request(), path, codec).await
         }
+
         /// Total number of received packets by the node.
         pub async fn peer_total_received(
             &mut self,
             request: impl tonic::IntoRequest<super::Empty>,
         ) -> Result<tonic::Response<super::NumberResponse>, tonic::Status> {
-            self.inner
-                .ready()
-                .await
-                .map_err(|e| {
-                    tonic::Status::new(
-                        tonic::Code::Unknown,
-                        format!("Service was not ready: {}", e.into()),
-                    )
-                })?;
+            self.inner.ready().await.map_err(|e| {
+                tonic::Status::new(
+                    tonic::Code::Unknown,
+                    format!("Service was not ready: {}", e.into()),
+                )
+            })?;
             let codec = tonic::codec::ProstCodec::default();
-            let path = http::uri::PathAndQuery::from_static(
-                "/concordium.P2P/PeerTotalReceived",
-            );
+            let path = http::uri::PathAndQuery::from_static("/concordium.P2P/PeerTotalReceived");
             self.inner.unary(request.into_request(), path, codec).await
         }
+
         /// Node software version.
         pub async fn peer_version(
             &mut self,
             request: impl tonic::IntoRequest<super::Empty>,
         ) -> Result<tonic::Response<super::StringResponse>, tonic::Status> {
-            self.inner
-                .ready()
-                .await
-                .map_err(|e| {
-                    tonic::Status::new(
-                        tonic::Code::Unknown,
-                        format!("Service was not ready: {}", e.into()),
-                    )
-                })?;
+            self.inner.ready().await.map_err(|e| {
+                tonic::Status::new(
+                    tonic::Code::Unknown,
+                    format!("Service was not ready: {}", e.into()),
+                )
+            })?;
             let codec = tonic::codec::ProstCodec::default();
-            let path = http::uri::PathAndQuery::from_static(
-                "/concordium.P2P/PeerVersion",
-            );
+            let path = http::uri::PathAndQuery::from_static("/concordium.P2P/PeerVersion");
             self.inner.unary(request.into_request(), path, codec).await
         }
+
         /// Stats for connected peers.
         pub async fn peer_stats(
             &mut self,
             request: impl tonic::IntoRequest<super::PeersRequest>,
         ) -> Result<tonic::Response<super::PeerStatsResponse>, tonic::Status> {
-            self.inner
-                .ready()
-                .await
-                .map_err(|e| {
-                    tonic::Status::new(
-                        tonic::Code::Unknown,
-                        format!("Service was not ready: {}", e.into()),
-                    )
-                })?;
+            self.inner.ready().await.map_err(|e| {
+                tonic::Status::new(
+                    tonic::Code::Unknown,
+                    format!("Service was not ready: {}", e.into()),
+                )
+            })?;
             let codec = tonic::codec::ProstCodec::default();
             let path = http::uri::PathAndQuery::from_static("/concordium.P2P/PeerStats");
             self.inner.unary(request.into_request(), path, codec).await
         }
+
         /// List of connected peers.
         pub async fn peer_list(
             &mut self,
             request: impl tonic::IntoRequest<super::PeersRequest>,
         ) -> Result<tonic::Response<super::PeerListResponse>, tonic::Status> {
-            self.inner
-                .ready()
-                .await
-                .map_err(|e| {
-                    tonic::Status::new(
-                        tonic::Code::Unknown,
-                        format!("Service was not ready: {}", e.into()),
-                    )
-                })?;
+            self.inner.ready().await.map_err(|e| {
+                tonic::Status::new(
+                    tonic::Code::Unknown,
+                    format!("Service was not ready: {}", e.into()),
+                )
+            })?;
             let codec = tonic::codec::ProstCodec::default();
             let path = http::uri::PathAndQuery::from_static("/concordium.P2P/PeerList");
             self.inner.unary(request.into_request(), path, codec).await
         }
+
         /// Ban a the given peer.
         pub async fn ban_node(
             &mut self,
             request: impl tonic::IntoRequest<super::PeerElement>,
         ) -> Result<tonic::Response<super::BoolResponse>, tonic::Status> {
-            self.inner
-                .ready()
-                .await
-                .map_err(|e| {
-                    tonic::Status::new(
-                        tonic::Code::Unknown,
-                        format!("Service was not ready: {}", e.into()),
-                    )
-                })?;
+            self.inner.ready().await.map_err(|e| {
+                tonic::Status::new(
+                    tonic::Code::Unknown,
+                    format!("Service was not ready: {}", e.into()),
+                )
+            })?;
             let codec = tonic::codec::ProstCodec::default();
             let path = http::uri::PathAndQuery::from_static("/concordium.P2P/BanNode");
             self.inner.unary(request.into_request(), path, codec).await
         }
+
         /// Unban the given peer.
         pub async fn unban_node(
             &mut self,
             request: impl tonic::IntoRequest<super::PeerElement>,
         ) -> Result<tonic::Response<super::BoolResponse>, tonic::Status> {
-            self.inner
-                .ready()
-                .await
-                .map_err(|e| {
-                    tonic::Status::new(
-                        tonic::Code::Unknown,
-                        format!("Service was not ready: {}", e.into()),
-                    )
-                })?;
+            self.inner.ready().await.map_err(|e| {
+                tonic::Status::new(
+                    tonic::Code::Unknown,
+                    format!("Service was not ready: {}", e.into()),
+                )
+            })?;
             let codec = tonic::codec::ProstCodec::default();
             let path = http::uri::PathAndQuery::from_static("/concordium.P2P/UnbanNode");
             self.inner.unary(request.into_request(), path, codec).await
         }
+
         /// Join the provided network.
         pub async fn join_network(
             &mut self,
             request: impl tonic::IntoRequest<super::NetworkChangeRequest>,
         ) -> Result<tonic::Response<super::BoolResponse>, tonic::Status> {
-            self.inner
-                .ready()
-                .await
-                .map_err(|e| {
-                    tonic::Status::new(
-                        tonic::Code::Unknown,
-                        format!("Service was not ready: {}", e.into()),
-                    )
-                })?;
+            self.inner.ready().await.map_err(|e| {
+                tonic::Status::new(
+                    tonic::Code::Unknown,
+                    format!("Service was not ready: {}", e.into()),
+                )
+            })?;
             let codec = tonic::codec::ProstCodec::default();
-            let path = http::uri::PathAndQuery::from_static(
-                "/concordium.P2P/JoinNetwork",
-            );
+            let path = http::uri::PathAndQuery::from_static("/concordium.P2P/JoinNetwork");
             self.inner.unary(request.into_request(), path, codec).await
         }
+
         /// Leave the provided network.
         pub async fn leave_network(
             &mut self,
             request: impl tonic::IntoRequest<super::NetworkChangeRequest>,
         ) -> Result<tonic::Response<super::BoolResponse>, tonic::Status> {
-            self.inner
-                .ready()
-                .await
-                .map_err(|e| {
-                    tonic::Status::new(
-                        tonic::Code::Unknown,
-                        format!("Service was not ready: {}", e.into()),
-                    )
-                })?;
+            self.inner.ready().await.map_err(|e| {
+                tonic::Status::new(
+                    tonic::Code::Unknown,
+                    format!("Service was not ready: {}", e.into()),
+                )
+            })?;
             let codec = tonic::codec::ProstCodec::default();
-            let path = http::uri::PathAndQuery::from_static(
-                "/concordium.P2P/LeaveNetwork",
-            );
+            let path = http::uri::PathAndQuery::from_static("/concordium.P2P/LeaveNetwork");
             self.inner.unary(request.into_request(), path, codec).await
         }
+
         /// Get information about the running node.
         pub async fn node_info(
             &mut self,
             request: impl tonic::IntoRequest<super::Empty>,
         ) -> Result<tonic::Response<super::NodeInfoResponse>, tonic::Status> {
-            self.inner
-                .ready()
-                .await
-                .map_err(|e| {
-                    tonic::Status::new(
-                        tonic::Code::Unknown,
-                        format!("Service was not ready: {}", e.into()),
-                    )
-                })?;
+            self.inner.ready().await.map_err(|e| {
+                tonic::Status::new(
+                    tonic::Code::Unknown,
+                    format!("Service was not ready: {}", e.into()),
+                )
+            })?;
             let codec = tonic::codec::ProstCodec::default();
             let path = http::uri::PathAndQuery::from_static("/concordium.P2P/NodeInfo");
             self.inner.unary(request.into_request(), path, codec).await
         }
+
         /// Get information about the consensus.
         /// A JSON schema for the return type is provided at: https://developer.concordium.software/en/mainnet/net/references/grpc.html.
         pub async fn get_consensus_status(
             &mut self,
             request: impl tonic::IntoRequest<super::Empty>,
         ) -> Result<tonic::Response<super::JsonResponse>, tonic::Status> {
-            self.inner
-                .ready()
-                .await
-                .map_err(|e| {
-                    tonic::Status::new(
-                        tonic::Code::Unknown,
-                        format!("Service was not ready: {}", e.into()),
-                    )
-                })?;
+            self.inner.ready().await.map_err(|e| {
+                tonic::Status::new(
+                    tonic::Code::Unknown,
+                    format!("Service was not ready: {}", e.into()),
+                )
+            })?;
             let codec = tonic::codec::ProstCodec::default();
-            let path = http::uri::PathAndQuery::from_static(
-                "/concordium.P2P/GetConsensusStatus",
-            );
+            let path = http::uri::PathAndQuery::from_static("/concordium.P2P/GetConsensusStatus");
             self.inner.unary(request.into_request(), path, codec).await
         }
+
         /// Get information about the block.
         /// A JSON schema for the return type is provided at: https://developer.concordium.software/en/mainnet/net/references/grpc.html.
         pub async fn get_block_info(
             &mut self,
             request: impl tonic::IntoRequest<super::BlockHash>,
         ) -> Result<tonic::Response<super::JsonResponse>, tonic::Status> {
-            self.inner
-                .ready()
-                .await
-                .map_err(|e| {
-                    tonic::Status::new(
-                        tonic::Code::Unknown,
-                        format!("Service was not ready: {}", e.into()),
-                    )
-                })?;
+            self.inner.ready().await.map_err(|e| {
+                tonic::Status::new(
+                    tonic::Code::Unknown,
+                    format!("Service was not ready: {}", e.into()),
+                )
+            })?;
             let codec = tonic::codec::ProstCodec::default();
-            let path = http::uri::PathAndQuery::from_static(
-                "/concordium.P2P/GetBlockInfo",
-            );
+            let path = http::uri::PathAndQuery::from_static("/concordium.P2P/GetBlockInfo");
             self.inner.unary(request.into_request(), path, codec).await
         }
+
         /// Get ancestors for the provided block.
         /// A JSON schema for the return type is provided at: https://developer.concordium.software/en/mainnet/net/references/grpc.html.
         pub async fn get_ancestors(
             &mut self,
             request: impl tonic::IntoRequest<super::BlockHashAndAmount>,
         ) -> Result<tonic::Response<super::JsonResponse>, tonic::Status> {
-            self.inner
-                .ready()
-                .await
-                .map_err(|e| {
-                    tonic::Status::new(
-                        tonic::Code::Unknown,
-                        format!("Service was not ready: {}", e.into()),
-                    )
-                })?;
+            self.inner.ready().await.map_err(|e| {
+                tonic::Status::new(
+                    tonic::Code::Unknown,
+                    format!("Service was not ready: {}", e.into()),
+                )
+            })?;
             let codec = tonic::codec::ProstCodec::default();
-            let path = http::uri::PathAndQuery::from_static(
-                "/concordium.P2P/GetAncestors",
-            );
+            let path = http::uri::PathAndQuery::from_static("/concordium.P2P/GetAncestors");
             self.inner.unary(request.into_request(), path, codec).await
         }
+
         /// Get the current branches.
         /// A JSON schema for the return type is provided at: https://developer.concordium.software/en/mainnet/net/references/grpc.html.
         pub async fn get_branches(
             &mut self,
             request: impl tonic::IntoRequest<super::Empty>,
         ) -> Result<tonic::Response<super::JsonResponse>, tonic::Status> {
-            self.inner
-                .ready()
-                .await
-                .map_err(|e| {
-                    tonic::Status::new(
-                        tonic::Code::Unknown,
-                        format!("Service was not ready: {}", e.into()),
-                    )
-                })?;
+            self.inner.ready().await.map_err(|e| {
+                tonic::Status::new(
+                    tonic::Code::Unknown,
+                    format!("Service was not ready: {}", e.into()),
+                )
+            })?;
             let codec = tonic::codec::ProstCodec::default();
-            let path = http::uri::PathAndQuery::from_static(
-                "/concordium.P2P/GetBranches",
-            );
+            let path = http::uri::PathAndQuery::from_static("/concordium.P2P/GetBranches");
             self.inner.unary(request.into_request(), path, codec).await
         }
+
         /// Get the blocks at the given height.
         /// A JSON schema for the return type is provided at: https://developer.concordium.software/en/mainnet/net/references/grpc.html.
         pub async fn get_blocks_at_height(
             &mut self,
             request: impl tonic::IntoRequest<super::BlockHeight>,
         ) -> Result<tonic::Response<super::JsonResponse>, tonic::Status> {
-            self.inner
-                .ready()
-                .await
-                .map_err(|e| {
-                    tonic::Status::new(
-                        tonic::Code::Unknown,
-                        format!("Service was not ready: {}", e.into()),
-                    )
-                })?;
+            self.inner.ready().await.map_err(|e| {
+                tonic::Status::new(
+                    tonic::Code::Unknown,
+                    format!("Service was not ready: {}", e.into()),
+                )
+            })?;
             let codec = tonic::codec::ProstCodec::default();
-            let path = http::uri::PathAndQuery::from_static(
-                "/concordium.P2P/GetBlocksAtHeight",
-            );
+            let path = http::uri::PathAndQuery::from_static("/concordium.P2P/GetBlocksAtHeight");
             self.inner.unary(request.into_request(), path, codec).await
         }
+
         /// Submit a transaction.
         pub async fn send_transaction(
             &mut self,
             request: impl tonic::IntoRequest<super::SendTransactionRequest>,
         ) -> Result<tonic::Response<super::BoolResponse>, tonic::Status> {
-            self.inner
-                .ready()
-                .await
-                .map_err(|e| {
-                    tonic::Status::new(
-                        tonic::Code::Unknown,
-                        format!("Service was not ready: {}", e.into()),
-                    )
-                })?;
+            self.inner.ready().await.map_err(|e| {
+                tonic::Status::new(
+                    tonic::Code::Unknown,
+                    format!("Service was not ready: {}", e.into()),
+                )
+            })?;
             let codec = tonic::codec::ProstCodec::default();
-            let path = http::uri::PathAndQuery::from_static(
-                "/concordium.P2P/SendTransaction",
-            );
+            let path = http::uri::PathAndQuery::from_static("/concordium.P2P/SendTransaction");
             self.inner.unary(request.into_request(), path, codec).await
         }
+
         /// Start the baker in the consensus module.
         pub async fn start_baker(
             &mut self,
             request: impl tonic::IntoRequest<super::Empty>,
         ) -> Result<tonic::Response<super::BoolResponse>, tonic::Status> {
-            self.inner
-                .ready()
-                .await
-                .map_err(|e| {
-                    tonic::Status::new(
-                        tonic::Code::Unknown,
-                        format!("Service was not ready: {}", e.into()),
-                    )
-                })?;
+            self.inner.ready().await.map_err(|e| {
+                tonic::Status::new(
+                    tonic::Code::Unknown,
+                    format!("Service was not ready: {}", e.into()),
+                )
+            })?;
             let codec = tonic::codec::ProstCodec::default();
-            let path = http::uri::PathAndQuery::from_static(
-                "/concordium.P2P/StartBaker",
-            );
+            let path = http::uri::PathAndQuery::from_static("/concordium.P2P/StartBaker");
             self.inner.unary(request.into_request(), path, codec).await
         }
+
         /// Stop the baker in the consensus module.
         pub async fn stop_baker(
             &mut self,
             request: impl tonic::IntoRequest<super::Empty>,
         ) -> Result<tonic::Response<super::BoolResponse>, tonic::Status> {
-            self.inner
-                .ready()
-                .await
-                .map_err(|e| {
-                    tonic::Status::new(
-                        tonic::Code::Unknown,
-                        format!("Service was not ready: {}", e.into()),
-                    )
-                })?;
+            self.inner.ready().await.map_err(|e| {
+                tonic::Status::new(
+                    tonic::Code::Unknown,
+                    format!("Service was not ready: {}", e.into()),
+                )
+            })?;
             let codec = tonic::codec::ProstCodec::default();
             let path = http::uri::PathAndQuery::from_static("/concordium.P2P/StopBaker");
             self.inner.unary(request.into_request(), path, codec).await
         }
-        /// Get a list of accounts that exist in the state after the given block.
-        /// A JSON schema for the return type is provided at: https://developer.concordium.software/en/mainnet/net/references/grpc.html.
+
+        /// Get a list of accounts that exist in the state after the given
+        /// block. A JSON schema for the return type is provided at: https://developer.concordium.software/en/mainnet/net/references/grpc.html.
         pub async fn get_account_list(
             &mut self,
             request: impl tonic::IntoRequest<super::BlockHash>,
         ) -> Result<tonic::Response<super::JsonResponse>, tonic::Status> {
-            self.inner
-                .ready()
-                .await
-                .map_err(|e| {
-                    tonic::Status::new(
-                        tonic::Code::Unknown,
-                        format!("Service was not ready: {}", e.into()),
-                    )
-                })?;
+            self.inner.ready().await.map_err(|e| {
+                tonic::Status::new(
+                    tonic::Code::Unknown,
+                    format!("Service was not ready: {}", e.into()),
+                )
+            })?;
             let codec = tonic::codec::ProstCodec::default();
-            let path = http::uri::PathAndQuery::from_static(
-                "/concordium.P2P/GetAccountList",
-            );
+            let path = http::uri::PathAndQuery::from_static("/concordium.P2P/GetAccountList");
             self.inner.unary(request.into_request(), path, codec).await
         }
-        /// Get all smart contract instances that exist in the state after the given block.
-        /// A JSON schema for the return type is provided at: https://developer.concordium.software/en/mainnet/net/references/grpc.html.
+
+        /// Get all smart contract instances that exist in the state after the
+        /// given block. A JSON schema for the return type is provided at: https://developer.concordium.software/en/mainnet/net/references/grpc.html.
         pub async fn get_instances(
             &mut self,
             request: impl tonic::IntoRequest<super::BlockHash>,
         ) -> Result<tonic::Response<super::JsonResponse>, tonic::Status> {
-            self.inner
-                .ready()
-                .await
-                .map_err(|e| {
-                    tonic::Status::new(
-                        tonic::Code::Unknown,
-                        format!("Service was not ready: {}", e.into()),
-                    )
-                })?;
+            self.inner.ready().await.map_err(|e| {
+                tonic::Status::new(
+                    tonic::Code::Unknown,
+                    format!("Service was not ready: {}", e.into()),
+                )
+            })?;
             let codec = tonic::codec::ProstCodec::default();
-            let path = http::uri::PathAndQuery::from_static(
-                "/concordium.P2P/GetInstances",
-            );
+            let path = http::uri::PathAndQuery::from_static("/concordium.P2P/GetInstances");
             self.inner.unary(request.into_request(), path, codec).await
         }
+
         /// Get information about an account.
         /// A JSON schema for the return type is provided at: https://developer.concordium.software/en/mainnet/net/references/grpc.html.
         pub async fn get_account_info(
             &mut self,
             request: impl tonic::IntoRequest<super::GetAddressInfoRequest>,
         ) -> Result<tonic::Response<super::JsonResponse>, tonic::Status> {
-            self.inner
-                .ready()
-                .await
-                .map_err(|e| {
-                    tonic::Status::new(
-                        tonic::Code::Unknown,
-                        format!("Service was not ready: {}", e.into()),
-                    )
-                })?;
+            self.inner.ready().await.map_err(|e| {
+                tonic::Status::new(
+                    tonic::Code::Unknown,
+                    format!("Service was not ready: {}", e.into()),
+                )
+            })?;
             let codec = tonic::codec::ProstCodec::default();
-            let path = http::uri::PathAndQuery::from_static(
-                "/concordium.P2P/GetAccountInfo",
-            );
+            let path = http::uri::PathAndQuery::from_static("/concordium.P2P/GetAccountInfo");
             self.inner.unary(request.into_request(), path, codec).await
         }
+
         /// Get information about a smart contract instance.
         /// A JSON schema for the return type is provided at: https://developer.concordium.software/en/mainnet/net/references/grpc.html.
         pub async fn get_instance_info(
             &mut self,
             request: impl tonic::IntoRequest<super::GetAddressInfoRequest>,
         ) -> Result<tonic::Response<super::JsonResponse>, tonic::Status> {
-            self.inner
-                .ready()
-                .await
-                .map_err(|e| {
-                    tonic::Status::new(
-                        tonic::Code::Unknown,
-                        format!("Service was not ready: {}", e.into()),
-                    )
-                })?;
+            self.inner.ready().await.map_err(|e| {
+                tonic::Status::new(
+                    tonic::Code::Unknown,
+                    format!("Service was not ready: {}", e.into()),
+                )
+            })?;
             let codec = tonic::codec::ProstCodec::default();
-            let path = http::uri::PathAndQuery::from_static(
-                "/concordium.P2P/GetInstanceInfo",
-            );
+            let path = http::uri::PathAndQuery::from_static("/concordium.P2P/GetInstanceInfo");
             self.inner.unary(request.into_request(), path, codec).await
         }
-        /// Invoke a smart contract instance and view the result *as if* it had been updated at the end of the provided block.
-        /// This is *not* a transaction.
-        /// A JSON schema for the return type is provided at: https://developer.concordium.software/en/mainnet/net/references/grpc.html.
+
+        /// Invoke a smart contract instance and view the result *as if* it had
+        /// been updated at the end of the provided block. This is *not*
+        /// a transaction. A JSON schema for the return type is provided at: https://developer.concordium.software/en/mainnet/net/references/grpc.html.
         pub async fn invoke_contract(
             &mut self,
             request: impl tonic::IntoRequest<super::InvokeContractRequest>,
         ) -> Result<tonic::Response<super::JsonResponse>, tonic::Status> {
-            self.inner
-                .ready()
-                .await
-                .map_err(|e| {
-                    tonic::Status::new(
-                        tonic::Code::Unknown,
-                        format!("Service was not ready: {}", e.into()),
-                    )
-                })?;
+            self.inner.ready().await.map_err(|e| {
+                tonic::Status::new(
+                    tonic::Code::Unknown,
+                    format!("Service was not ready: {}", e.into()),
+                )
+            })?;
             let codec = tonic::codec::ProstCodec::default();
-            let path = http::uri::PathAndQuery::from_static(
-                "/concordium.P2P/InvokeContract",
-            );
+            let path = http::uri::PathAndQuery::from_static("/concordium.P2P/InvokeContract");
             self.inner.unary(request.into_request(), path, codec).await
         }
-        /// Get an overview of the balance of special accounts in the given block.
-        /// A JSON schema for the return type is provided at: https://developer.concordium.software/en/mainnet/net/references/grpc.html.
+
+        /// Get an overview of the balance of special accounts in the given
+        /// block. A JSON schema for the return type is provided at: https://developer.concordium.software/en/mainnet/net/references/grpc.html.
         pub async fn get_reward_status(
             &mut self,
             request: impl tonic::IntoRequest<super::BlockHash>,
         ) -> Result<tonic::Response<super::JsonResponse>, tonic::Status> {
-            self.inner
-                .ready()
-                .await
-                .map_err(|e| {
-                    tonic::Status::new(
-                        tonic::Code::Unknown,
-                        format!("Service was not ready: {}", e.into()),
-                    )
-                })?;
+            self.inner.ready().await.map_err(|e| {
+                tonic::Status::new(
+                    tonic::Code::Unknown,
+                    format!("Service was not ready: {}", e.into()),
+                )
+            })?;
             let codec = tonic::codec::ProstCodec::default();
-            let path = http::uri::PathAndQuery::from_static(
-                "/concordium.P2P/GetRewardStatus",
-            );
+            let path = http::uri::PathAndQuery::from_static("/concordium.P2P/GetRewardStatus");
             self.inner.unary(request.into_request(), path, codec).await
         }
+
         /// Get an overview of the parameters used for baking.
         /// A JSON schema for the return type is provided at: https://developer.concordium.software/en/mainnet/net/references/grpc.html.
         pub async fn get_birk_parameters(
             &mut self,
             request: impl tonic::IntoRequest<super::BlockHash>,
         ) -> Result<tonic::Response<super::JsonResponse>, tonic::Status> {
-            self.inner
-                .ready()
-                .await
-                .map_err(|e| {
-                    tonic::Status::new(
-                        tonic::Code::Unknown,
-                        format!("Service was not ready: {}", e.into()),
-                    )
-                })?;
+            self.inner.ready().await.map_err(|e| {
+                tonic::Status::new(
+                    tonic::Code::Unknown,
+                    format!("Service was not ready: {}", e.into()),
+                )
+            })?;
             let codec = tonic::codec::ProstCodec::default();
-            let path = http::uri::PathAndQuery::from_static(
-                "/concordium.P2P/GetBirkParameters",
-            );
+            let path = http::uri::PathAndQuery::from_static("/concordium.P2P/GetBirkParameters");
             self.inner.unary(request.into_request(), path, codec).await
         }
-        /// Get a list of smart contract modules that exist in the state after the given block.
-        /// A JSON schema for the return type is provided at: https://developer.concordium.software/en/mainnet/net/references/grpc.html.
+
+        /// Get a list of smart contract modules that exist in the state after
+        /// the given block. A JSON schema for the return type is provided at: https://developer.concordium.software/en/mainnet/net/references/grpc.html.
         pub async fn get_module_list(
             &mut self,
             request: impl tonic::IntoRequest<super::BlockHash>,
         ) -> Result<tonic::Response<super::JsonResponse>, tonic::Status> {
-            self.inner
-                .ready()
-                .await
-                .map_err(|e| {
-                    tonic::Status::new(
-                        tonic::Code::Unknown,
-                        format!("Service was not ready: {}", e.into()),
-                    )
-                })?;
+            self.inner.ready().await.map_err(|e| {
+                tonic::Status::new(
+                    tonic::Code::Unknown,
+                    format!("Service was not ready: {}", e.into()),
+                )
+            })?;
             let codec = tonic::codec::ProstCodec::default();
-            let path = http::uri::PathAndQuery::from_static(
-                "/concordium.P2P/GetModuleList",
-            );
+            let path = http::uri::PathAndQuery::from_static("/concordium.P2P/GetModuleList");
             self.inner.unary(request.into_request(), path, codec).await
         }
+
         /// Get the source of a smart contract module.
         pub async fn get_module_source(
             &mut self,
             request: impl tonic::IntoRequest<super::GetModuleSourceRequest>,
         ) -> Result<tonic::Response<super::BytesResponse>, tonic::Status> {
-            self.inner
-                .ready()
-                .await
-                .map_err(|e| {
-                    tonic::Status::new(
-                        tonic::Code::Unknown,
-                        format!("Service was not ready: {}", e.into()),
-                    )
-                })?;
+            self.inner.ready().await.map_err(|e| {
+                tonic::Status::new(
+                    tonic::Code::Unknown,
+                    format!("Service was not ready: {}", e.into()),
+                )
+            })?;
             let codec = tonic::codec::ProstCodec::default();
-            let path = http::uri::PathAndQuery::from_static(
-                "/concordium.P2P/GetModuleSource",
-            );
+            let path = http::uri::PathAndQuery::from_static("/concordium.P2P/GetModuleSource");
             self.inner.unary(request.into_request(), path, codec).await
         }
-        /// Get a list of all identity providers that exist in the state after the given block.
-        /// A JSON schema for the return type is provided at: https://developer.concordium.software/en/mainnet/net/references/grpc.html.
+
+        /// Get a list of all identity providers that exist in the state after
+        /// the given block. A JSON schema for the return type is provided at: https://developer.concordium.software/en/mainnet/net/references/grpc.html.
         pub async fn get_identity_providers(
             &mut self,
             request: impl tonic::IntoRequest<super::BlockHash>,
         ) -> Result<tonic::Response<super::JsonResponse>, tonic::Status> {
-            self.inner
-                .ready()
-                .await
-                .map_err(|e| {
-                    tonic::Status::new(
-                        tonic::Code::Unknown,
-                        format!("Service was not ready: {}", e.into()),
-                    )
-                })?;
+            self.inner.ready().await.map_err(|e| {
+                tonic::Status::new(
+                    tonic::Code::Unknown,
+                    format!("Service was not ready: {}", e.into()),
+                )
+            })?;
             let codec = tonic::codec::ProstCodec::default();
-            let path = http::uri::PathAndQuery::from_static(
-                "/concordium.P2P/GetIdentityProviders",
-            );
+            let path = http::uri::PathAndQuery::from_static("/concordium.P2P/GetIdentityProviders");
             self.inner.unary(request.into_request(), path, codec).await
         }
-        /// Get a list of all anonymity revokers that exist in the state after the given block.
-        /// A JSON schema for the return type is provided at: https://developer.concordium.software/en/mainnet/net/references/grpc.html.
+
+        /// Get a list of all anonymity revokers that exist in the state after
+        /// the given block. A JSON schema for the return type is provided at: https://developer.concordium.software/en/mainnet/net/references/grpc.html.
         pub async fn get_anonymity_revokers(
             &mut self,
             request: impl tonic::IntoRequest<super::BlockHash>,
         ) -> Result<tonic::Response<super::JsonResponse>, tonic::Status> {
-            self.inner
-                .ready()
-                .await
-                .map_err(|e| {
-                    tonic::Status::new(
-                        tonic::Code::Unknown,
-                        format!("Service was not ready: {}", e.into()),
-                    )
-                })?;
+            self.inner.ready().await.map_err(|e| {
+                tonic::Status::new(
+                    tonic::Code::Unknown,
+                    format!("Service was not ready: {}", e.into()),
+                )
+            })?;
             let codec = tonic::codec::ProstCodec::default();
-            let path = http::uri::PathAndQuery::from_static(
-                "/concordium.P2P/GetAnonymityRevokers",
-            );
+            let path = http::uri::PathAndQuery::from_static("/concordium.P2P/GetAnonymityRevokers");
             self.inner.unary(request.into_request(), path, codec).await
         }
+
         /// Get the cryptographic parameters used in the given block.
         /// A JSON schema for the return type is provided at: https://developer.concordium.software/en/mainnet/net/references/grpc.html.
         pub async fn get_cryptographic_parameters(
             &mut self,
             request: impl tonic::IntoRequest<super::BlockHash>,
         ) -> Result<tonic::Response<super::JsonResponse>, tonic::Status> {
-            self.inner
-                .ready()
-                .await
-                .map_err(|e| {
-                    tonic::Status::new(
-                        tonic::Code::Unknown,
-                        format!("Service was not ready: {}", e.into()),
-                    )
-                })?;
+            self.inner.ready().await.map_err(|e| {
+                tonic::Status::new(
+                    tonic::Code::Unknown,
+                    format!("Service was not ready: {}", e.into()),
+                )
+            })?;
             let codec = tonic::codec::ProstCodec::default();
-            let path = http::uri::PathAndQuery::from_static(
-                "/concordium.P2P/GetCryptographicParameters",
-            );
+            let path =
+                http::uri::PathAndQuery::from_static("/concordium.P2P/GetCryptographicParameters");
             self.inner.unary(request.into_request(), path, codec).await
         }
-        /// Get a list of all baker IDs registered at that block in ascending order. Or null, if the block is invalid.
-        /// A JSON schema for the return type is provided at: https://developer.concordium.software/en/mainnet/net/references/grpc.html.
+
+        /// Get a list of all baker IDs registered at that block in ascending
+        /// order. Or null, if the block is invalid. A JSON schema for the return type is provided at: https://developer.concordium.software/en/mainnet/net/references/grpc.html.
         pub async fn get_baker_list(
             &mut self,
             request: impl tonic::IntoRequest<super::BlockHash>,
         ) -> Result<tonic::Response<super::JsonResponse>, tonic::Status> {
-            self.inner
-                .ready()
-                .await
-                .map_err(|e| {
-                    tonic::Status::new(
-                        tonic::Code::Unknown,
-                        format!("Service was not ready: {}", e.into()),
-                    )
-                })?;
+            self.inner.ready().await.map_err(|e| {
+                tonic::Status::new(
+                    tonic::Code::Unknown,
+                    format!("Service was not ready: {}", e.into()),
+                )
+            })?;
             let codec = tonic::codec::ProstCodec::default();
-            let path = http::uri::PathAndQuery::from_static(
-                "/concordium.P2P/GetBakerList",
-            );
+            let path = http::uri::PathAndQuery::from_static("/concordium.P2P/GetBakerList");
             self.inner.unary(request.into_request(), path, codec).await
         }
-        /// Get the status of a pool. If passiveDelegation == true, this returns the status for the passive delegators.
-        /// Otherwise, it returns the status for the baker with the specified ID (if it exists).
-        /// A JSON schema for the return type is provided at: https://developer.concordium.software/en/mainnet/net/references/grpc.html.
+
+        /// Get the status of a pool. If passiveDelegation == true, this returns
+        /// the status for the passive delegators. Otherwise, it returns
+        /// the status for the baker with the specified ID (if it exists). A JSON schema for the return type is provided at: https://developer.concordium.software/en/mainnet/net/references/grpc.html.
         pub async fn get_pool_status(
             &mut self,
             request: impl tonic::IntoRequest<super::GetPoolStatusRequest>,
         ) -> Result<tonic::Response<super::JsonResponse>, tonic::Status> {
-            self.inner
-                .ready()
-                .await
-                .map_err(|e| {
-                    tonic::Status::new(
-                        tonic::Code::Unknown,
-                        format!("Service was not ready: {}", e.into()),
-                    )
-                })?;
+            self.inner.ready().await.map_err(|e| {
+                tonic::Status::new(
+                    tonic::Code::Unknown,
+                    format!("Service was not ready: {}", e.into()),
+                )
+            })?;
             let codec = tonic::codec::ProstCodec::default();
-            let path = http::uri::PathAndQuery::from_static(
-                "/concordium.P2P/GetPoolStatus",
-            );
+            let path = http::uri::PathAndQuery::from_static("/concordium.P2P/GetPoolStatus");
             self.inner.unary(request.into_request(), path, codec).await
         }
+
         /// Get a list of banned peers.
         pub async fn get_banned_peers(
             &mut self,
             request: impl tonic::IntoRequest<super::Empty>,
         ) -> Result<tonic::Response<super::PeerListResponse>, tonic::Status> {
-            self.inner
-                .ready()
-                .await
-                .map_err(|e| {
-                    tonic::Status::new(
-                        tonic::Code::Unknown,
-                        format!("Service was not ready: {}", e.into()),
-                    )
-                })?;
+            self.inner.ready().await.map_err(|e| {
+                tonic::Status::new(
+                    tonic::Code::Unknown,
+                    format!("Service was not ready: {}", e.into()),
+                )
+            })?;
             let codec = tonic::codec::ProstCodec::default();
-            let path = http::uri::PathAndQuery::from_static(
-                "/concordium.P2P/GetBannedPeers",
-            );
+            let path = http::uri::PathAndQuery::from_static("/concordium.P2P/GetBannedPeers");
             self.inner.unary(request.into_request(), path, codec).await
         }
+
         /// Shut down the node.
         pub async fn shutdown(
             &mut self,
             request: impl tonic::IntoRequest<super::Empty>,
         ) -> Result<tonic::Response<super::BoolResponse>, tonic::Status> {
-            self.inner
-                .ready()
-                .await
-                .map_err(|e| {
-                    tonic::Status::new(
-                        tonic::Code::Unknown,
-                        format!("Service was not ready: {}", e.into()),
-                    )
-                })?;
+            self.inner.ready().await.map_err(|e| {
+                tonic::Status::new(
+                    tonic::Code::Unknown,
+                    format!("Service was not ready: {}", e.into()),
+                )
+            })?;
             let codec = tonic::codec::ProstCodec::default();
             let path = http::uri::PathAndQuery::from_static("/concordium.P2P/Shutdown");
             self.inner.unary(request.into_request(), path, codec).await
         }
+
         /// Start dumping packages into the specified file.
         /// Only enabled if the node was built with the `network_dump` feature.
         pub async fn dump_start(
             &mut self,
             request: impl tonic::IntoRequest<super::DumpRequest>,
         ) -> Result<tonic::Response<super::BoolResponse>, tonic::Status> {
-            self.inner
-                .ready()
-                .await
-                .map_err(|e| {
-                    tonic::Status::new(
-                        tonic::Code::Unknown,
-                        format!("Service was not ready: {}", e.into()),
-                    )
-                })?;
+            self.inner.ready().await.map_err(|e| {
+                tonic::Status::new(
+                    tonic::Code::Unknown,
+                    format!("Service was not ready: {}", e.into()),
+                )
+            })?;
             let codec = tonic::codec::ProstCodec::default();
             let path = http::uri::PathAndQuery::from_static("/concordium.P2P/DumpStart");
             self.inner.unary(request.into_request(), path, codec).await
         }
+
         /// Stop dumping packages.
         /// Only enabled if the node was built with the `network_dump` feature.
         pub async fn dump_stop(
             &mut self,
             request: impl tonic::IntoRequest<super::Empty>,
         ) -> Result<tonic::Response<super::BoolResponse>, tonic::Status> {
-            self.inner
-                .ready()
-                .await
-                .map_err(|e| {
-                    tonic::Status::new(
-                        tonic::Code::Unknown,
-                        format!("Service was not ready: {}", e.into()),
-                    )
-                })?;
+            self.inner.ready().await.map_err(|e| {
+                tonic::Status::new(
+                    tonic::Code::Unknown,
+                    format!("Service was not ready: {}", e.into()),
+                )
+            })?;
             let codec = tonic::codec::ProstCodec::default();
             let path = http::uri::PathAndQuery::from_static("/concordium.P2P/DumpStop");
             self.inner.unary(request.into_request(), path, codec).await
         }
+
         /// Query for the status of a transaction by its hash.
         /// A JSON schema for the return type is provided at: https://developer.concordium.software/en/mainnet/net/references/grpc.html.
         pub async fn get_transaction_status(
             &mut self,
             request: impl tonic::IntoRequest<super::TransactionHash>,
         ) -> Result<tonic::Response<super::JsonResponse>, tonic::Status> {
-            self.inner
-                .ready()
-                .await
-                .map_err(|e| {
-                    tonic::Status::new(
-                        tonic::Code::Unknown,
-                        format!("Service was not ready: {}", e.into()),
-                    )
-                })?;
+            self.inner.ready().await.map_err(|e| {
+                tonic::Status::new(
+                    tonic::Code::Unknown,
+                    format!("Service was not ready: {}", e.into()),
+                )
+            })?;
             let codec = tonic::codec::ProstCodec::default();
-            let path = http::uri::PathAndQuery::from_static(
-                "/concordium.P2P/GetTransactionStatus",
-            );
+            let path = http::uri::PathAndQuery::from_static("/concordium.P2P/GetTransactionStatus");
             self.inner.unary(request.into_request(), path, codec).await
         }
+
         /// Query for transactions in a block by its hash.
         /// A JSON schema for the return type is provided at: https://developer.concordium.software/en/mainnet/net/references/grpc.html.
         pub async fn get_transaction_status_in_block(
             &mut self,
             request: impl tonic::IntoRequest<super::GetTransactionStatusInBlockRequest>,
         ) -> Result<tonic::Response<super::JsonResponse>, tonic::Status> {
-            self.inner
-                .ready()
-                .await
-                .map_err(|e| {
-                    tonic::Status::new(
-                        tonic::Code::Unknown,
-                        format!("Service was not ready: {}", e.into()),
-                    )
-                })?;
+            self.inner.ready().await.map_err(|e| {
+                tonic::Status::new(
+                    tonic::Code::Unknown,
+                    format!("Service was not ready: {}", e.into()),
+                )
+            })?;
             let codec = tonic::codec::ProstCodec::default();
-            let path = http::uri::PathAndQuery::from_static(
-                "/concordium.P2P/GetTransactionStatusInBlock",
-            );
+            let path =
+                http::uri::PathAndQuery::from_static("/concordium.P2P/GetTransactionStatusInBlock");
             self.inner.unary(request.into_request(), path, codec).await
         }
-        /// Query for non-finalized transactions present on an account by the account address.
-        /// A JSON schema for the return type is provided at: https://developer.concordium.software/en/mainnet/net/references/grpc.html.
+
+        /// Query for non-finalized transactions present on an account by the
+        /// account address. A JSON schema for the return type is provided at: https://developer.concordium.software/en/mainnet/net/references/grpc.html.
         pub async fn get_account_non_finalized_transactions(
             &mut self,
             request: impl tonic::IntoRequest<super::AccountAddress>,
         ) -> Result<tonic::Response<super::JsonResponse>, tonic::Status> {
-            self.inner
-                .ready()
-                .await
-                .map_err(|e| {
-                    tonic::Status::new(
-                        tonic::Code::Unknown,
-                        format!("Service was not ready: {}", e.into()),
-                    )
-                })?;
+            self.inner.ready().await.map_err(|e| {
+                tonic::Status::new(
+                    tonic::Code::Unknown,
+                    format!("Service was not ready: {}", e.into()),
+                )
+            })?;
             let codec = tonic::codec::ProstCodec::default();
             let path = http::uri::PathAndQuery::from_static(
                 "/concordium.P2P/GetAccountNonFinalizedTransactions",
             );
             self.inner.unary(request.into_request(), path, codec).await
         }
+
         /// Request a summary for a block by its hash.
         /// A JSON schema for the return type is provided at: https://developer.concordium.software/en/mainnet/net/references/grpc.html.
         pub async fn get_block_summary(
             &mut self,
             request: impl tonic::IntoRequest<super::BlockHash>,
         ) -> Result<tonic::Response<super::JsonResponse>, tonic::Status> {
-            self.inner
-                .ready()
-                .await
-                .map_err(|e| {
-                    tonic::Status::new(
-                        tonic::Code::Unknown,
-                        format!("Service was not ready: {}", e.into()),
-                    )
-                })?;
+            self.inner.ready().await.map_err(|e| {
+                tonic::Status::new(
+                    tonic::Code::Unknown,
+                    format!("Service was not ready: {}", e.into()),
+                )
+            })?;
             let codec = tonic::codec::ProstCodec::default();
-            let path = http::uri::PathAndQuery::from_static(
-                "/concordium.P2P/GetBlockSummary",
-            );
+            let path = http::uri::PathAndQuery::from_static("/concordium.P2P/GetBlockSummary");
             self.inner.unary(request.into_request(), path, codec).await
         }
+
         /// Request next nonce information for an account.
         /// A JSON schema for the return type is provided at: https://developer.concordium.software/en/mainnet/net/references/grpc.html.
         pub async fn get_next_account_nonce(
             &mut self,
             request: impl tonic::IntoRequest<super::AccountAddress>,
         ) -> Result<tonic::Response<super::JsonResponse>, tonic::Status> {
-            self.inner
-                .ready()
-                .await
-                .map_err(|e| {
-                    tonic::Status::new(
-                        tonic::Code::Unknown,
-                        format!("Service was not ready: {}", e.into()),
-                    )
-                })?;
+            self.inner.ready().await.map_err(|e| {
+                tonic::Status::new(
+                    tonic::Code::Unknown,
+                    format!("Service was not ready: {}", e.into()),
+                )
+            })?;
             let codec = tonic::codec::ProstCodec::default();
-            let path = http::uri::PathAndQuery::from_static(
-                "/concordium.P2P/GetNextAccountNonce",
-            );
+            let path = http::uri::PathAndQuery::from_static("/concordium.P2P/GetNextAccountNonce");
             self.inner.unary(request.into_request(), path, codec).await
         }
     }

--- a/src/v2/generated/concordium.v2.rs
+++ b/src/v2/generated/concordium.v2.rs
@@ -1,25 +1,30 @@
 /// A message that contains no information.
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct Empty {}
 /// Hash of a block. This is always 32 bytes long.
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct BlockHash {
     #[prost(bytes = "vec", tag = "1")]
     pub value: ::prost::alloc::vec::Vec<u8>,
 }
 /// A SHA256 hash. This is always 32 bytes long.
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct Sha256Hash {
     #[prost(bytes = "vec", tag = "1")]
     pub value: ::prost::alloc::vec::Vec<u8>,
 }
 /// Hash of a transaction. This is always 32 bytes long.
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct TransactionHash {
     #[prost(bytes = "vec", tag = "1")]
     pub value: ::prost::alloc::vec::Vec<u8>,
 }
 /// Hash of the state after some block. This is always 32 bytes long.
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct StateHash {
     #[prost(bytes = "vec", tag = "1")]
@@ -28,6 +33,7 @@ pub struct StateHash {
 /// The absolute height of a block. This is the number of ancestors of a block
 /// since the genesis block. In particular, the chain genesis block has absolute
 /// height 0.
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct AbsoluteBlockHeight {
     #[prost(uint64, tag = "1")]
@@ -36,12 +42,14 @@ pub struct AbsoluteBlockHeight {
 /// The height of a block relative to the last genesis. This differs from the
 /// absolute block height in that it counts height from the last protocol
 /// update.
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct BlockHeight {
     #[prost(uint64, tag = "1")]
     pub value: u64,
 }
 /// The ID of a baker, which is the index of its account.
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct BakerId {
     #[prost(uint64, tag = "1")]
@@ -49,18 +57,21 @@ pub struct BakerId {
 }
 /// Index of the account in the account table. These are assigned sequentially
 /// in the order of creation of accounts. The first account has index 0.
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct AccountIndex {
     #[prost(uint64, tag = "1")]
     pub value: u64,
 }
 /// A smart contract module reference. This is always 32 bytes long.
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct ModuleRef {
     #[prost(bytes = "vec", tag = "1")]
     pub value: ::prost::alloc::vec::Vec<u8>,
 }
 /// Source bytes of a versioned smart contract module.
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct VersionedModuleSource {
     #[prost(oneof = "versioned_module_source::Module", tags = "1, 2")]
@@ -69,17 +80,20 @@ pub struct VersionedModuleSource {
 /// Nested message and enum types in `VersionedModuleSource`.
 pub mod versioned_module_source {
     /// Source bytes of a smart contract v0 module.
+    #[allow(clippy::derive_partial_eq_without_eq)]
     #[derive(Clone, PartialEq, ::prost::Message)]
     pub struct ModuleSourceV0 {
         #[prost(bytes = "vec", tag = "1")]
         pub value: ::prost::alloc::vec::Vec<u8>,
     }
     /// Source bytes of a smart contract v1 module.
+    #[allow(clippy::derive_partial_eq_without_eq)]
     #[derive(Clone, PartialEq, ::prost::Message)]
     pub struct ModuleSourceV1 {
         #[prost(bytes = "vec", tag = "1")]
         pub value: ::prost::alloc::vec::Vec<u8>,
     }
+    #[allow(clippy::derive_partial_eq_without_eq)]
     #[derive(Clone, PartialEq, ::prost::Oneof)]
     pub enum Module {
         #[prost(message, tag = "1")]
@@ -89,12 +103,14 @@ pub mod versioned_module_source {
     }
 }
 /// Unix timestamp in milliseconds.
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct Timestamp {
     #[prost(uint64, tag = "1")]
     pub value: u64,
 }
 /// An individual release of a locked balance.
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct Release {
     /// Effective time of the release in milliseconds since unix epoch.
@@ -109,6 +125,7 @@ pub struct Release {
 }
 /// A new individual release. Part of a single transfer with schedule
 /// transaction.
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct NewRelease {
     /// Effective time of the release in milliseconds since unix epoch.
@@ -120,6 +137,7 @@ pub struct NewRelease {
 }
 /// State of the account's release schedule. This is the balance of the account
 /// that is owned by the account, but cannot be used until the release point.
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct ReleaseSchedule {
     /// Total amount locked in the release schedule.
@@ -134,11 +152,13 @@ pub struct ReleaseSchedule {
 /// represents the high 32 bits. The chunks are serialized in order and
 /// represented as a byte array.
 /// Always 192 bytes.
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct EncryptedAmount {
     #[prost(bytes = "vec", tag = "1")]
     pub value: ::prost::alloc::vec::Vec<u8>,
 }
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct EncryptedBalance {
     /// Encrypted amount that is a result of this account's actions.
@@ -174,6 +194,7 @@ pub struct EncryptedBalance {
     pub incoming_amounts:  ::prost::alloc::vec::Vec<EncryptedAmount>,
 }
 /// Entity to which the account delegates a portion of its stake.
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct DelegationTarget {
     #[prost(oneof = "delegation_target::Target", tags = "1, 2")]
@@ -181,6 +202,7 @@ pub struct DelegationTarget {
 }
 /// Nested message and enum types in `DelegationTarget`.
 pub mod delegation_target {
+    #[allow(clippy::derive_partial_eq_without_eq)]
     #[derive(Clone, PartialEq, ::prost::Oneof)]
     pub enum Target {
         /// Delegate passively, i.e., to no specific baker.
@@ -192,6 +214,7 @@ pub mod delegation_target {
     }
 }
 /// Baker's public key used to check whether they won the lottery or not.
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct BakerElectionVerifyKey {
     #[prost(bytes = "vec", tag = "1")]
@@ -199,6 +222,7 @@ pub struct BakerElectionVerifyKey {
 }
 /// Baker's public key used to check that they are indeed the ones who
 /// produced the block.
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct BakerSignatureVerifyKey {
     #[prost(bytes = "vec", tag = "1")]
@@ -207,12 +231,14 @@ pub struct BakerSignatureVerifyKey {
 /// Baker's public key used to check signatures on finalization records.
 /// This is only used if the baker has sufficient stake to participate in
 /// finalization.
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct BakerAggregationVerifyKey {
     #[prost(bytes = "vec", tag = "1")]
     pub value: ::prost::alloc::vec::Vec<u8>,
 }
 /// Information about a baker.
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct BakerInfo {
     /// Identity of the baker. This is actually the account index of
@@ -233,6 +259,7 @@ pub struct BakerInfo {
     pub aggregation_key: ::core::option::Option<BakerAggregationVerifyKey>,
 }
 /// Pending change to the stake either of a baker or delegator.
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct StakePendingChange {
     #[prost(oneof = "stake_pending_change::Change", tags = "1, 2")]
@@ -240,6 +267,7 @@ pub struct StakePendingChange {
 }
 /// Nested message and enum types in `StakePendingChange`.
 pub mod stake_pending_change {
+    #[allow(clippy::derive_partial_eq_without_eq)]
     #[derive(Clone, PartialEq, ::prost::Message)]
     pub struct Reduce {
         #[prost(message, optional, tag = "1")]
@@ -248,6 +276,7 @@ pub mod stake_pending_change {
         #[prost(message, optional, tag = "2")]
         pub effective_time: ::core::option::Option<super::Timestamp>,
     }
+    #[allow(clippy::derive_partial_eq_without_eq)]
     #[derive(Clone, PartialEq, ::prost::Oneof)]
     pub enum Change {
         #[prost(message, tag = "1")]
@@ -259,6 +288,7 @@ pub mod stake_pending_change {
     }
 }
 /// A fraction of an amount with a precision of `1/100_000`.
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct AmountFraction {
     /// Must not exceed 100000.
@@ -266,6 +296,7 @@ pub struct AmountFraction {
     pub parts_per_hundred_thousand: u32,
 }
 /// Distribution of the rewards for the particular pool.
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct CommissionRates {
     /// Fraction of finalization rewards charged by the pool owner.
@@ -280,6 +311,7 @@ pub struct CommissionRates {
 }
 /// Additional information about a baking pool.
 /// This information is added with the introduction of delegation.
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct BakerPoolInfo {
     /// Whether the pool allows delegators.
@@ -294,6 +326,7 @@ pub struct BakerPoolInfo {
 }
 /// Information about the account stake, if the account is either a baker or a
 /// delegator.
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct AccountStakingInfo {
     #[prost(oneof = "account_staking_info::StakingInfo", tags = "1, 2")]
@@ -301,6 +334,7 @@ pub struct AccountStakingInfo {
 }
 /// Nested message and enum types in `AccountStakingInfo`.
 pub mod account_staking_info {
+    #[allow(clippy::derive_partial_eq_without_eq)]
     #[derive(Clone, PartialEq, ::prost::Message)]
     pub struct Baker {
         /// Amount staked at present.
@@ -321,6 +355,7 @@ pub mod account_staking_info {
         #[prost(message, optional, tag = "5")]
         pub pool_info:        ::core::option::Option<super::BakerPoolInfo>,
     }
+    #[allow(clippy::derive_partial_eq_without_eq)]
     #[derive(Clone, PartialEq, ::prost::Message)]
     pub struct Delegator {
         /// The amount that the account delegates.
@@ -336,6 +371,7 @@ pub mod account_staking_info {
         #[prost(message, optional, tag = "4")]
         pub pending_change:   ::core::option::Option<super::StakePendingChange>,
     }
+    #[allow(clippy::derive_partial_eq_without_eq)]
     #[derive(Clone, PartialEq, ::prost::Oneof)]
     pub enum StakingInfo {
         /// The account is a baker.
@@ -348,6 +384,7 @@ pub mod account_staking_info {
 }
 /// A sequence number that determines the ordering of transactions from the
 /// account. The minimum sequence number is 1.
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct SequenceNumber {
     /// The sequence number.
@@ -357,6 +394,7 @@ pub struct SequenceNumber {
 /// A sequence number that determines the ordering of update transactions.
 /// Equivalent to `SequenceNumber` for account transactions.
 /// Update sequence numbers are per update type and the minimum value is 1.
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct UpdateSequenceNumber {
     /// The sequence number.
@@ -364,42 +402,49 @@ pub struct UpdateSequenceNumber {
     pub value: u64,
 }
 /// An amount of microCCD.
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct Amount {
     #[prost(uint64, tag = "1")]
     pub value: u64,
 }
 /// Index of a credential on an account.
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct CredentialIndex {
     #[prost(uint32, tag = "1")]
     pub value: u32,
 }
 /// The number of signatures required to sign.
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct SignatureThreshold {
     #[prost(uint32, tag = "1")]
     pub value: u32,
 }
 /// The number of credentials required to sign an account transaction.
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct AccountThreshold {
     #[prost(uint32, tag = "1")]
     pub value: u32,
 }
 /// An account encryption key. Always 96 bytes.
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct EncryptionKey {
     #[prost(bytes = "vec", tag = "1")]
     pub value: ::prost::alloc::vec::Vec<u8>,
 }
 /// An address of an account. Always 32 bytes.
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct AccountAddress {
     #[prost(bytes = "vec", tag = "1")]
     pub value: ::prost::alloc::vec::Vec<u8>,
 }
 /// An address of either a contract or an account.
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct Address {
     #[prost(oneof = "address::Type", tags = "1, 2")]
@@ -407,6 +452,7 @@ pub struct Address {
 }
 /// Nested message and enum types in `Address`.
 pub mod address {
+    #[allow(clippy::derive_partial_eq_without_eq)]
     #[derive(Clone, PartialEq, ::prost::Oneof)]
     pub enum Type {
         #[prost(message, tag = "1")]
@@ -416,6 +462,7 @@ pub mod address {
     }
 }
 /// A public key used to verify transaction signatures from an account.
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct AccountVerifyKey {
     #[prost(oneof = "account_verify_key::Key", tags = "1")]
@@ -423,6 +470,7 @@ pub struct AccountVerifyKey {
 }
 /// Nested message and enum types in `AccountVerifyKey`.
 pub mod account_verify_key {
+    #[allow(clippy::derive_partial_eq_without_eq)]
     #[derive(Clone, PartialEq, ::prost::Oneof)]
     pub enum Key {
         #[prost(bytes, tag = "1")]
@@ -430,6 +478,7 @@ pub mod account_verify_key {
     }
 }
 /// Public keys of a single credential.
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct CredentialPublicKeys {
     #[prost(map = "uint32, message", tag = "1")]
@@ -439,6 +488,7 @@ pub struct CredentialPublicKeys {
 }
 /// A registration ID of a credential, derived from the secret PRF key and a
 /// nonce. This is always 48 bytes long.
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct CredentialRegistrationId {
     #[prost(bytes = "vec", tag = "1")]
@@ -446,12 +496,14 @@ pub struct CredentialRegistrationId {
 }
 /// An index of the identity provider that identifies them uniquely in the
 /// context of a specific chain.
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct IdentityProviderIdentity {
     #[prost(uint32, tag = "1")]
     pub value: u32,
 }
 /// Representation of the pair of a year and month.
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct YearMonth {
     #[prost(uint32, tag = "1")]
@@ -460,6 +512,7 @@ pub struct YearMonth {
     pub month: u32,
 }
 /// Policy on a credential.
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct Policy {
     /// The year and month when the identity object from which the credential is
@@ -477,6 +530,7 @@ pub struct Policy {
     pub attributes: ::std::collections::HashMap<u32, ::prost::alloc::vec::Vec<u8>>,
 }
 /// Values contained in an initial credential.
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct InitialCredentialValues {
     /// Public keys of the credential.
@@ -495,6 +549,7 @@ pub struct InitialCredentialValues {
 }
 /// Data relating to a single anonymity revoker sent by the account holder to
 /// the chain.
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct ChainArData {
     /// Share of the encryption of IdCredPub.
@@ -503,6 +558,7 @@ pub struct ChainArData {
 }
 /// The number of anonymity revokers needed to revoke anonymity of a credential
 /// holder.
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct ArThreshold {
     #[prost(uint32, tag = "1")]
@@ -510,12 +566,14 @@ pub struct ArThreshold {
 }
 /// A single commitment in the G1 group of the BLS curve. This is always 48
 /// bytes in length.
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct Commitment {
     #[prost(bytes = "vec", tag = "1")]
     pub value: ::prost::alloc::vec::Vec<u8>,
 }
 /// Commitments that are part of a normal credential.
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct CredentialCommitments {
     /// Commitment to the PRF key.
@@ -540,6 +598,7 @@ pub struct CredentialCommitments {
     pub id_cred_sec_sharing_coeff: ::prost::alloc::vec::Vec<Commitment>,
 }
 /// Values contained in a normal (non-initial) credential.
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct NormalCredentialValues {
     /// Public keys of the credential.
@@ -568,6 +627,7 @@ pub struct NormalCredentialValues {
     pub commitments:  ::core::option::Option<CredentialCommitments>,
 }
 /// Credential that is part of an account.
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct AccountCredential {
     #[prost(oneof = "account_credential::CredentialValues", tags = "1, 2")]
@@ -575,6 +635,7 @@ pub struct AccountCredential {
 }
 /// Nested message and enum types in `AccountCredential`.
 pub mod account_credential {
+    #[allow(clippy::derive_partial_eq_without_eq)]
     #[derive(Clone, PartialEq, ::prost::Oneof)]
     pub enum CredentialValues {
         #[prost(message, tag = "1")]
@@ -584,6 +645,7 @@ pub mod account_credential {
     }
 }
 /// Information about the account at a particular point in time.
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct AccountInfo {
     /// Next sequence number to be used for transactions signed from this
@@ -630,6 +692,7 @@ pub struct AccountInfo {
     pub address:           ::core::option::Option<AccountAddress>,
 }
 /// Input to queries which take a block as a parameter.
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct BlockHashInput {
     #[prost(oneof = "block_hash_input::BlockHashInput", tags = "1, 2, 3")]
@@ -637,6 +700,7 @@ pub struct BlockHashInput {
 }
 /// Nested message and enum types in `BlockHashInput`.
 pub mod block_hash_input {
+    #[allow(clippy::derive_partial_eq_without_eq)]
     #[derive(Clone, PartialEq, ::prost::Oneof)]
     pub enum BlockHashInput {
         /// Query for the best block.
@@ -652,6 +716,7 @@ pub mod block_hash_input {
     }
 }
 /// Input to queries which take an account as a parameter.
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct AccountIdentifierInput {
     #[prost(
@@ -663,6 +728,7 @@ pub struct AccountIdentifierInput {
 }
 /// Nested message and enum types in `AccountIdentifierInput`.
 pub mod account_identifier_input {
+    #[allow(clippy::derive_partial_eq_without_eq)]
     #[derive(Clone, PartialEq, ::prost::Oneof)]
     pub enum AccountIdentifierInput {
         /// Identify the account by the address of the account.
@@ -678,6 +744,7 @@ pub mod account_identifier_input {
     }
 }
 /// Request for account information.
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct AccountInfoRequest {
     /// Block in which to query the account information.
@@ -688,6 +755,7 @@ pub struct AccountInfoRequest {
     pub account_identifier: ::core::option::Option<AccountIdentifierInput>,
 }
 /// Information about a finalized block that is part of the streaming response.
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct FinalizedBlockInfo {
     /// Hash of the block.
@@ -698,6 +766,7 @@ pub struct FinalizedBlockInfo {
     pub height: ::core::option::Option<AbsoluteBlockHeight>,
 }
 /// Request the ancestors for the given block.
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct AncestorsRequest {
     /// The block to get ancestors of.
@@ -708,6 +777,7 @@ pub struct AncestorsRequest {
     pub amount:     u64,
 }
 /// Request for getting the source of a smart contract module.
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct ModuleSourceRequest {
     /// The block to be used for the query.
@@ -718,6 +788,7 @@ pub struct ModuleSourceRequest {
     pub module_ref: ::core::option::Option<ModuleRef>,
 }
 /// Address of a smart contract instance.
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct ContractAddress {
     /// The index of the smart contract.
@@ -729,6 +800,7 @@ pub struct ContractAddress {
     pub subindex: u64,
 }
 /// Request for getting information about a smart contract instance.
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct InstanceInfoRequest {
     /// The block to be used for the query.
@@ -739,6 +811,7 @@ pub struct InstanceInfoRequest {
     pub address:    ::core::option::Option<ContractAddress>,
 }
 /// Information about a smart contract instance.
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct InstanceInfo {
     /// The information depends on the smart contract version used by the
@@ -749,6 +822,7 @@ pub struct InstanceInfo {
 /// Nested message and enum types in `InstanceInfo`.
 pub mod instance_info {
     /// Version 0 smart contract instance information.
+    #[allow(clippy::derive_partial_eq_without_eq)]
     #[derive(Clone, PartialEq, ::prost::Message)]
     pub struct V0 {
         /// The state of the instance.
@@ -771,6 +845,7 @@ pub mod instance_info {
         pub source_module: ::core::option::Option<super::ModuleRef>,
     }
     /// Version 1 smart contract instance information.
+    #[allow(clippy::derive_partial_eq_without_eq)]
     #[derive(Clone, PartialEq, ::prost::Message)]
     pub struct V1 {
         /// The account address which deployed the instance.
@@ -791,6 +866,7 @@ pub mod instance_info {
     }
     /// The information depends on the smart contract version used by the
     /// instance.
+    #[allow(clippy::derive_partial_eq_without_eq)]
     #[derive(Clone, PartialEq, ::prost::Oneof)]
     pub enum Version {
         #[prost(message, tag = "1")]
@@ -800,6 +876,7 @@ pub mod instance_info {
     }
 }
 /// A smart contract instance key-value pair.
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct InstanceStateKvPair {
     #[prost(bytes = "vec", tag = "1")]
@@ -808,6 +885,7 @@ pub struct InstanceStateKvPair {
     pub value: ::prost::alloc::vec::Vec<u8>,
 }
 /// Request for a specific key of a smart contract instance state.
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct InstanceStateLookupRequest {
     /// The block to be used for the query.
@@ -823,6 +901,7 @@ pub struct InstanceStateLookupRequest {
 }
 /// Value at the requested key of a smart contract instance state. For V0
 /// contracts this will always be the entire state of the contract.
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct InstanceStateValueAtKey {
     #[prost(bytes = "vec", tag = "1")]
@@ -831,6 +910,7 @@ pub struct InstanceStateValueAtKey {
 /// The receive name of a smart contract function. Expected format:
 /// `<contract_name>.<func_name>`. It must only consist of atmost 100 ASCII
 /// alphanumeric or punctuation characters, and must contain a '.'.
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct ReceiveName {
     #[prost(string, tag = "1")]
@@ -840,24 +920,28 @@ pub struct ReceiveName {
 /// `init_<contract_name>`. It must only consist of atmost 100 ASCII
 /// alphanumeric or punctuation characters, must not contain a '.' and must
 /// start with 'init_'.
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct InitName {
     #[prost(string, tag = "1")]
     pub value: ::prost::alloc::string::String,
 }
 /// Parameter to a smart contract initialization or invocation.
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct Parameter {
     #[prost(bytes = "vec", tag = "1")]
     pub value: ::prost::alloc::vec::Vec<u8>,
 }
 /// A smart contract v0 state.
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct ContractStateV0 {
     #[prost(bytes = "vec", tag = "1")]
     pub value: ::prost::alloc::vec::Vec<u8>,
 }
 /// Status of a block item known to the node.
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct BlockItemStatus {
     #[prost(oneof = "block_item_status::Status", tags = "1, 2, 3")]
@@ -865,16 +949,19 @@ pub struct BlockItemStatus {
 }
 /// Nested message and enum types in `BlockItemStatus`.
 pub mod block_item_status {
+    #[allow(clippy::derive_partial_eq_without_eq)]
     #[derive(Clone, PartialEq, ::prost::Message)]
     pub struct Committed {
         #[prost(message, repeated, tag = "1")]
         pub outcomes: ::prost::alloc::vec::Vec<super::BlockItemSummaryInBlock>,
     }
+    #[allow(clippy::derive_partial_eq_without_eq)]
     #[derive(Clone, PartialEq, ::prost::Message)]
     pub struct Finalized {
         #[prost(message, optional, tag = "1")]
         pub outcome: ::core::option::Option<super::BlockItemSummaryInBlock>,
     }
+    #[allow(clippy::derive_partial_eq_without_eq)]
     #[derive(Clone, PartialEq, ::prost::Oneof)]
     pub enum Status {
         /// Block item is received, but not yet in any blocks.
@@ -892,6 +979,7 @@ pub mod block_item_status {
     }
 }
 /// A block item summary together with a block hash. Used in BlockItemStatus.
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct BlockItemSummaryInBlock {
     /// The block hash.
@@ -903,18 +991,21 @@ pub struct BlockItemSummaryInBlock {
 }
 /// Energy is used to count exact execution cost.
 /// This cost is then converted to CCD amounts.
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct Energy {
     #[prost(uint64, tag = "1")]
     pub value: u64,
 }
 /// A number representing a slot for baking a block.
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct Slot {
     #[prost(uint64, tag = "1")]
     pub value: u64,
 }
 /// The response for getNextAccountSequenceNumber.
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct NextAccountSequenceNumber {
     /// The best guess for the available account sequence number.
@@ -926,6 +1017,7 @@ pub struct NextAccountSequenceNumber {
     pub all_final:       bool,
 }
 /// A duration of milliseconds.
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct Duration {
     #[prost(uint64, tag = "1")]
@@ -934,6 +1026,7 @@ pub struct Duration {
 /// A reason for why a transaction was rejected. Rejected means included in a
 /// block, but the desired action was not achieved. The only effect of a
 /// rejected transaction is payment.
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct RejectReason {
     #[prost(
@@ -946,6 +1039,7 @@ pub struct RejectReason {
 }
 /// Nested message and enum types in `RejectReason`.
 pub mod reject_reason {
+    #[allow(clippy::derive_partial_eq_without_eq)]
     #[derive(Clone, PartialEq, ::prost::Message)]
     pub struct InvalidInitMethod {
         #[prost(message, optional, tag = "1")]
@@ -953,6 +1047,7 @@ pub mod reject_reason {
         #[prost(message, optional, tag = "2")]
         pub init_name:  ::core::option::Option<super::InitName>,
     }
+    #[allow(clippy::derive_partial_eq_without_eq)]
     #[derive(Clone, PartialEq, ::prost::Message)]
     pub struct InvalidReceiveMethod {
         #[prost(message, optional, tag = "1")]
@@ -960,6 +1055,7 @@ pub mod reject_reason {
         #[prost(message, optional, tag = "2")]
         pub receive_name: ::core::option::Option<super::ReceiveName>,
     }
+    #[allow(clippy::derive_partial_eq_without_eq)]
     #[derive(Clone, PartialEq, ::prost::Message)]
     pub struct AmountTooLarge {
         #[prost(message, optional, tag = "1")]
@@ -967,11 +1063,13 @@ pub mod reject_reason {
         #[prost(message, optional, tag = "2")]
         pub amount:  ::core::option::Option<super::Amount>,
     }
+    #[allow(clippy::derive_partial_eq_without_eq)]
     #[derive(Clone, PartialEq, ::prost::Message)]
     pub struct RejectedInit {
         #[prost(int32, tag = "1")]
         pub reject_reason: i32,
     }
+    #[allow(clippy::derive_partial_eq_without_eq)]
     #[derive(Clone, PartialEq, ::prost::Message)]
     pub struct RejectedReceive {
         #[prost(int32, tag = "1")]
@@ -983,16 +1081,19 @@ pub mod reject_reason {
         #[prost(message, optional, tag = "4")]
         pub parameter:        ::core::option::Option<super::Parameter>,
     }
+    #[allow(clippy::derive_partial_eq_without_eq)]
     #[derive(Clone, PartialEq, ::prost::Message)]
     pub struct DuplicateCredIds {
         #[prost(message, repeated, tag = "1")]
         pub ids: ::prost::alloc::vec::Vec<super::CredentialRegistrationId>,
     }
+    #[allow(clippy::derive_partial_eq_without_eq)]
     #[derive(Clone, PartialEq, ::prost::Message)]
     pub struct NonExistentCredIds {
         #[prost(message, repeated, tag = "1")]
         pub ids: ::prost::alloc::vec::Vec<super::CredentialRegistrationId>,
     }
+    #[allow(clippy::derive_partial_eq_without_eq)]
     #[derive(Clone, PartialEq, ::prost::Oneof)]
     pub enum Reason {
         /// Raised while validating a Wasm module that is not well formed.
@@ -1184,6 +1285,7 @@ pub mod reject_reason {
     }
 }
 /// Data generated as part of initializing a single contract instance.
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct ContractInitializedEvent {
     /// Contract version.
@@ -1207,6 +1309,7 @@ pub struct ContractInitializedEvent {
     pub events:           ::prost::alloc::vec::Vec<ContractEvent>,
 }
 /// An event generated by a smart contract.
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct ContractEvent {
     #[prost(bytes = "vec", tag = "1")]
@@ -1215,6 +1318,7 @@ pub struct ContractEvent {
 /// Data generated as part of updating a single contract instance.
 /// In general a single Update transaction will
 /// generate one or more of these events, together with possibly some transfers.
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct InstanceUpdatedEvent {
     /// Contract version.
@@ -1243,6 +1347,7 @@ pub struct InstanceUpdatedEvent {
 }
 /// Effects produced by successful smart contract invocations.
 /// A single invocation will produce a sequence of these effects.
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct ContractTraceElement {
     #[prost(oneof = "contract_trace_element::Element", tags = "1, 2, 3, 4, 5")]
@@ -1251,6 +1356,7 @@ pub struct ContractTraceElement {
 /// Nested message and enum types in `ContractTraceElement`.
 pub mod contract_trace_element {
     /// A contract transferred an amount to an account.
+    #[allow(clippy::derive_partial_eq_without_eq)]
     #[derive(Clone, PartialEq, ::prost::Message)]
     pub struct Transferred {
         /// Sender contract.
@@ -1266,6 +1372,7 @@ pub mod contract_trace_element {
     /// A contract was interrupted.
     /// This occurs when a contract invokes another contract or makes a transfer
     /// to an account.
+    #[allow(clippy::derive_partial_eq_without_eq)]
     #[derive(Clone, PartialEq, ::prost::Message)]
     pub struct Interrupted {
         /// The contract interrupted.
@@ -1276,6 +1383,7 @@ pub mod contract_trace_element {
         pub events:  ::prost::alloc::vec::Vec<super::ContractEvent>,
     }
     /// A previously interrupted contract was resumed.
+    #[allow(clippy::derive_partial_eq_without_eq)]
     #[derive(Clone, PartialEq, ::prost::Message)]
     pub struct Resumed {
         /// The contract resumed.
@@ -1287,6 +1395,7 @@ pub mod contract_trace_element {
         pub success: bool,
     }
     /// A previously interrupted contract was resumed.
+    #[allow(clippy::derive_partial_eq_without_eq)]
     #[derive(Clone, PartialEq, ::prost::Message)]
     pub struct Upgraded {
         /// The that was upgraded.
@@ -1299,6 +1408,7 @@ pub mod contract_trace_element {
         #[prost(message, optional, tag = "3")]
         pub to:      ::core::option::Option<super::ModuleRef>,
     }
+    #[allow(clippy::derive_partial_eq_without_eq)]
     #[derive(Clone, PartialEq, ::prost::Oneof)]
     pub enum Element {
         /// A contract instance was updated.
@@ -1321,6 +1431,7 @@ pub mod contract_trace_element {
     }
 }
 /// Result of a successful change of baker keys.
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct BakerKeysEvent {
     /// ID of the baker whose keys were changed.
@@ -1341,11 +1452,13 @@ pub struct BakerKeysEvent {
     pub aggregation_key: ::core::option::Option<BakerAggregationVerifyKey>,
 }
 /// A memo which can be included as part of a transfer. Max size is 256 bytes.
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct Memo {
     #[prost(bytes = "vec", tag = "1")]
     pub value: ::prost::alloc::vec::Vec<u8>,
 }
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct BakerStakeUpdatedData {
     /// Affected baker.
@@ -1361,6 +1474,7 @@ pub struct BakerStakeUpdatedData {
 }
 /// Event generated when one or more encrypted amounts are consumed from the
 /// account.
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct EncryptedAmountRemovedEvent {
     /// The affected account.
@@ -1377,6 +1491,7 @@ pub struct EncryptedAmountRemovedEvent {
     pub up_to_index:  u64,
 }
 /// Event generated when an account receives a new encrypted amount.
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct NewEncryptedAmountEvent {
     /// The account onto which the amount was added.
@@ -1389,6 +1504,7 @@ pub struct NewEncryptedAmountEvent {
     #[prost(message, optional, tag = "3")]
     pub encrypted_amount: ::core::option::Option<EncryptedAmount>,
 }
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct EncryptedSelfAmountAddedEvent {
     /// The affected account.
@@ -1402,12 +1518,14 @@ pub struct EncryptedSelfAmountAddedEvent {
     pub amount:     ::core::option::Option<Amount>,
 }
 /// Data registered on the chain with a register data transaction.
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct RegisteredData {
     #[prost(bytes = "vec", tag = "1")]
     pub value: ::prost::alloc::vec::Vec<u8>,
 }
 /// Events that may result from the ConfigureBaker transaction.
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct BakerEvent {
     #[prost(
@@ -1419,6 +1537,7 @@ pub struct BakerEvent {
 /// Nested message and enum types in `BakerEvent`.
 pub mod baker_event {
     /// A baker was added.
+    #[allow(clippy::derive_partial_eq_without_eq)]
     #[derive(Clone, PartialEq, ::prost::Message)]
     pub struct BakerAdded {
         /// The keys with which the baker registered.
@@ -1434,6 +1553,7 @@ pub mod baker_event {
         pub restake_earnings: bool,
     }
     /// Baker stake increased.
+    #[allow(clippy::derive_partial_eq_without_eq)]
     #[derive(Clone, PartialEq, ::prost::Message)]
     pub struct BakerStakeIncreased {
         /// Baker's id.
@@ -1443,6 +1563,7 @@ pub mod baker_event {
         #[prost(message, optional, tag = "2")]
         pub new_stake: ::core::option::Option<super::Amount>,
     }
+    #[allow(clippy::derive_partial_eq_without_eq)]
     #[derive(Clone, PartialEq, ::prost::Message)]
     pub struct BakerStakeDecreased {
         /// Baker's id.
@@ -1452,6 +1573,7 @@ pub mod baker_event {
         #[prost(message, optional, tag = "2")]
         pub new_stake: ::core::option::Option<super::Amount>,
     }
+    #[allow(clippy::derive_partial_eq_without_eq)]
     #[derive(Clone, PartialEq, ::prost::Message)]
     pub struct BakerRestakeEarningsUpdated {
         /// Baker's id.
@@ -1462,6 +1584,7 @@ pub mod baker_event {
         pub restake_earnings: bool,
     }
     /// Updated open status for a baker pool.
+    #[allow(clippy::derive_partial_eq_without_eq)]
     #[derive(Clone, PartialEq, ::prost::Message)]
     pub struct BakerSetOpenStatus {
         /// Baker's id.
@@ -1472,6 +1595,7 @@ pub mod baker_event {
         pub open_status: i32,
     }
     /// Updated metadata url for a baker pool.
+    #[allow(clippy::derive_partial_eq_without_eq)]
     #[derive(Clone, PartialEq, ::prost::Message)]
     pub struct BakerSetMetadataUrl {
         /// Baker's id.
@@ -1482,6 +1606,7 @@ pub mod baker_event {
         pub url:      ::prost::alloc::string::String,
     }
     /// Updated transaction fee commission for a baker pool.
+    #[allow(clippy::derive_partial_eq_without_eq)]
     #[derive(Clone, PartialEq, ::prost::Message)]
     pub struct BakerSetTransactionFeeCommission {
         /// Baker's id.
@@ -1492,6 +1617,7 @@ pub mod baker_event {
         pub transaction_fee_commission: ::core::option::Option<super::AmountFraction>,
     }
     /// Updated baking reward commission for baker pool
+    #[allow(clippy::derive_partial_eq_without_eq)]
     #[derive(Clone, PartialEq, ::prost::Message)]
     pub struct BakerSetBakingRewardCommission {
         /// Baker's id
@@ -1502,6 +1628,7 @@ pub mod baker_event {
         pub baking_reward_commission: ::core::option::Option<super::AmountFraction>,
     }
     /// Updated finalization reward commission for baker pool
+    #[allow(clippy::derive_partial_eq_without_eq)]
     #[derive(Clone, PartialEq, ::prost::Message)]
     pub struct BakerSetFinalizationRewardCommission {
         /// Baker's id
@@ -1511,6 +1638,7 @@ pub mod baker_event {
         #[prost(message, optional, tag = "2")]
         pub finalization_reward_commission: ::core::option::Option<super::AmountFraction>,
     }
+    #[allow(clippy::derive_partial_eq_without_eq)]
     #[derive(Clone, PartialEq, ::prost::Oneof)]
     pub enum Event {
         /// A baker was added.
@@ -1549,11 +1677,13 @@ pub mod baker_event {
     }
 }
 /// The identifier for a delegator.
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct DelegatorId {
     #[prost(message, optional, tag = "1")]
     pub id: ::core::option::Option<AccountIndex>,
 }
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct DelegationEvent {
     #[prost(oneof = "delegation_event::Event", tags = "1, 2, 3, 4, 5, 6")]
@@ -1561,6 +1691,7 @@ pub struct DelegationEvent {
 }
 /// Nested message and enum types in `DelegationEvent`.
 pub mod delegation_event {
+    #[allow(clippy::derive_partial_eq_without_eq)]
     #[derive(Clone, PartialEq, ::prost::Message)]
     pub struct DelegationStakeIncreased {
         /// Delegator's id
@@ -1570,6 +1701,7 @@ pub mod delegation_event {
         #[prost(message, optional, tag = "2")]
         pub new_stake:    ::core::option::Option<super::Amount>,
     }
+    #[allow(clippy::derive_partial_eq_without_eq)]
     #[derive(Clone, PartialEq, ::prost::Message)]
     pub struct DelegationStakeDecreased {
         /// Delegator's id
@@ -1579,6 +1711,7 @@ pub mod delegation_event {
         #[prost(message, optional, tag = "2")]
         pub new_stake:    ::core::option::Option<super::Amount>,
     }
+    #[allow(clippy::derive_partial_eq_without_eq)]
     #[derive(Clone, PartialEq, ::prost::Message)]
     pub struct DelegationSetRestakeEarnings {
         /// Delegator's id
@@ -1588,6 +1721,7 @@ pub mod delegation_event {
         #[prost(bool, tag = "2")]
         pub restake_earnings: bool,
     }
+    #[allow(clippy::derive_partial_eq_without_eq)]
     #[derive(Clone, PartialEq, ::prost::Message)]
     pub struct DelegationSetDelegationTarget {
         /// Delegator's id
@@ -1597,6 +1731,7 @@ pub mod delegation_event {
         #[prost(message, optional, tag = "2")]
         pub delegation_target: ::core::option::Option<super::DelegationTarget>,
     }
+    #[allow(clippy::derive_partial_eq_without_eq)]
     #[derive(Clone, PartialEq, ::prost::Oneof)]
     pub enum Event {
         /// The delegator's stake increased.
@@ -1621,6 +1756,7 @@ pub mod delegation_event {
 }
 /// Effects of an account transaction. All variants except `None`
 /// correspond to a unique transaction that was successful.
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct AccountTransactionEffects {
     #[prost(
@@ -1633,6 +1769,7 @@ pub struct AccountTransactionEffects {
 pub mod account_transaction_effects {
     /// No effects other than payment from this transaction.
     /// The rejection reason indicates why the transaction failed.
+    #[allow(clippy::derive_partial_eq_without_eq)]
     #[derive(Clone, PartialEq, ::prost::Message)]
     pub struct None {
         /// Transaction type of a failed transaction, if known.
@@ -1645,6 +1782,7 @@ pub mod account_transaction_effects {
     }
     /// A contract update transaction was issued and produced the given trace.
     /// This is the result of Update transaction.
+    #[allow(clippy::derive_partial_eq_without_eq)]
     #[derive(Clone, PartialEq, ::prost::Message)]
     pub struct ContractUpdateIssued {
         #[prost(message, repeated, tag = "1")]
@@ -1652,6 +1790,7 @@ pub mod account_transaction_effects {
     }
     /// A simple account to account transfer occurred. This is the result of a
     /// successful Transfer transaction.
+    #[allow(clippy::derive_partial_eq_without_eq)]
     #[derive(Clone, PartialEq, ::prost::Message)]
     pub struct AccountTransfer {
         /// Amount that was transferred.
@@ -1666,6 +1805,7 @@ pub mod account_transaction_effects {
     }
     /// An account was deregistered as a baker. This is the result of a
     /// successful UpdateBakerStake transaction.
+    #[allow(clippy::derive_partial_eq_without_eq)]
     #[derive(Clone, PartialEq, ::prost::Message)]
     pub struct BakerStakeUpdated {
         /// If the stake was updated (that is, it changed and did not stay the
@@ -1675,6 +1815,7 @@ pub mod account_transaction_effects {
     }
     /// An encrypted amount was transferred. This is the result of a successful
     /// EncryptedAmountTransfer transaction.
+    #[allow(clippy::derive_partial_eq_without_eq)]
     #[derive(Clone, PartialEq, ::prost::Message)]
     pub struct EncryptedAmountTransferred {
         #[prost(message, optional, tag = "1")]
@@ -1687,6 +1828,7 @@ pub mod account_transaction_effects {
     /// An account transferred part of its encrypted balance to its public
     /// balance. This is the result of a successful TransferToPublic
     /// transaction.
+    #[allow(clippy::derive_partial_eq_without_eq)]
     #[derive(Clone, PartialEq, ::prost::Message)]
     pub struct TransferredToPublic {
         #[prost(message, optional, tag = "1")]
@@ -1696,6 +1838,7 @@ pub mod account_transaction_effects {
     }
     /// A transfer with schedule was performed. This is the result of a
     /// successful TransferWithSchedule transaction.
+    #[allow(clippy::derive_partial_eq_without_eq)]
     #[derive(Clone, PartialEq, ::prost::Message)]
     pub struct TransferredWithSchedule {
         /// Receiver account.
@@ -1710,6 +1853,7 @@ pub mod account_transaction_effects {
     }
     /// Account's credentials were updated. This is the result of a
     /// successful UpdateCredentials transaction.
+    #[allow(clippy::derive_partial_eq_without_eq)]
     #[derive(Clone, PartialEq, ::prost::Message)]
     pub struct CredentialsUpdated {
         /// The credential ids that were added.
@@ -1724,6 +1868,7 @@ pub mod account_transaction_effects {
     }
     /// A baker was configured. The details of what happened are contained in
     /// the list of BakerEvents.
+    #[allow(clippy::derive_partial_eq_without_eq)]
     #[derive(Clone, PartialEq, ::prost::Message)]
     pub struct BakerConfigured {
         #[prost(message, repeated, tag = "1")]
@@ -1731,11 +1876,13 @@ pub mod account_transaction_effects {
     }
     /// An account configured delegation. The details of what happened are
     /// contained in the list of DelegationEvents.
+    #[allow(clippy::derive_partial_eq_without_eq)]
     #[derive(Clone, PartialEq, ::prost::Message)]
     pub struct DelegationConfigured {
         #[prost(message, repeated, tag = "1")]
         pub events: ::prost::alloc::vec::Vec<super::DelegationEvent>,
     }
+    #[allow(clippy::derive_partial_eq_without_eq)]
     #[derive(Clone, PartialEq, ::prost::Oneof)]
     pub enum Effect {
         /// No effects other than payment from this transaction.
@@ -1803,18 +1950,67 @@ pub mod account_transaction_effects {
     }
 }
 /// Election difficulty parameter.
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct ElectionDifficulty {
     #[prost(message, optional, tag = "1")]
     pub value: ::core::option::Option<AmountFraction>,
 }
+/// Parameters that determine timeouts in the consensus protocol used from
+/// protocol version 6.
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct TimeoutParameters {
+    /// The base value for triggering a timeout
+    #[prost(message, optional, tag = "1")]
+    pub timeout_base:     ::core::option::Option<Duration>,
+    /// Factor for increasing the timeout. Must be greater than 1.
+    #[prost(message, optional, tag = "2")]
+    pub timeout_increase: ::core::option::Option<Ratio>,
+    /// Factor for decreasing the timeout. Must be between 0 and 1.
+    #[prost(message, optional, tag = "3")]
+    pub timeout_decrease: ::core::option::Option<Ratio>,
+}
+/// Finalization committee parameters used from protocol version 6
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct FinalizationCommitteeParameters {
+    /// The minimum size of a finalization committee before
+    /// `finalizer_relative_stake_threshold` takes effect.
+    #[prost(uint32, tag = "1")]
+    pub minimum_finalizers:                 u32,
+    /// The maximum size of a finalization committee.
+    #[prost(uint32, tag = "2")]
+    pub maximum_finalizers:                 u32,
+    /// The threshold for determining the stake required for being eligible the
+    /// finalization committee. The amount is given by `total stake in pools
+    /// * finalizer_relative_stake_threshold`
+    #[prost(message, optional, tag = "3")]
+    pub finalizer_relative_stake_threshold: ::core::option::Option<AmountFraction>,
+}
+/// Parameters for the consensus protocol used from protocol version 6.
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct ConsensusParametersV1 {
+    /// Parameters controlling round timeouts.
+    #[prost(message, optional, tag = "1")]
+    pub timeout_parameters: ::core::option::Option<TimeoutParameters>,
+    /// Minimum time interval between blocks.
+    #[prost(message, optional, tag = "2")]
+    pub min_block_time:     ::core::option::Option<Duration>,
+    /// Maximum energy allowed per block.
+    #[prost(message, optional, tag = "3")]
+    pub block_energy_limit: ::core::option::Option<Energy>,
+}
 /// Represents an exchange rate.
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct ExchangeRate {
     #[prost(message, optional, tag = "1")]
     pub value: ::core::option::Option<Ratio>,
 }
 /// Represents a ratio, i.e., 'numerator / denominator'.
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct Ratio {
     /// The numerator.
@@ -1825,6 +2021,7 @@ pub struct Ratio {
     pub denominator: u64,
 }
 /// A public key used for chain updates.
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct UpdatePublicKey {
     #[prost(bytes = "vec", tag = "1")]
@@ -1832,6 +2029,7 @@ pub struct UpdatePublicKey {
 }
 /// The threshold for how many UpdatePublicKeys are need to make a certain chain
 /// update.
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct UpdateKeysThreshold {
     /// Is ensured to be within between 1 and 2^16.
@@ -1839,12 +2037,14 @@ pub struct UpdateKeysThreshold {
     pub value: u32,
 }
 /// Index of a key in an authorizations update payload.
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct UpdateKeysIndex {
     #[prost(uint32, tag = "1")]
     pub value: u32,
 }
 /// Represents root or level 1 keys.
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct HigherLevelKeys {
     /// The keys.
@@ -1858,6 +2058,7 @@ pub struct HigherLevelKeys {
 /// HigherLevelKeys that are allowed to make chain update of a specific type.
 /// The threshold defines the minimum number of allowed keys needed to make the
 /// actual update.
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct AccessStructure {
     /// Unique indexes into the set of keys in AuthorizationV0.
@@ -1870,6 +2071,7 @@ pub struct AccessStructure {
 /// The set of keys authorized for chain updates, together with access
 /// structures determining which keys are authorized for which update types.
 /// This is the payload of an update to authorization.
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct AuthorizationsV0 {
     /// The set of keys authorized for chain updates.
@@ -1881,9 +2083,10 @@ pub struct AuthorizationsV0 {
     /// New protocol update keys.
     #[prost(message, optional, tag = "3")]
     pub protocol: ::core::option::Option<AccessStructure>,
-    /// Access structure for updating the election difficulty.
+    /// Access structure for updating the consensus parameters.
+    /// Previously, this was the election difficulty.
     #[prost(message, optional, tag = "4")]
-    pub parameter_election_difficulty: ::core::option::Option<AccessStructure>,
+    pub parameter_consensus: ::core::option::Option<AccessStructure>,
     /// Access structure for updating the euro per energy.
     #[prost(message, optional, tag = "5")]
     pub parameter_euro_per_energy: ::core::option::Option<AccessStructure>,
@@ -1916,6 +2119,7 @@ pub struct AuthorizationsV0 {
 /// The set of keys authorized for chain updates, together with access
 /// structures determining which keys are authorized for which update types.
 /// This is the payload of an update to authorization.
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct AuthorizationsV1 {
     #[prost(message, optional, tag = "1")]
@@ -1930,6 +2134,7 @@ pub struct AuthorizationsV1 {
 }
 /// Description either of an anonymity revoker or identity provider.
 /// Metadata that should be visible on the chain.
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct Description {
     /// The name.
@@ -1945,6 +2150,7 @@ pub struct Description {
 }
 /// Information on a single anonymity revoker help by the identity provider.
 /// Typically an identity provider will hold more than one.
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct ArInfo {
     /// Unique identifier of the anonymity revoker.
@@ -1961,12 +2167,14 @@ pub struct ArInfo {
 pub mod ar_info {
     /// Identity of the anonymity revoker on the chain. This defines their
     /// evaluateion point for secret sharing, and thus it cannot be 0.
+    #[allow(clippy::derive_partial_eq_without_eq)]
     #[derive(Clone, PartialEq, ::prost::Message)]
     pub struct ArIdentity {
         #[prost(uint32, tag = "1")]
         pub value: u32,
     }
     /// Public key of an anonymity revoker.
+    #[allow(clippy::derive_partial_eq_without_eq)]
     #[derive(Clone, PartialEq, ::prost::Message)]
     pub struct ArPublicKey {
         #[prost(bytes = "vec", tag = "1")]
@@ -1976,12 +2184,14 @@ pub mod ar_info {
 /// A succinct identifier of an identity provider on the chain.
 /// In credential deployments, and other interactions with the chain this is
 /// used to identify which identity provider is meant.
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct IpIdentity {
     #[prost(uint32, tag = "1")]
     pub value: u32,
 }
 /// Public information about an identity provider.
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct IpInfo {
     /// Unique identifier of the identity provider.
@@ -2000,12 +2210,14 @@ pub struct IpInfo {
 /// Nested message and enum types in `IpInfo`.
 pub mod ip_info {
     /// Pointcheval-Sanders public key of the identity provider.
+    #[allow(clippy::derive_partial_eq_without_eq)]
     #[derive(Clone, PartialEq, ::prost::Message)]
     pub struct IpVerifyKey {
         #[prost(bytes = "vec", tag = "1")]
         pub value: ::prost::alloc::vec::Vec<u8>,
     }
     /// Ed25519 public key of the identity provider.
+    #[allow(clippy::derive_partial_eq_without_eq)]
     #[derive(Clone, PartialEq, ::prost::Message)]
     pub struct IpCdiVerifyKey {
         #[prost(bytes = "vec", tag = "1")]
@@ -2013,12 +2225,14 @@ pub mod ip_info {
     }
 }
 /// A duration in seconds.
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct DurationSeconds {
     #[prost(uint64, tag = "1")]
     pub value: u64,
 }
 /// Inclusive range of amount fractions.
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct InclusiveRangeAmountFraction {
     #[prost(message, optional, tag = "1")]
@@ -2027,6 +2241,7 @@ pub struct InclusiveRangeAmountFraction {
     pub max: ::core::option::Option<AmountFraction>,
 }
 /// Ranges of allowed commission values that pools may choose from.
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct CommissionRanges {
     /// The range of allowed finalization commissions.
@@ -2041,18 +2256,21 @@ pub struct CommissionRanges {
 }
 /// A bound on the relative share of the total staked capital that a baker can
 /// have as its stake. This is required to be greater than 0.
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct CapitalBound {
     #[prost(message, optional, tag = "1")]
     pub value: ::core::option::Option<AmountFraction>,
 }
 /// A leverage factor.
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct LeverageFactor {
     #[prost(message, optional, tag = "1")]
     pub value: ::core::option::Option<Ratio>,
 }
 /// A chain epoch.
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct Epoch {
     #[prost(uint64, tag = "1")]
@@ -2060,6 +2278,7 @@ pub struct Epoch {
 }
 /// Length of a reward period in epochs.
 /// Must always be a strictly positive number.
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct RewardPeriodLength {
     #[prost(message, optional, tag = "1")]
@@ -2067,6 +2286,7 @@ pub struct RewardPeriodLength {
 }
 /// A minting rate of CCD.
 /// The value is `mantissa * 10^(-exponent)`.
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct MintRate {
     #[prost(uint32, tag = "1")]
@@ -2075,6 +2295,7 @@ pub struct MintRate {
     #[prost(uint32, tag = "2")]
     pub exponent: u32,
 }
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct CooldownParametersCpv1 {
     /// Number of seconds that pool owners must cooldown
@@ -2087,6 +2308,7 @@ pub struct CooldownParametersCpv1 {
     pub delegator_cooldown:  ::core::option::Option<DurationSeconds>,
 }
 /// Parameters related to staking pools.
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct PoolParametersCpv1 {
     /// Fraction of finalization rewards charged by the passive delegation.
@@ -2116,6 +2338,7 @@ pub struct PoolParametersCpv1 {
 /// The time parameters are introduced as of protocol version 4, and consist of
 /// the reward period length and the mint rate per payday. These are coupled as
 /// a change to either affects the overall rate of minting.
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct TimeParametersCpv1 {
     #[prost(message, optional, tag = "1")]
@@ -2124,6 +2347,7 @@ pub struct TimeParametersCpv1 {
     pub mint_per_payday:      ::core::option::Option<MintRate>,
 }
 /// Mint distribution payload as it looks in protocol version 4 and onward.
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct MintDistributionCpv1 {
     #[prost(message, optional, tag = "1")]
@@ -2131,6 +2355,7 @@ pub struct MintDistributionCpv1 {
     #[prost(message, optional, tag = "2")]
     pub finalization_reward: ::core::option::Option<AmountFraction>,
 }
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct ProtocolUpdate {
     /// A brief message about the update.
@@ -2150,6 +2375,7 @@ pub struct ProtocolUpdate {
 /// finalizers, and the foundation account. It must be the case that
 /// baking_reward + finalization_reward <= 1. The remaining amount is the
 /// platform development charge.
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct MintDistributionCpv0 {
     /// Mint rate per slot.
@@ -2163,6 +2389,7 @@ pub struct MintDistributionCpv0 {
     pub finalization_reward: ::core::option::Option<AmountFraction>,
 }
 /// Parameters determining the distribution of transaction fees.
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct TransactionFeeDistribution {
     /// The fraction allocated to the baker.
@@ -2172,7 +2399,8 @@ pub struct TransactionFeeDistribution {
     #[prost(message, optional, tag = "2")]
     pub gas_account: ::core::option::Option<AmountFraction>,
 }
-/// Distribution of gas rewards.
+/// Distribution of gas rewards for chain parameters version 0 and 1.
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct GasRewards {
     /// The fraction paid to the baker.
@@ -2189,8 +2417,24 @@ pub struct GasRewards {
     #[prost(message, optional, tag = "4")]
     pub chain_update:       ::core::option::Option<AmountFraction>,
 }
+/// Distribution of gas rewards for chain parameters version 2.
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct GasRewardsCpv2 {
+    /// The fraction paid to the baker.
+    #[prost(message, optional, tag = "1")]
+    pub baker:            ::core::option::Option<AmountFraction>,
+    /// Fraction paid for including each account creation transaction in a
+    /// block.
+    #[prost(message, optional, tag = "3")]
+    pub account_creation: ::core::option::Option<AmountFraction>,
+    /// Fraction paid for including an update transaction in a block.
+    #[prost(message, optional, tag = "4")]
+    pub chain_update:     ::core::option::Option<AmountFraction>,
+}
 /// Minimum stake needed to become a baker. This only applies to protocol
 /// version 1-3.
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct BakerStakeThreshold {
     /// Minimum threshold required for registering as a baker.
@@ -2200,6 +2444,7 @@ pub struct BakerStakeThreshold {
 /// Root updates are the highest kind of key updates. They can update every
 /// other set of keys, even themselves. They can only be performed by Root level
 /// keys.
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct RootUpdate {
     #[prost(oneof = "root_update::UpdateType", tags = "1, 2, 3, 4")]
@@ -2207,6 +2452,7 @@ pub struct RootUpdate {
 }
 /// Nested message and enum types in `RootUpdate`.
 pub mod root_update {
+    #[allow(clippy::derive_partial_eq_without_eq)]
     #[derive(Clone, PartialEq, ::prost::Oneof)]
     pub enum UpdateType {
         /// The root keys were updated.
@@ -2227,6 +2473,7 @@ pub mod root_update {
 /// Level 1 updates are the intermediate update kind.
 /// They can update themselves or level 2 keys. They can only be performed by
 /// level 1 keys.
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct Level1Update {
     #[prost(oneof = "level1_update::UpdateType", tags = "1, 2, 3")]
@@ -2234,6 +2481,7 @@ pub struct Level1Update {
 }
 /// Nested message and enum types in `Level1Update`.
 pub mod level1_update {
+    #[allow(clippy::derive_partial_eq_without_eq)]
     #[derive(Clone, PartialEq, ::prost::Oneof)]
     pub enum UpdateType {
         /// The level 1 keys were updated.
@@ -2249,16 +2497,18 @@ pub mod level1_update {
     }
 }
 /// The payload of a chain update.
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct UpdatePayload {
     #[prost(
         oneof = "update_payload::Payload",
-        tags = "1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17"
+        tags = "1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22"
     )]
     pub payload: ::core::option::Option<update_payload::Payload>,
 }
 /// Nested message and enum types in `UpdatePayload`.
 pub mod update_payload {
+    #[allow(clippy::derive_partial_eq_without_eq)]
     #[derive(Clone, PartialEq, ::prost::Oneof)]
     pub enum Payload {
         /// The protocol version was updated.
@@ -2312,9 +2562,26 @@ pub mod update_payload {
         /// The mint distribution was updated.
         #[prost(message, tag = "17")]
         MintDistributionCpv1Update(super::MintDistributionCpv1),
+        /// The gas rewards were updated (chain parameters version 2).
+        #[prost(message, tag = "18")]
+        GasRewardsCpv2Update(super::GasRewardsCpv2),
+        /// The consensus timeouts were updated (chain parameters version 2).
+        #[prost(message, tag = "19")]
+        TimeoutParametersUpdate(super::TimeoutParameters),
+        /// The minimum time between blocks was updated (chain parameters
+        /// version 2).
+        #[prost(message, tag = "20")]
+        MinBlockTimeUpdate(super::Duration),
+        /// The block energy limit was updated (chain parameters version 2).
+        #[prost(message, tag = "21")]
+        BlockEnergyLimitUpdate(super::Energy),
+        /// Finalization committee parameters (chain parameters version 2).
+        #[prost(message, tag = "22")]
+        FinalizationCommitteeParametersUpdate(super::FinalizationCommitteeParameters),
     }
 }
 /// Details about an account transaction.
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct AccountTransactionDetails {
     /// The cost of the transaction. Paid by the sender.
@@ -2330,6 +2597,7 @@ pub struct AccountTransactionDetails {
 /// Details of an account creation. These transactions are free, and we only
 /// ever get a response for them if the account is created, hence no failure
 /// cases.
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct AccountCreationDetails {
     /// Whether this is an initial or normal account.
@@ -2343,6 +2611,7 @@ pub struct AccountCreationDetails {
     pub reg_id:          ::core::option::Option<CredentialRegistrationId>,
 }
 /// Transaction time specified as seconds since unix epoch.
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct TransactionTime {
     #[prost(uint64, tag = "1")]
@@ -2351,6 +2620,7 @@ pub struct TransactionTime {
 /// Details of an update instruction. These are free, and we only ever get a
 /// response for them if the update is successfully enqueued, hence no failure
 /// cases.
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct UpdateDetails {
     /// The time at which the update will be effective.
@@ -2362,6 +2632,7 @@ pub struct UpdateDetails {
 }
 /// Summary of the outcome of a block item in structured form.
 /// The summary determines which transaction type it was.
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct BlockItemSummary {
     /// Index of the transaction in the block where it is included.
@@ -2379,12 +2650,14 @@ pub struct BlockItemSummary {
 }
 /// Nested message and enum types in `BlockItemSummary`.
 pub mod block_item_summary {
+    #[allow(clippy::derive_partial_eq_without_eq)]
     #[derive(Clone, PartialEq, ::prost::Message)]
     pub struct TransactionIndex {
         #[prost(uint64, tag = "1")]
         pub value: u64,
     }
     /// Details that are specific to different transaction types.
+    #[allow(clippy::derive_partial_eq_without_eq)]
     #[derive(Clone, PartialEq, ::prost::Oneof)]
     pub enum Details {
         /// Detailsa about an account transaction.
@@ -2402,12 +2675,14 @@ pub mod block_item_summary {
 /// protocol update instruction might not change the protocol version
 /// specified in the previous field, but it always increments the genesis
 /// index.
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct GenesisIndex {
     #[prost(uint32, tag = "1")]
     pub value: u32,
 }
 /// The response for GetConsensusInfo.
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct ConsensusInfo {
     /// Hash of the current best block.
@@ -2514,6 +2789,7 @@ pub struct ConsensusInfo {
     pub current_era_genesis_time:    ::core::option::Option<Timestamp>,
 }
 /// Information about an arrived block that is part of the streaming response.
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct ArrivedBlockInfo {
     /// Hash of the block.
@@ -2524,6 +2800,7 @@ pub struct ArrivedBlockInfo {
     pub height: ::core::option::Option<AbsoluteBlockHeight>,
 }
 /// The response for GetCryptographicParameters.
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct CryptographicParameters {
     /// A free-form string used to distinguish between different chains even if
@@ -2544,6 +2821,7 @@ pub struct CryptographicParameters {
     pub on_chain_commitment_key: ::prost::alloc::vec::Vec<u8>,
 }
 /// The response for GetBlockInfo.
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct BlockInfo {
     /// Hash of the block.
@@ -2601,6 +2879,7 @@ pub struct BlockInfo {
     pub state_hash:               ::core::option::Option<StateHash>,
 }
 /// Request for GetPoolInfo.
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct PoolInfoRequest {
     /// Block in which to query the pool information.
@@ -2611,6 +2890,7 @@ pub struct PoolInfoRequest {
     pub baker:      ::core::option::Option<BakerId>,
 }
 /// A pending change to a baker pool.
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct PoolPendingChange {
     #[prost(oneof = "pool_pending_change::Change", tags = "1, 2")]
@@ -2619,6 +2899,7 @@ pub struct PoolPendingChange {
 /// Nested message and enum types in `PoolPendingChange`.
 pub mod pool_pending_change {
     /// A reduction in baker equity capital is pending.
+    #[allow(clippy::derive_partial_eq_without_eq)]
     #[derive(Clone, PartialEq, ::prost::Message)]
     pub struct Reduce {
         /// New baker equity capital.
@@ -2629,12 +2910,14 @@ pub mod pool_pending_change {
         pub effective_time:         ::core::option::Option<super::Timestamp>,
     }
     /// Removal of the pool is pending.
+    #[allow(clippy::derive_partial_eq_without_eq)]
     #[derive(Clone, PartialEq, ::prost::Message)]
     pub struct Remove {
         /// Timestamp when the change takes effect.
         #[prost(message, optional, tag = "1")]
         pub effective_time: ::core::option::Option<super::Timestamp>,
     }
+    #[allow(clippy::derive_partial_eq_without_eq)]
     #[derive(Clone, PartialEq, ::prost::Oneof)]
     pub enum Change {
         #[prost(message, tag = "1")]
@@ -2644,6 +2927,7 @@ pub mod pool_pending_change {
     }
 }
 /// Information about a baker pool in the current reward period.
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct PoolCurrentPaydayInfo {
     /// The number of blocks baked in the current reward period.
@@ -2672,6 +2956,7 @@ pub struct PoolCurrentPaydayInfo {
 }
 /// Type for the response of GetPoolInfo.
 /// Contains information about a given pool at the end of a given block.
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct PoolInfoResponse {
     /// The 'BakerId' of the pool owner.
@@ -2706,6 +2991,7 @@ pub struct PoolInfoResponse {
 }
 /// Type for the response of GetPassiveDelegationInfo.
 /// Contains information about passive delegators at the end of a given block.
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct PassiveDelegationInfo {
     /// The total capital delegated passively.
@@ -2727,6 +3013,7 @@ pub struct PassiveDelegationInfo {
     pub all_pool_total_capital: ::core::option::Option<Amount>,
 }
 /// Request for GetBlocksAtHeight.
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct BlocksAtHeightRequest {
     #[prost(oneof = "blocks_at_height_request::BlocksAtHeight", tags = "1, 2")]
@@ -2735,6 +3022,7 @@ pub struct BlocksAtHeightRequest {
 /// Nested message and enum types in `BlocksAtHeightRequest`.
 pub mod blocks_at_height_request {
     /// Request using an absolute block height.
+    #[allow(clippy::derive_partial_eq_without_eq)]
     #[derive(Clone, PartialEq, ::prost::Message)]
     pub struct Absolute {
         /// The absolute block height.
@@ -2742,6 +3030,7 @@ pub mod blocks_at_height_request {
         pub height: ::core::option::Option<super::AbsoluteBlockHeight>,
     }
     /// Request using a relative block height.
+    #[allow(clippy::derive_partial_eq_without_eq)]
     #[derive(Clone, PartialEq, ::prost::Message)]
     pub struct Relative {
         /// Genesis index to start from.
@@ -2756,6 +3045,7 @@ pub mod blocks_at_height_request {
         #[prost(bool, tag = "3")]
         pub restrict:      bool,
     }
+    #[allow(clippy::derive_partial_eq_without_eq)]
     #[derive(Clone, PartialEq, ::prost::Oneof)]
     pub enum BlocksAtHeight {
         #[prost(message, tag = "1")]
@@ -2765,6 +3055,7 @@ pub mod blocks_at_height_request {
     }
 }
 /// Response for GetBlocksAtHeight.
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct BlocksAtHeightResponse {
     /// Live blocks at the given height.
@@ -2773,6 +3064,7 @@ pub struct BlocksAtHeightResponse {
 }
 /// Type for the response of GetTokenomicsInfo.
 /// Contains information related to tokenomics at the end of a given block.
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct TokenomicsInfo {
     #[prost(oneof = "tokenomics_info::Tokenomics", tags = "1, 2")]
@@ -2781,6 +3073,7 @@ pub struct TokenomicsInfo {
 /// Nested message and enum types in `TokenomicsInfo`.
 pub mod tokenomics_info {
     /// Version 0 tokenomics.
+    #[allow(clippy::derive_partial_eq_without_eq)]
     #[derive(Clone, PartialEq, ::prost::Message)]
     pub struct V0 {
         /// The total CCD in existence.
@@ -2803,6 +3096,7 @@ pub mod tokenomics_info {
         pub protocol_version:            i32,
     }
     /// Version 1 tokenomics.
+    #[allow(clippy::derive_partial_eq_without_eq)]
     #[derive(Clone, PartialEq, ::prost::Message)]
     pub struct V1 {
         /// The total CCD in existence.
@@ -2838,6 +3132,7 @@ pub mod tokenomics_info {
         #[prost(enumeration = "super::ProtocolVersion", tag = "10")]
         pub protocol_version:               i32,
     }
+    #[allow(clippy::derive_partial_eq_without_eq)]
     #[derive(Clone, PartialEq, ::prost::Oneof)]
     pub enum Tokenomics {
         #[prost(message, tag = "1")]
@@ -2847,6 +3142,7 @@ pub mod tokenomics_info {
     }
 }
 /// Request for InvokeInstance.
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct InvokeInstanceRequest {
     /// Block to invoke the contract. The invocation will be at the end of the
@@ -2879,6 +3175,7 @@ pub struct InvokeInstanceRequest {
     pub energy:     ::core::option::Option<Energy>,
 }
 /// Response type for InvokeInstance.
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct InvokeInstanceResponse {
     #[prost(oneof = "invoke_instance_response::Result", tags = "1, 2")]
@@ -2887,6 +3184,7 @@ pub struct InvokeInstanceResponse {
 /// Nested message and enum types in `InvokeInstanceResponse`.
 pub mod invoke_instance_response {
     /// Contract execution failed.
+    #[allow(clippy::derive_partial_eq_without_eq)]
     #[derive(Clone, PartialEq, ::prost::Message)]
     pub struct Failure {
         /// If invoking a V0 contract this is not provided, otherwise it is
@@ -2904,6 +3202,7 @@ pub mod invoke_instance_response {
         pub reason:       ::core::option::Option<super::RejectReason>,
     }
     /// Contract execution succeeded.
+    #[allow(clippy::derive_partial_eq_without_eq)]
     #[derive(Clone, PartialEq, ::prost::Message)]
     pub struct Success {
         /// If invoking a V0 contract this is absent. Otherwise it is the return
@@ -2917,6 +3216,7 @@ pub mod invoke_instance_response {
         #[prost(message, repeated, tag = "3")]
         pub effects:      ::prost::alloc::vec::Vec<super::ContractTraceElement>,
     }
+    #[allow(clippy::derive_partial_eq_without_eq)]
     #[derive(Clone, PartialEq, ::prost::Oneof)]
     pub enum Result {
         #[prost(message, tag = "1")]
@@ -2926,6 +3226,7 @@ pub mod invoke_instance_response {
     }
 }
 /// Request for GetPoolDelegators and GetPoolDelegatorsRewardPeriod.
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct GetPoolDelegatorsRequest {
     /// Block in which to query the delegators.
@@ -2936,6 +3237,7 @@ pub struct GetPoolDelegatorsRequest {
     pub baker:      ::core::option::Option<BakerId>,
 }
 /// Stream item for GetPoolDelegators and GetPassiveDelegators.
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct DelegatorInfo {
     /// The delegator account address.
@@ -2950,6 +3252,7 @@ pub struct DelegatorInfo {
 }
 /// Stream item for GetPoolDelegatorsRewardPeriod and
 /// GetPassiveDelegatorsRewardPeriod.
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct DelegatorRewardPeriodInfo {
     /// The delegator account address.
@@ -2960,6 +3263,7 @@ pub struct DelegatorRewardPeriodInfo {
     pub stake:   ::core::option::Option<Amount>,
 }
 /// Response type for GetBranches.
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct Branch {
     /// The hash of the block.
@@ -2972,6 +3276,7 @@ pub struct Branch {
 /// The leadership election nonce is an unpredictable value updated once an
 /// epoch to make sure that bakers cannot predict too far in the future when
 /// they will win the right to bake blocks.
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct LeadershipElectionNonce {
     #[prost(bytes = "vec", tag = "1")]
@@ -2979,6 +3284,7 @@ pub struct LeadershipElectionNonce {
 }
 /// Response type for GetElectionInfo.
 /// Contains information related to baker election for a perticular block.
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct ElectionInfo {
     /// Baking lottery election difficulty.
@@ -2993,6 +3299,7 @@ pub struct ElectionInfo {
 }
 /// Nested message and enum types in `ElectionInfo`.
 pub mod election_info {
+    #[allow(clippy::derive_partial_eq_without_eq)]
     #[derive(Clone, PartialEq, ::prost::Message)]
     pub struct Baker {
         /// The ID of the baker.
@@ -3010,6 +3317,7 @@ pub mod election_info {
 /// A protocol generated event that is not directly caused by a transaction.
 /// This includes minting new CCD, rewarding different bakers and delegators,
 /// etc.
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct BlockSpecialEvent {
     #[prost(oneof = "block_special_event::Event", tags = "1, 2, 3, 4, 5, 6, 7, 8")]
@@ -3018,6 +3326,7 @@ pub struct BlockSpecialEvent {
 /// Nested message and enum types in `BlockSpecialEvent`.
 pub mod block_special_event {
     /// A representation of a mapping from an account address to an amount.
+    #[allow(clippy::derive_partial_eq_without_eq)]
     #[derive(Clone, PartialEq, ::prost::Message)]
     pub struct AccountAmounts {
         #[prost(message, repeated, tag = "1")]
@@ -3026,6 +3335,7 @@ pub mod block_special_event {
     /// Nested message and enum types in `AccountAmounts`.
     pub mod account_amounts {
         /// The entry for the map.
+        #[allow(clippy::derive_partial_eq_without_eq)]
         #[derive(Clone, PartialEq, ::prost::Message)]
         pub struct Entry {
             /// The key type
@@ -3038,6 +3348,7 @@ pub mod block_special_event {
     }
     /// Payment to each baker of a previous epoch, in proportion to the number
     /// of blocks they contributed.
+    #[allow(clippy::derive_partial_eq_without_eq)]
     #[derive(Clone, PartialEq, ::prost::Message)]
     pub struct BakingRewards {
         /// The amount awarded to each baker.
@@ -3048,6 +3359,7 @@ pub mod block_special_event {
         pub remainder:     ::core::option::Option<super::Amount>,
     }
     /// Minting of new CCD.
+    #[allow(clippy::derive_partial_eq_without_eq)]
     #[derive(Clone, PartialEq, ::prost::Message)]
     pub struct Mint {
         /// The amount allocated to the banking reward account.
@@ -3065,6 +3377,7 @@ pub mod block_special_event {
     }
     /// Payment to each finalizer on inclusion of a finalization record in a
     /// block.
+    #[allow(clippy::derive_partial_eq_without_eq)]
     #[derive(Clone, PartialEq, ::prost::Message)]
     pub struct FinalizationRewards {
         /// The amount awarded to each finalizer.
@@ -3079,6 +3392,7 @@ pub mod block_special_event {
     ///
     /// ```transaction_fees + old_gas_account = new_gas_account + baker_reward +
     /// foundation_charge```
+    #[allow(clippy::derive_partial_eq_without_eq)]
     #[derive(Clone, PartialEq, ::prost::Message)]
     pub struct BlockReward {
         /// The total fees paid for transactions in the block.
@@ -3104,6 +3418,7 @@ pub mod block_special_event {
         pub foundation_account: ::core::option::Option<super::AccountAddress>,
     }
     /// Foundation tax.
+    #[allow(clippy::derive_partial_eq_without_eq)]
     #[derive(Clone, PartialEq, ::prost::Message)]
     pub struct PaydayFoundationReward {
         /// The account that got rewarded.
@@ -3114,6 +3429,7 @@ pub mod block_special_event {
         pub development_charge: ::core::option::Option<super::Amount>,
     }
     /// Reward payment to the given account.
+    #[allow(clippy::derive_partial_eq_without_eq)]
     #[derive(Clone, PartialEq, ::prost::Message)]
     pub struct PaydayAccountReward {
         /// The account that got rewarded.
@@ -3130,6 +3446,7 @@ pub mod block_special_event {
         pub finalization_reward: ::core::option::Option<super::Amount>,
     }
     /// Amounts accrued to accounts for each baked block.
+    #[allow(clippy::derive_partial_eq_without_eq)]
     #[derive(Clone, PartialEq, ::prost::Message)]
     pub struct BlockAccrueReward {
         /// The total fees paid for transactions in the block.
@@ -3155,6 +3472,7 @@ pub mod block_special_event {
         pub baker:             ::core::option::Option<super::BakerId>,
     }
     /// Payment distributed to a pool or passive delegators.
+    #[allow(clippy::derive_partial_eq_without_eq)]
     #[derive(Clone, PartialEq, ::prost::Message)]
     pub struct PaydayPoolReward {
         /// The pool owner (passive delegators when not present).
@@ -3170,6 +3488,7 @@ pub mod block_special_event {
         #[prost(message, optional, tag = "4")]
         pub finalization_reward: ::core::option::Option<super::Amount>,
     }
+    #[allow(clippy::derive_partial_eq_without_eq)]
     #[derive(Clone, PartialEq, ::prost::Oneof)]
     pub enum Event {
         #[prost(message, tag = "1")]
@@ -3191,6 +3510,7 @@ pub mod block_special_event {
     }
 }
 /// A pending update.
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct PendingUpdate {
     /// The effective time of the update.
@@ -3199,13 +3519,15 @@ pub struct PendingUpdate {
     /// The effect of the update.
     #[prost(
         oneof = "pending_update::Effect",
-        tags = "2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20"
+        tags = "2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, \
+                24, 25"
     )]
     pub effect:         ::core::option::Option<pending_update::Effect>,
 }
 /// Nested message and enum types in `PendingUpdate`.
 pub mod pending_update {
     /// The effect of the update.
+    #[allow(clippy::derive_partial_eq_without_eq)]
     #[derive(Clone, PartialEq, ::prost::Oneof)]
     pub enum Effect {
         /// Updates to the root keys.
@@ -3269,64 +3591,97 @@ pub mod pending_update {
         /// in protocol version 4.
         #[prost(message, tag = "20")]
         TimeParameters(super::TimeParametersCpv1),
+        /// Updates to the GAS rewards effective from protocol version 6 (chain
+        /// parameters version 2).
+        #[prost(message, tag = "21")]
+        GasRewardsCpv2(super::GasRewardsCpv2),
+        /// Updates to the consensus timeouts for chain parameters version 2.
+        #[prost(message, tag = "22")]
+        TimeoutParameters(super::TimeoutParameters),
+        /// Updates to the the minimum time between blocks for chain parameters
+        /// version 2.
+        #[prost(message, tag = "23")]
+        MinBlockTime(super::Duration),
+        /// Updates to the block energy limit for chain parameters version 2.
+        #[prost(message, tag = "24")]
+        BlockEnergyLimit(super::Energy),
+        /// Updates to the finalization committee for for chain parameters
+        /// version 2.
+        #[prost(message, tag = "25")]
+        FinalizationCommitteeParameters(super::FinalizationCommitteeParameters),
     }
 }
 /// The response for `GetNextUpdateSequenceNumbers`.
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct NextUpdateSequenceNumbers {
     /// Updates to the root keys.
     #[prost(message, optional, tag = "1")]
-    pub root_keys:                    ::core::option::Option<SequenceNumber>,
+    pub root_keys: ::core::option::Option<SequenceNumber>,
     /// Updates to the level 1 keys.
     #[prost(message, optional, tag = "2")]
-    pub level1_keys:                  ::core::option::Option<SequenceNumber>,
+    pub level1_keys: ::core::option::Option<SequenceNumber>,
     /// Updates to the level 2 keys.
     #[prost(message, optional, tag = "3")]
-    pub level2_keys:                  ::core::option::Option<SequenceNumber>,
+    pub level2_keys: ::core::option::Option<SequenceNumber>,
     /// Protocol updates.
     #[prost(message, optional, tag = "4")]
-    pub protocol:                     ::core::option::Option<SequenceNumber>,
+    pub protocol: ::core::option::Option<SequenceNumber>,
     /// Updates to the election difficulty parameter.
     #[prost(message, optional, tag = "5")]
-    pub election_difficulty:          ::core::option::Option<SequenceNumber>,
+    pub election_difficulty: ::core::option::Option<SequenceNumber>,
     /// Updates to the euro:energy exchange rate.
     #[prost(message, optional, tag = "6")]
-    pub euro_per_energy:              ::core::option::Option<SequenceNumber>,
+    pub euro_per_energy: ::core::option::Option<SequenceNumber>,
     /// Updates to the CCD:EUR exchange rate.
     #[prost(message, optional, tag = "7")]
-    pub micro_ccd_per_euro:           ::core::option::Option<SequenceNumber>,
+    pub micro_ccd_per_euro: ::core::option::Option<SequenceNumber>,
     /// Updates to the foundation account.
     #[prost(message, optional, tag = "8")]
-    pub foundation_account:           ::core::option::Option<SequenceNumber>,
+    pub foundation_account: ::core::option::Option<SequenceNumber>,
     /// Updates to the mint distribution.
     #[prost(message, optional, tag = "9")]
-    pub mint_distribution:            ::core::option::Option<SequenceNumber>,
+    pub mint_distribution: ::core::option::Option<SequenceNumber>,
     /// Updates to the transaction fee distribution.
     #[prost(message, optional, tag = "10")]
     pub transaction_fee_distribution: ::core::option::Option<SequenceNumber>,
     /// Updates to the GAS rewards.
     #[prost(message, optional, tag = "11")]
-    pub gas_rewards:                  ::core::option::Option<SequenceNumber>,
+    pub gas_rewards: ::core::option::Option<SequenceNumber>,
     /// Updates pool parameters.
     #[prost(message, optional, tag = "12")]
-    pub pool_parameters:              ::core::option::Option<SequenceNumber>,
+    pub pool_parameters: ::core::option::Option<SequenceNumber>,
     /// Adds a new anonymity revoker.
     #[prost(message, optional, tag = "13")]
-    pub add_anonymity_revoker:        ::core::option::Option<SequenceNumber>,
+    pub add_anonymity_revoker: ::core::option::Option<SequenceNumber>,
     /// Adds a new identity provider.
     #[prost(message, optional, tag = "14")]
-    pub add_identity_provider:        ::core::option::Option<SequenceNumber>,
+    pub add_identity_provider: ::core::option::Option<SequenceNumber>,
     /// Updates to cooldown parameters for chain parameters version 1 introduced
     /// in protocol version 4.
     #[prost(message, optional, tag = "15")]
-    pub cooldown_parameters:          ::core::option::Option<SequenceNumber>,
+    pub cooldown_parameters: ::core::option::Option<SequenceNumber>,
     /// Updates to time parameters for chain parameters version 1 introduced in
     /// protocol version 4.
     #[prost(message, optional, tag = "16")]
-    pub time_parameters:              ::core::option::Option<SequenceNumber>,
+    pub time_parameters: ::core::option::Option<SequenceNumber>,
+    /// Updates to the timeout parameters
+    #[prost(message, optional, tag = "17")]
+    pub timeout_parameters: ::core::option::Option<SequenceNumber>,
+    /// Updates to the the minimum time between blocks for chain parameters
+    /// version 2.
+    #[prost(message, optional, tag = "18")]
+    pub min_block_time: ::core::option::Option<SequenceNumber>,
+    /// Updates to the block energy limit for chain parameters version 2.
+    #[prost(message, optional, tag = "19")]
+    pub block_energy_limit: ::core::option::Option<SequenceNumber>,
+    /// Updates to the finalization committee parameters
+    #[prost(message, optional, tag = "20")]
+    pub finalization_committee_parameters: ::core::option::Option<SequenceNumber>,
 }
 /// A request to send a new block item to the chain.
 /// An IP address
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct IpAddress {
     #[prost(string, tag = "1")]
@@ -3335,6 +3690,7 @@ pub struct IpAddress {
 /// A port
 /// Valid port numbers are expected thus
 /// the value is expected to be in the range (0..u16::MAX).
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct Port {
     #[prost(uint32, tag = "1")]
@@ -3342,6 +3698,7 @@ pub struct Port {
 }
 /// A socket address consisting of
 /// an IP + port.
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct IpSocketAddress {
     #[prost(message, optional, tag = "1")]
@@ -3355,12 +3712,14 @@ pub struct IpSocketAddress {
 /// The underlying value is simply a u64.
 /// Note. There is no authenticity of the peer id and
 /// as such it is only used for logging purposes.
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct PeerId {
     #[prost(string, tag = "1")]
     pub value: ::prost::alloc::string::String,
 }
 /// A banned peer
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct BannedPeer {
     /// The IP address of the banned peer.
@@ -3369,6 +3728,7 @@ pub struct BannedPeer {
 }
 /// The banned peers given by
 /// their IP addresses.
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct BannedPeers {
     #[prost(message, repeated, tag = "1")]
@@ -3377,12 +3737,14 @@ pub struct BannedPeers {
 /// A peer to ban specified by its IP.
 /// Note. This will ban all peers located behind the
 /// specified IP even though they are using different ports.
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct PeerToBan {
     #[prost(message, optional, tag = "1")]
     pub ip_address: ::core::option::Option<IpAddress>,
 }
 /// Request to enable dumping of network packages.
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct DumpRequest {
     /// Which file to dump the packages into.
@@ -3394,6 +3756,7 @@ pub struct DumpRequest {
     pub raw:  bool,
 }
 /// Peers and their associated network related statistics
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct PeersInfo {
     #[prost(message, repeated, tag = "1")]
@@ -3402,6 +3765,7 @@ pub struct PeersInfo {
 /// Nested message and enum types in `PeersInfo`.
 pub mod peers_info {
     /// A peer that the node is connected to.
+    #[allow(clippy::derive_partial_eq_without_eq)]
     #[derive(Clone, PartialEq, ::prost::Message)]
     pub struct Peer {
         /// The identifier of the peer that it
@@ -3421,6 +3785,7 @@ pub mod peers_info {
     /// Nested message and enum types in `Peer`.
     pub mod peer {
         /// Network statistics for the peer
+        #[allow(clippy::derive_partial_eq_without_eq)]
         #[derive(Clone, PartialEq, ::prost::Message)]
         pub struct NetworkStats {
             /// The number of messages sent to the peer.
@@ -3478,8 +3843,20 @@ pub mod peers_info {
                     CatchupStatus::Catchingup => "CATCHINGUP",
                 }
             }
+
+            /// Creates an enum from field names used in the ProtoBuf
+            /// definition.
+            pub fn from_str_name(value: &str) -> ::core::option::Option<Self> {
+                match value {
+                    "UPTODATE" => Some(Self::Uptodate),
+                    "PENDING" => Some(Self::Pending),
+                    "CATCHINGUP" => Some(Self::Catchingup),
+                    _ => None,
+                }
+            }
         }
         /// consensus related information of the peer.
+        #[allow(clippy::derive_partial_eq_without_eq)]
         #[derive(Clone, PartialEq, ::prost::Oneof)]
         pub enum ConsensusInfo {
             /// The peer is of type `Bootstrapper` is not participating in
@@ -3496,6 +3873,7 @@ pub mod peers_info {
 /// Node info response
 /// Contains various information of the
 /// enquired node.
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct NodeInfo {
     /// The version of the node.
@@ -3518,6 +3896,7 @@ pub struct NodeInfo {
 /// Nested message and enum types in `NodeInfo`.
 pub mod node_info {
     /// Network related information of the node.
+    #[allow(clippy::derive_partial_eq_without_eq)]
     #[derive(Clone, PartialEq, ::prost::Message)]
     pub struct NetworkInfo {
         /// The node id.
@@ -3537,6 +3916,7 @@ pub mod node_info {
         pub avg_bps_out:         u64,
     }
     /// Consensus info for a node configured with baker keys.
+    #[allow(clippy::derive_partial_eq_without_eq)]
     #[derive(Clone, PartialEq, ::prost::Message)]
     pub struct BakerConsensusInfo {
         #[prost(message, optional, tag = "1")]
@@ -3550,11 +3930,13 @@ pub mod node_info {
         /// Tagging message type for a node that
         /// is configured with baker keys and active in
         /// the current baking committee
+        #[allow(clippy::derive_partial_eq_without_eq)]
         #[derive(Clone, PartialEq, ::prost::Message)]
         pub struct ActiveBakerCommitteeInfo {}
         /// Tagging message type for a node that
         /// is configured with baker keys and active in
         /// the current finalizer committee (and also baking committee).
+        #[allow(clippy::derive_partial_eq_without_eq)]
         #[derive(Clone, PartialEq, ::prost::Message)]
         pub struct ActiveFinalizerCommitteeInfo {}
         /// The committee information of a node configured with
@@ -3592,8 +3974,20 @@ pub mod node_info {
                     PassiveCommitteeInfo::AddedButWrongKeys => "ADDED_BUT_WRONG_KEYS",
                 }
             }
+
+            /// Creates an enum from field names used in the ProtoBuf
+            /// definition.
+            pub fn from_str_name(value: &str) -> ::core::option::Option<Self> {
+                match value {
+                    "NOT_IN_COMMITTEE" => Some(Self::NotInCommittee),
+                    "ADDED_BUT_NOT_ACTIVE_IN_COMMITTEE" => Some(Self::AddedButNotActiveInCommittee),
+                    "ADDED_BUT_WRONG_KEYS" => Some(Self::AddedButWrongKeys),
+                    _ => None,
+                }
+            }
         }
         /// Status of the baker configured node.
+        #[allow(clippy::derive_partial_eq_without_eq)]
         #[derive(Clone, PartialEq, ::prost::Oneof)]
         pub enum Status {
             /// The node is currently not baking.
@@ -3610,6 +4004,7 @@ pub mod node_info {
         }
     }
     /// The node is a regular node.
+    #[allow(clippy::derive_partial_eq_without_eq)]
     #[derive(Clone, PartialEq, ::prost::Message)]
     pub struct Node {
         #[prost(oneof = "node::ConsensusStatus", tags = "1, 2, 3")]
@@ -3617,6 +4012,7 @@ pub mod node_info {
     }
     /// Nested message and enum types in `Node`.
     pub mod node {
+        #[allow(clippy::derive_partial_eq_without_eq)]
         #[derive(Clone, PartialEq, ::prost::Oneof)]
         pub enum ConsensusStatus {
             /// The node is not running consensus.
@@ -3639,6 +4035,7 @@ pub mod node_info {
         }
     }
     /// Details of the node.
+    #[allow(clippy::derive_partial_eq_without_eq)]
     #[derive(Clone, PartialEq, ::prost::Oneof)]
     pub enum Details {
         /// The node is a bootstrapper and is not running consensus.
@@ -3650,6 +4047,7 @@ pub mod node_info {
         Node(Node),
     }
 }
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct SendBlockItemRequest {
     #[prost(oneof = "send_block_item_request::BlockItem", tags = "1, 2, 3")]
@@ -3657,6 +4055,7 @@ pub struct SendBlockItemRequest {
 }
 /// Nested message and enum types in `SendBlockItemRequest`.
 pub mod send_block_item_request {
+    #[allow(clippy::derive_partial_eq_without_eq)]
     #[derive(Clone, PartialEq, ::prost::Oneof)]
     pub enum BlockItem {
         /// Account transactions are messages which are signed and paid for by
@@ -3678,6 +4077,7 @@ pub mod send_block_item_request {
 /// Credential deployments create new accounts. They are not paid for
 /// directly by the sender. Instead, bakers are rewarded by the protocol for
 /// including them.
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct CredentialDeployment {
     #[prost(message, optional, tag = "1")]
@@ -3689,6 +4089,7 @@ pub struct CredentialDeployment {
 /// Nested message and enum types in `CredentialDeployment`.
 pub mod credential_deployment {
     /// The credential to be added.
+    #[allow(clippy::derive_partial_eq_without_eq)]
     #[derive(Clone, PartialEq, ::prost::Oneof)]
     pub enum Payload {
         /// A raw payload, which is just the encoded payload.
@@ -3699,6 +4100,7 @@ pub mod credential_deployment {
 }
 /// A single signature. Used when sending block items to a node with
 /// `SendBlockItem`.
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct Signature {
     #[prost(bytes = "vec", tag = "1")]
@@ -3706,6 +4108,7 @@ pub struct Signature {
 }
 /// Wrapper for a map from indexes to signatures.
 /// Needed because protobuf doesn't allow nested maps directly.
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct SignatureMap {
     #[prost(map = "uint32, message", tag = "1")]
@@ -3714,11 +4117,13 @@ pub struct SignatureMap {
 /// Wrapper for a map from indexes to signatures.
 /// Needed because protobuf doesn't allow nested maps directly.
 /// The keys in the SignatureMap must not exceed 2^8.
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct AccountSignatureMap {
     #[prost(map = "uint32, message", tag = "1")]
     pub signatures: ::std::collections::HashMap<u32, Signature>,
 }
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct AccountTransactionSignature {
     /// A map from `CredentialIndex` to `SignatureMap`s.
@@ -3730,6 +4135,7 @@ pub struct AccountTransactionSignature {
 /// Header of an account transaction that contains basic data to check whether
 /// the sender and the transaction are valid. The header is shared by all
 /// transaction types.
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct AccountTransactionHeader {
     /// Sender of the transaction.
@@ -3746,6 +4152,7 @@ pub struct AccountTransactionHeader {
     pub expiry:          ::core::option::Option<TransactionTime>,
 }
 /// Data required to initialize a new contract instance.
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct InitContractPayload {
     /// Amount of CCD to send to the instance.
@@ -3763,6 +4170,7 @@ pub struct InitContractPayload {
     pub parameter:  ::core::option::Option<Parameter>,
 }
 /// Data required to update a contract instance.
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct UpdateContractPayload {
     /// Amount of CCD to send to the instance.
@@ -3780,6 +4188,7 @@ pub struct UpdateContractPayload {
     pub parameter:    ::core::option::Option<Parameter>,
 }
 /// Payload of a transfer between two accounts.
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct TransferPayload {
     /// Amount of CCD to send.
@@ -3790,6 +4199,7 @@ pub struct TransferPayload {
     pub receiver: ::core::option::Option<AccountAddress>,
 }
 /// Payload of a transfer between two accounts with a memo.
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct TransferWithMemoPayload {
     /// Amount of CCD to send.
@@ -3803,6 +4213,7 @@ pub struct TransferWithMemoPayload {
     pub memo:     ::core::option::Option<Memo>,
 }
 /// The payload for an account transaction.
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct AccountTransactionPayload {
     #[prost(
@@ -3813,6 +4224,7 @@ pub struct AccountTransactionPayload {
 }
 /// Nested message and enum types in `AccountTransactionPayload`.
 pub mod account_transaction_payload {
+    #[allow(clippy::derive_partial_eq_without_eq)]
     #[derive(Clone, PartialEq, ::prost::Oneof)]
     pub enum Payload {
         /// A pre-serialized payload in the binary serialization format defined
@@ -3836,6 +4248,7 @@ pub mod account_transaction_payload {
 }
 /// An unsigned account transaction. This is used with the
 /// `GetTransactionSignHash` endpoint to obtain the message to sign.
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct PreAccountTransaction {
     #[prost(message, optional, tag = "1")]
@@ -3845,6 +4258,7 @@ pub struct PreAccountTransaction {
 }
 /// Account transactions are messages which are signed and paid for by the
 /// sender account.
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct AccountTransaction {
     #[prost(message, optional, tag = "1")]
@@ -3854,6 +4268,7 @@ pub struct AccountTransaction {
     #[prost(message, optional, tag = "3")]
     pub payload:   ::core::option::Option<AccountTransactionPayload>,
 }
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct UpdateInstructionSignature {
     /// A map from `UpdateKeysIndex` to `Signature`.
@@ -3862,6 +4277,7 @@ pub struct UpdateInstructionSignature {
     #[prost(map = "uint32, message", tag = "1")]
     pub signatures: ::std::collections::HashMap<u32, Signature>,
 }
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct UpdateInstructionHeader {
     #[prost(message, optional, tag = "1")]
@@ -3872,6 +4288,7 @@ pub struct UpdateInstructionHeader {
     pub timeout:         ::core::option::Option<TransactionTime>,
 }
 /// The payload for an UpdateInstruction.
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct UpdateInstructionPayload {
     #[prost(oneof = "update_instruction_payload::Payload", tags = "3")]
@@ -3879,6 +4296,7 @@ pub struct UpdateInstructionPayload {
 }
 /// Nested message and enum types in `UpdateInstructionPayload`.
 pub mod update_instruction_payload {
+    #[allow(clippy::derive_partial_eq_without_eq)]
     #[derive(Clone, PartialEq, ::prost::Oneof)]
     pub enum Payload {
         /// A raw payload encoded according to the format defined by the
@@ -3887,6 +4305,7 @@ pub mod update_instruction_payload {
         RawPayload(::prost::alloc::vec::Vec<u8>),
     }
 }
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct UpdateInstruction {
     /// A map from `UpdateKeysIndex` to `Signature`. Keys must not exceed 2^16.
@@ -3899,6 +4318,7 @@ pub struct UpdateInstruction {
 }
 /// Signature on an account transaction is defined to be the signature on the
 /// hash of the `PreAccountTransaction`.
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct AccountTransactionSignHash {
     #[prost(bytes = "vec", tag = "1")]
@@ -3906,12 +4326,14 @@ pub struct AccountTransactionSignHash {
 }
 /// The number of credential deployments allowed in a block. This in effect
 /// determines the number of accounts that can be created in a block.
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct CredentialsPerBlockLimit {
     #[prost(uint32, tag = "1")]
     pub value: u32,
 }
 /// Updatable chain parameters that apply to protocol versions 1-3.
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct ChainParametersV0 {
     /// Election difficulty for consensus lottery.
@@ -3955,7 +4377,8 @@ pub struct ChainParametersV0 {
     #[prost(message, optional, tag = "13")]
     pub level2_keys:                  ::core::option::Option<AuthorizationsV0>,
 }
-/// Updatable chain parameters that apply to protocol versions 1-3.
+/// Updatable chain parameters that apply to protocol versions 4-5.
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct ChainParametersV1 {
     /// Election difficulty for consensus lottery.
@@ -3971,6 +4394,9 @@ pub struct ChainParametersV1 {
     /// deregistration is completed.
     #[prost(message, optional, tag = "4")]
     pub cooldown_parameters:          ::core::option::Option<CooldownParametersCpv1>,
+    /// Current time parameters.
+    /// The time parameters indicates the mint rate and the
+    /// reward period length, i.e. the time between paydays.
     #[prost(message, optional, tag = "5")]
     pub time_parameters:              ::core::option::Option<TimeParametersCpv1>,
     /// The limit for the number of account creations in a block.
@@ -4001,27 +4427,87 @@ pub struct ChainParametersV1 {
     #[prost(message, optional, tag = "14")]
     pub level2_keys:                  ::core::option::Option<AuthorizationsV1>,
 }
+/// Updatable chain parameters that apply to protocol versions 6.
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct ChainParametersV2 {
+    /// Consensus parameters.
+    #[prost(message, optional, tag = "1")]
+    pub consensus_parameters: ::core::option::Option<ConsensusParametersV1>,
+    /// Euro per energy exchange rate.
+    #[prost(message, optional, tag = "2")]
+    pub euro_per_energy: ::core::option::Option<ExchangeRate>,
+    /// Micro CCD per euro exchange rate.
+    #[prost(message, optional, tag = "3")]
+    pub micro_ccd_per_euro: ::core::option::Option<ExchangeRate>,
+    /// Extra number of epochs before reduction in stake, or baker
+    /// deregistration is completed.
+    #[prost(message, optional, tag = "4")]
+    pub cooldown_parameters: ::core::option::Option<CooldownParametersCpv1>,
+    /// Current time parameters.
+    /// The time parameters indicates the mint rate and the
+    /// reward period length, i.e. the time between paydays.
+    #[prost(message, optional, tag = "5")]
+    pub time_parameters: ::core::option::Option<TimeParametersCpv1>,
+    /// The limit for the number of account creations in a block.
+    #[prost(message, optional, tag = "6")]
+    pub account_creation_limit: ::core::option::Option<CredentialsPerBlockLimit>,
+    /// Current mint distribution
+    #[prost(message, optional, tag = "7")]
+    pub mint_distribution: ::core::option::Option<MintDistributionCpv1>,
+    /// Current transaction fee distribution.
+    #[prost(message, optional, tag = "8")]
+    pub transaction_fee_distribution: ::core::option::Option<TransactionFeeDistribution>,
+    /// Current gas reward parameters.
+    #[prost(message, optional, tag = "9")]
+    pub gas_rewards: ::core::option::Option<GasRewardsCpv2>,
+    /// The foundation account.
+    #[prost(message, optional, tag = "10")]
+    pub foundation_account: ::core::option::Option<AccountAddress>,
+    /// Parameters governing baking pools and their commissions.
+    #[prost(message, optional, tag = "11")]
+    pub pool_parameters: ::core::option::Option<PoolParametersCpv1>,
+    /// Keys allowed to do root updates.
+    #[prost(message, optional, tag = "12")]
+    pub root_keys: ::core::option::Option<HigherLevelKeys>,
+    /// Keys allowed to do level1 updates;
+    #[prost(message, optional, tag = "13")]
+    pub level1_keys: ::core::option::Option<HigherLevelKeys>,
+    /// Keys allowed to do parameter updates.
+    #[prost(message, optional, tag = "14")]
+    pub level2_keys: ::core::option::Option<AuthorizationsV1>,
+    /// Finalization committee parameters
+    #[prost(message, optional, tag = "15")]
+    pub finalization_committee_parameters: ::core::option::Option<FinalizationCommitteeParameters>,
+}
 /// Chain parameters.
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct ChainParameters {
-    #[prost(oneof = "chain_parameters::Parameters", tags = "1, 2")]
+    #[prost(oneof = "chain_parameters::Parameters", tags = "1, 2, 3")]
     pub parameters: ::core::option::Option<chain_parameters::Parameters>,
 }
 /// Nested message and enum types in `ChainParameters`.
 pub mod chain_parameters {
+    #[allow(clippy::derive_partial_eq_without_eq)]
     #[derive(Clone, PartialEq, ::prost::Oneof)]
     pub enum Parameters {
         /// Chain parameters that apply when the block is a protocol version 1-3
         /// block.
         #[prost(message, tag = "1")]
         V0(super::ChainParametersV0),
-        /// Chain parameters that apply when the block is a protocol version 4
-        /// or up block.
+        /// Chain parameters that apply when the block is a protocol version 4-5
+        /// block.
         #[prost(message, tag = "2")]
         V1(super::ChainParametersV1),
+        /// Chain parameters that apply when the block is a protocol version 6-
+        /// block.
+        #[prost(message, tag = "3")]
+        V2(super::ChainParametersV2),
     }
 }
 /// Details about a finalizer for the finalization round.
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct FinalizationSummaryParty {
     /// Baker ID. Every finalizer is in particular a baker.
@@ -4038,12 +4524,14 @@ pub struct FinalizationSummaryParty {
 }
 /// Index of the finalization round. This increases on each successfully
 /// completed finalization.
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct FinalizationIndex {
     #[prost(uint64, tag = "1")]
     pub value: u64,
 }
 /// Details about a finalization record included in a block.
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct FinalizationSummary {
     /// Block that was finalized by the finalization record.
@@ -4061,6 +4549,7 @@ pub struct FinalizationSummary {
     pub finalizers: ::prost::alloc::vec::Vec<FinalizationSummaryParty>,
 }
 /// Finalization summary that may or may not be part of the block.
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct BlockFinalizationSummary {
     #[prost(oneof = "block_finalization_summary::Summary", tags = "1, 2")]
@@ -4068,6 +4557,7 @@ pub struct BlockFinalizationSummary {
 }
 /// Nested message and enum types in `BlockFinalizationSummary`.
 pub mod block_finalization_summary {
+    #[allow(clippy::derive_partial_eq_without_eq)]
     #[derive(Clone, PartialEq, ::prost::Oneof)]
     pub enum Summary {
         /// There is no finalization data in the block.
@@ -4078,6 +4568,7 @@ pub mod block_finalization_summary {
         Record(super::FinalizationSummary),
     }
 }
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct BlockItem {
     /// The hash of the block item that identifies it to the chain.
@@ -4088,6 +4579,7 @@ pub struct BlockItem {
 }
 /// Nested message and enum types in `BlockItem`.
 pub mod block_item {
+    #[allow(clippy::derive_partial_eq_without_eq)]
     #[derive(Clone, PartialEq, ::prost::Oneof)]
     pub enum BlockItem {
         /// Account transactions are messages which are signed and paid for by
@@ -4127,6 +4619,16 @@ impl OpenStatus {
             OpenStatus::ClosedForAll => "OPEN_STATUS_CLOSED_FOR_ALL",
         }
     }
+
+    /// Creates an enum from field names used in the ProtoBuf definition.
+    pub fn from_str_name(value: &str) -> ::core::option::Option<Self> {
+        match value {
+            "OPEN_STATUS_OPEN_FOR_ALL" => Some(Self::OpenForAll),
+            "OPEN_STATUS_CLOSED_FOR_NEW" => Some(Self::ClosedForNew),
+            "OPEN_STATUS_CLOSED_FOR_ALL" => Some(Self::ClosedForAll),
+            _ => None,
+        }
+    }
 }
 /// Version of smart contract.
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, ::prost::Enumeration)]
@@ -4145,6 +4647,15 @@ impl ContractVersion {
         match self {
             ContractVersion::V0 => "V0",
             ContractVersion::V1 => "V1",
+        }
+    }
+
+    /// Creates an enum from field names used in the ProtoBuf definition.
+    pub fn from_str_name(value: &str) -> ::core::option::Option<Self> {
+        match value {
+            "V0" => Some(Self::V0),
+            "V1" => Some(Self::V1),
+            _ => None,
         }
     }
 }
@@ -4169,6 +4680,15 @@ impl CredentialType {
             CredentialType::Normal => "CREDENTIAL_TYPE_NORMAL",
         }
     }
+
+    /// Creates an enum from field names used in the ProtoBuf definition.
+    pub fn from_str_name(value: &str) -> ::core::option::Option<Self> {
+        match value {
+            "CREDENTIAL_TYPE_INITIAL" => Some(Self::Initial),
+            "CREDENTIAL_TYPE_NORMAL" => Some(Self::Normal),
+            _ => None,
+        }
+    }
 }
 /// The type of chain update.
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, ::prost::Enumeration)]
@@ -4190,6 +4710,10 @@ pub enum UpdateType {
     UpdateLevel2Keys     = 13,
     UpdateCooldownParameters = 14,
     UpdateTimeParameters = 15,
+    UpdateTimeoutParameters = 16,
+    UpdateMinBlockTime   = 17,
+    UpdateBlockEnergyLimit = 18,
+    UpdateFinalizationCommitteeParameters = 19,
 }
 impl UpdateType {
     /// String value of the enum field names used in the ProtoBuf definition.
@@ -4215,6 +4739,41 @@ impl UpdateType {
             UpdateType::UpdateLevel2Keys => "UPDATE_LEVEL2_KEYS",
             UpdateType::UpdateCooldownParameters => "UPDATE_COOLDOWN_PARAMETERS",
             UpdateType::UpdateTimeParameters => "UPDATE_TIME_PARAMETERS",
+            UpdateType::UpdateTimeoutParameters => "UPDATE_TIMEOUT_PARAMETERS",
+            UpdateType::UpdateMinBlockTime => "UPDATE_MIN_BLOCK_TIME",
+            UpdateType::UpdateBlockEnergyLimit => "UPDATE_BLOCK_ENERGY_LIMIT",
+            UpdateType::UpdateFinalizationCommitteeParameters => {
+                "UPDATE_FINALIZATION_COMMITTEE_PARAMETERS"
+            }
+        }
+    }
+
+    /// Creates an enum from field names used in the ProtoBuf definition.
+    pub fn from_str_name(value: &str) -> ::core::option::Option<Self> {
+        match value {
+            "UPDATE_PROTOCOL" => Some(Self::UpdateProtocol),
+            "UPDATE_ELECTION_DIFFICULTY" => Some(Self::UpdateElectionDifficulty),
+            "UPDATE_EURO_PER_ENERGY" => Some(Self::UpdateEuroPerEnergy),
+            "UPDATE_MICRO_CCD_PER_EURO" => Some(Self::UpdateMicroCcdPerEuro),
+            "UPDATE_FOUNDATION_ACCOUNT" => Some(Self::UpdateFoundationAccount),
+            "UPDATE_MINT_DISTRIBUTION" => Some(Self::UpdateMintDistribution),
+            "UPDATE_TRANSACTION_FEE_DISTRIBUTION" => Some(Self::UpdateTransactionFeeDistribution),
+            "UPDATE_GAS_REWARDS" => Some(Self::UpdateGasRewards),
+            "UPDATE_POOL_PARAMETERS" => Some(Self::UpdatePoolParameters),
+            "ADD_ANONYMITY_REVOKER" => Some(Self::AddAnonymityRevoker),
+            "ADD_IDENTITY_PROVIDER" => Some(Self::AddIdentityProvider),
+            "UPDATE_ROOT_KEYS" => Some(Self::UpdateRootKeys),
+            "UPDATE_LEVEL1_KEYS" => Some(Self::UpdateLevel1Keys),
+            "UPDATE_LEVEL2_KEYS" => Some(Self::UpdateLevel2Keys),
+            "UPDATE_COOLDOWN_PARAMETERS" => Some(Self::UpdateCooldownParameters),
+            "UPDATE_TIME_PARAMETERS" => Some(Self::UpdateTimeParameters),
+            "UPDATE_TIMEOUT_PARAMETERS" => Some(Self::UpdateTimeoutParameters),
+            "UPDATE_MIN_BLOCK_TIME" => Some(Self::UpdateMinBlockTime),
+            "UPDATE_BLOCK_ENERGY_LIMIT" => Some(Self::UpdateBlockEnergyLimit),
+            "UPDATE_FINALIZATION_COMMITTEE_PARAMETERS" => {
+                Some(Self::UpdateFinalizationCommitteeParameters)
+            }
+            _ => None,
         }
     }
 }
@@ -4277,6 +4836,34 @@ impl TransactionType {
             TransactionType::ConfigureDelegation => "CONFIGURE_DELEGATION",
         }
     }
+
+    /// Creates an enum from field names used in the ProtoBuf definition.
+    pub fn from_str_name(value: &str) -> ::core::option::Option<Self> {
+        match value {
+            "DEPLOY_MODULE" => Some(Self::DeployModule),
+            "INIT_CONTRACT" => Some(Self::InitContract),
+            "UPDATE" => Some(Self::Update),
+            "TRANSFER" => Some(Self::Transfer),
+            "ADD_BAKER" => Some(Self::AddBaker),
+            "REMOVE_BAKER" => Some(Self::RemoveBaker),
+            "UPDATE_BAKER_STAKE" => Some(Self::UpdateBakerStake),
+            "UPDATE_BAKER_RESTAKE_EARNINGS" => Some(Self::UpdateBakerRestakeEarnings),
+            "UPDATE_BAKER_KEYS" => Some(Self::UpdateBakerKeys),
+            "UPDATE_CREDENTIAL_KEYS" => Some(Self::UpdateCredentialKeys),
+            "ENCRYPTED_AMOUNT_TRANSFER" => Some(Self::EncryptedAmountTransfer),
+            "TRANSFER_TO_ENCRYPTED" => Some(Self::TransferToEncrypted),
+            "TRANSFER_TO_PUBLIC" => Some(Self::TransferToPublic),
+            "TRANSFER_WITH_SCHEDULE" => Some(Self::TransferWithSchedule),
+            "UPDATE_CREDENTIALS" => Some(Self::UpdateCredentials),
+            "REGISTER_DATA" => Some(Self::RegisterData),
+            "TRANSFER_WITH_MEMO" => Some(Self::TransferWithMemo),
+            "ENCRYPTED_AMOUNT_TRANSFER_WITH_MEMO" => Some(Self::EncryptedAmountTransferWithMemo),
+            "TRANSFER_WITH_SCHEDULE_AND_MEMO" => Some(Self::TransferWithScheduleAndMemo),
+            "CONFIGURE_BAKER" => Some(Self::ConfigureBaker),
+            "CONFIGURE_DELEGATION" => Some(Self::ConfigureDelegation),
+            _ => None,
+        }
+    }
 }
 /// The different versions of the protocol.
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, ::prost::Enumeration)]
@@ -4303,6 +4890,19 @@ impl ProtocolVersion {
             ProtocolVersion::ProtocolVersion4 => "PROTOCOL_VERSION_4",
             ProtocolVersion::ProtocolVersion5 => "PROTOCOL_VERSION_5",
             ProtocolVersion::ProtocolVersion6 => "PROTOCOL_VERSION_6",
+        }
+    }
+
+    /// Creates an enum from field names used in the ProtoBuf definition.
+    pub fn from_str_name(value: &str) -> ::core::option::Option<Self> {
+        match value {
+            "PROTOCOL_VERSION_1" => Some(Self::ProtocolVersion1),
+            "PROTOCOL_VERSION_2" => Some(Self::ProtocolVersion2),
+            "PROTOCOL_VERSION_3" => Some(Self::ProtocolVersion3),
+            "PROTOCOL_VERSION_4" => Some(Self::ProtocolVersion4),
+            "PROTOCOL_VERSION_5" => Some(Self::ProtocolVersion5),
+            "PROTOCOL_VERSION_6" => Some(Self::ProtocolVersion6),
+            _ => None,
         }
     }
 }
@@ -5248,8 +5848,8 @@ pub mod queries_client {
             self.inner.unary(request.into_request(), path, codec).await
         }
 
-        //// Get a list of the peers that the node is connected to
-        //// and assoicated network related information for each peer.
+        /// / Get a list of the peers that the node is connected to
+        /// / and assoicated network related information for each peer.
         pub async fn get_peers_info(
             &mut self,
             request: impl tonic::IntoRequest<super::Empty>,

--- a/src/v2/mod.rs
+++ b/src/v2/mod.rs
@@ -26,12 +26,13 @@ use concordium_base::{
         types::{TransactionSignature, TransactionTime},
     },
     contracts_common::{
-        AccountAddress, Amount, ContractAddress, OwnedContractName, OwnedParameter,
+        AccountAddress, Amount, ContractAddress, Duration, OwnedContractName, OwnedParameter,
         OwnedReceiveName, ReceiveName,
     },
     transactions::{BlockItem, EncodedPayload, PayloadLike},
     updates::{
-        AuthorizationsV0, CooldownParameters, GASRewards, PoolParameters, TimeParameters,
+        AuthorizationsV0, CooldownParameters, FinalizationCommitteeParameters, GASRewards,
+        GASRewardsV1, PoolParameters, TimeParameters, TimeoutParameters,
         TransactionFeeDistribution,
     },
 };
@@ -168,7 +169,7 @@ pub struct ChainParametersV0 {
 
 #[derive(Debug, Clone)]
 /// Values of chain parameters that can be updated via chain updates.
-/// This applies to protocol version 4 and up.
+/// This applies to protocol version 4 and 5.
 pub struct ChainParametersV1 {
     /// Election difficulty for consensus lottery.
     pub election_difficulty: ElectionDifficulty,
@@ -194,6 +195,42 @@ pub struct ChainParametersV1 {
     pub keys: types::UpdateKeysCollection<ChainParameterVersion1>,
 }
 
+#[derive(Debug, Clone)]
+/// Values of chain parameters that can be updated via chain updates.
+/// This applies to protocol version 6 and up.
+pub struct ChainParametersV2 {
+    /// Consensus protocol version 2 timeout parameters.
+    pub timeout_parameters: TimeoutParameters,
+    /// Minimum time interval between blocks.
+    pub min_block_time: Duration,
+    /// Maximum energy allowed per block.
+    pub block_energy_limit: Energy,
+    /// Euro per energy exchange rate.
+    pub euro_per_energy: ExchangeRate,
+    /// Micro ccd per euro exchange rate.
+    pub micro_ccd_per_euro: ExchangeRate,
+    /// Parameters related to cooldowns when staking.
+    pub cooldown_parameters: CooldownParameters,
+    /// Parameters related mint rate and reward period.
+    pub time_parameters: TimeParameters,
+    /// The limit for the number of account creations in a block.
+    pub account_creation_limit: CredentialsPerBlockLimit,
+    /// Parameters related to the distribution of newly minted CCD.
+    pub mint_distribution: MintDistributionV1,
+    /// Parameters related to the distribution of transaction fees.
+    pub transaction_fee_distribution: TransactionFeeDistribution,
+    /// Parameters related to the distribution from the GAS account.
+    pub gas_rewards: GASRewardsV1,
+    /// Address of the foundation account.
+    pub foundation_account: AccountAddress,
+    /// Parameters for baker pools.
+    pub pool_parameters: PoolParameters,
+    /// The finalization committee parameters.
+    pub finalization_committee_parameters: FinalizationCommitteeParameters,
+    /// Keys allowed to do updates.
+    pub keys: types::UpdateKeysCollection<ChainParameterVersion1>,
+}
+
 /// Chain parameters. See [`ChainParametersV0`] and [`ChainParametersV1`] for
 /// details. `V0` parameters apply to protocol version `1..=3`, and `V1`
 /// parameters apply to protocol versions `4` and up.
@@ -201,6 +238,7 @@ pub struct ChainParametersV1 {
 pub enum ChainParameters {
     V0(ChainParametersV0),
     V1(ChainParametersV1),
+    V2(ChainParametersV2),
 }
 
 impl ChainParameters {
@@ -209,6 +247,7 @@ impl ChainParameters {
         match self {
             Self::V0(data) => &data.keys.level_2_keys,
             Self::V1(data) => &data.keys.level_2_keys.v0,
+            Self::V2(data) => &data.keys.level_2_keys.v0,
         }
     }
 }
@@ -233,6 +272,14 @@ impl ChainParameters {
                     u128::from(y.denominator()) * u128::from(y.denominator()),
                 )
             }
+            ChainParameters::V2(v2) => {
+                let x = v2.micro_ccd_per_euro;
+                let y = v2.euro_per_energy;
+                (
+                    u128::from(x.numerator()) * u128::from(y.numerator()),
+                    u128::from(y.denominator()) * u128::from(y.denominator()),
+                )
+            }
         };
         num::rational::Ratio::new(num, denom)
     }
@@ -242,6 +289,7 @@ impl ChainParameters {
         match self {
             ChainParameters::V0(v0) => v0.foundation_account,
             ChainParameters::V1(v1) => v1.foundation_account,
+            ChainParameters::V2(v2) => v2.foundation_account,
         }
     }
 }

--- a/src/v2/proto_schema_version.rs
+++ b/src/v2/proto_schema_version.rs
@@ -1,1 +1,1 @@
-pub const PROTO_SCHEMA_VERSION: &str = "e244ceacd738df5031e2d88f63d77fe584f13ed3";
+pub const PROTO_SCHEMA_VERSION: &str = "b09e484a53953a6a2a0863ee0834d33b09b913d1";


### PR DESCRIPTION
## Purpose

Introduces changes needed for genesis-creator to support P6
Related to https://github.com/Concordium/concordium-misc-tools/pull/51

## Changes

- Introduce `ChainParametersV2` struct for protocol version 6.
- Introduce generic `gas_reward` in `RewardParametersSkeleton` for supporting different versions of GASRewards.

## Checklist

- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [x] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [x] (If necessary) I have updated the CHANGELOG.
