### PR TITLE
Refactor contract clients in preparation for CIS4.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@
   use of the new API.
 - Re-export `http::Scheme` from `http` crate since it is often needed when
   configuring endpoints.
+- Add a new `ContractClient` that supports operations on smart contract
+  instances such as queries and updates.
 
 ## 2.4.0
 

--- a/src/cis0.rs
+++ b/src/cis0.rs
@@ -102,6 +102,8 @@ pub enum StandardIdentifier {
     CIS0,
     CIS1,
     CIS2,
+    CIS3,
+    CIS4,
     Other(String),
 }
 
@@ -111,6 +113,8 @@ impl std::fmt::Display for StandardIdentifier {
             StandardIdentifier::CIS0 => f.write_str("CIS-0"),
             StandardIdentifier::CIS1 => f.write_str("CIS-1"),
             StandardIdentifier::CIS2 => f.write_str("CIS-2"),
+            StandardIdentifier::CIS3 => f.write_str("CIS-3"),
+            StandardIdentifier::CIS4 => f.write_str("CIS-4"),
             StandardIdentifier::Other(s) => f.write_str(s),
         }
     }
@@ -129,6 +133,8 @@ impl std::str::FromStr for StandardIdentifier {
             "CIS-0" => Ok(Self::CIS0),
             "CIS-1" => Ok(Self::CIS1),
             "CIS-2" => Ok(Self::CIS2),
+            "CIS-3" => Ok(Self::CIS3),
+            "CIS-4" => Ok(Self::CIS4),
             other if other.is_ascii() && other.len() <= 255 => Ok(Self::Other(other.into())),
             _ => Err(InvalidStandardName),
         }
@@ -149,6 +155,14 @@ impl contracts_common::Serial for StandardIdentifier {
             StandardIdentifier::CIS2 => {
                 out.write_u8(5)?; // length
                 out.write_all(b"CIS-2")
+            }
+            StandardIdentifier::CIS3 => {
+                out.write_u8(5)?; // length
+                out.write_all(b"CIS-3")
+            }
+            StandardIdentifier::CIS4 => {
+                out.write_u8(5)?; // length
+                out.write_all(b"CIS-4")
             }
             StandardIdentifier::Other(s) => {
                 out.write_u8(s.len() as u8)?;

--- a/src/cis2/mod.rs
+++ b/src/cis2/mod.rs
@@ -6,32 +6,27 @@
 //! functions for querying and making transactions to smart contract.
 mod types;
 
-use crate::{
-    common, id,
-    types::{self as sdk_types, smart_contracts::DEFAULT_INVOKE_ENERGY},
-    v2::{Client, IntoBlockIdentifier},
+use crate::{contract_client::*, types as sdk_types, v2::IntoBlockIdentifier};
+use concordium_base::{
+    base::Energy,
+    contracts_common::{Address, Amount},
 };
-use concordium_base::{base::Energy, contracts_common::Address};
-use sdk_types::{smart_contracts, transactions, ContractAddress};
+use sdk_types::{smart_contracts, transactions};
 use smart_contracts::concordium_contracts_common;
-use std::{
-    convert::{From, TryFrom},
-    sync::Arc,
-};
+use std::convert::From;
 use thiserror::*;
 pub use types::*;
+
+#[doc(hidden)]
+#[derive(Debug, Clone, Copy)]
+pub enum Cis2Type {}
 
 /// A wrapper around the client representing a CIS2 token smart contract, which
 /// provides functions for interaction.
 ///
 /// Note that cloning is cheap and is, therefore, the intended way of sharing
 /// this type between multiple tasks.
-#[derive(Debug, Clone)]
-pub struct Cis2Contract {
-    client:        Client,
-    address:       ContractAddress,
-    contract_name: Arc<concordium_contracts_common::OwnedContractName>,
-}
+pub type Cis2Contract = ContractClient<Cis2Type>;
 
 /// Error which can occur when submitting a transaction such as `transfer` and
 /// `updateOperator` to a CIS2 smart contract.
@@ -118,43 +113,16 @@ impl From<sdk_types::RejectReason> for Cis2QueryError {
     fn from(err: sdk_types::RejectReason) -> Self { Self::NodeRejected(err) }
 }
 
-/// Transaction metadata for CIS-2
-#[derive(Debug, Clone, Copy)]
-pub struct Cis2TransactionMetadata {
-    /// The account address sending the transaction.
-    pub sender_address: id::types::AccountAddress,
-    /// The nonce to use for the transaction.
-    pub nonce:          sdk_types::Nonce,
-    /// Expiry date of the transaction.
-    pub expiry:         common::types::TransactionTime,
-    /// The limit on energy to use for the transaction.
-    pub energy:         transactions::send::GivenEnergy,
-    /// The amount of CCD to include in the transaction.
-    pub amount:         common::types::Amount,
+// This is implemented manually, since deriving it using thiserror requires
+// `RejectReason` to implement std::error::Error.
+impl From<sdk_types::RejectReason> for Cis2DryRunError {
+    fn from(err: sdk_types::RejectReason) -> Self { Self::NodeRejected(err) }
 }
 
-impl Cis2Contract {
-    /// Construct a Cis2Contract.
-    ///
-    /// # Arguments
-    ///
-    /// * `client` - The RPC client for the concordium node. Note that cloning
-    ///   [Client](crate::endpoints::Client) is cheap and is therefore the
-    ///   intended way of sharing.
-    /// * `address` - The contract address of the CIS2 token smart contract.
-    /// * `contract_name` - The name of the contract.
-    pub fn new(
-        client: Client,
-        address: ContractAddress,
-        contract_name: concordium_contracts_common::OwnedContractName,
-    ) -> Cis2Contract {
-        Cis2Contract {
-            client,
-            address,
-            contract_name: Arc::new(contract_name),
-        }
-    }
+/// Transaction metadata for CIS-2
+pub type Cis2TransactionMetadata = ContractTransactionMetadata;
 
+impl Cis2Contract {
     /// Like [`transfer`](Self::transfer) except it only dry-runs the
     /// transaction to get the response and, in case of success, amount of
     /// energy used for execution.
@@ -172,26 +140,14 @@ impl Cis2Contract {
         transfers: Vec<Transfer>,
     ) -> Result<Energy, Cis2DryRunError> {
         let parameter = TransferParams::new(transfers)?;
-        let bytes = concordium_contracts_common::to_bytes(&parameter);
-        let contract_name = self.contract_name.as_contract_name().contract_name();
-        let receive_name =
-            smart_contracts::OwnedReceiveName::try_from(format!("{}.transfer", contract_name))?;
-
-        let context = smart_contracts::ContractContext {
-            invoker:   Some(sender),
-            contract:  self.address,
-            amount:    common::types::Amount::from_micro_ccd(0),
-            method:    receive_name,
-            parameter: smart_contracts::OwnedParameter::try_from(bytes)
-                .map_err(|_| Cis2DryRunError::InvalidTransferParams(NewTransferParamsError))?,
-            energy:    DEFAULT_INVOKE_ENERGY,
-        };
-        let response = self.client.invoke_instance(bi, &context).await?;
-        match response.response {
+        let parameter = smart_contracts::OwnedParameter::from_serial(&parameter)
+            .map_err(|_| Cis2DryRunError::InvalidTransferParams(NewTransferParamsError))?;
+        let ir = self
+            .invoke_raw::<Cis2DryRunError>("transfer", Amount::zero(), Some(sender), parameter, bi)
+            .await?;
+        match ir {
             smart_contracts::InvokeContractResult::Success { used_energy, .. } => Ok(used_energy),
-            smart_contracts::InvokeContractResult::Failure { reason, .. } => {
-                Err(Cis2DryRunError::NodeRejected(reason))
-            }
+            smart_contracts::InvokeContractResult::Failure { reason, .. } => Err(reason.into()),
         }
     }
 
@@ -223,32 +179,10 @@ impl Cis2Contract {
         transfers: Vec<Transfer>,
     ) -> Result<sdk_types::hashes::TransactionHash, Cis2TransactionError> {
         let parameter = TransferParams::new(transfers)?;
-        let bytes = concordium_contracts_common::to_bytes(&parameter);
-        let contract_name = self.contract_name.as_contract_name().contract_name();
-        let receive_name =
-            smart_contracts::OwnedReceiveName::try_from(format!("{}.transfer", contract_name))?;
-
-        let payload = transactions::Payload::Update {
-            payload: transactions::UpdateContractPayload {
-                amount: transaction_metadata.amount,
-                address: self.address,
-                receive_name,
-                message: smart_contracts::OwnedParameter::try_from(bytes).map_err(|_| {
-                    Cis2TransactionError::InvalidTransferParams(NewTransferParamsError)
-                })?,
-            },
-        };
-        let tx = transactions::send::make_and_sign_transaction(
-            signer,
-            transaction_metadata.sender_address,
-            transaction_metadata.nonce,
-            transaction_metadata.expiry,
-            transaction_metadata.energy,
-            payload,
-        );
-        let bi = transactions::BlockItem::AccountTransaction(tx);
-        let hash = self.client.send_block_item(&bi).await?;
-        Ok(hash)
+        let message = smart_contracts::OwnedParameter::from_serial(&parameter)
+            .map_err(|_| Cis2TransactionError::InvalidTransferParams(NewTransferParamsError))?;
+        self.update_raw(signer, &transaction_metadata, "transfer", message)
+            .await
     }
 
     /// Like [`transfer`](Self::transfer), except it is more ergonomic
@@ -280,30 +214,20 @@ impl Cis2Contract {
         updates: Vec<UpdateOperator>,
     ) -> anyhow::Result<Energy, Cis2DryRunError> {
         let parameter = UpdateOperatorParams::new(updates)?;
-        let bytes = concordium_contracts_common::to_bytes(&parameter);
-        let contract_name = self.contract_name.as_contract_name().contract_name();
-
-        let receive_name = smart_contracts::OwnedReceiveName::try_from(format!(
-            "{}.updateOperator",
-            contract_name
-        ))?;
-
-        let context = smart_contracts::ContractContext {
-            invoker:   Some(owner),
-            contract:  self.address,
-            amount:    common::types::Amount::from_micro_ccd(0),
-            method:    receive_name,
-            parameter: smart_contracts::OwnedParameter::try_from(bytes)
-                .map_err(|_| Cis2DryRunError::InvalidTransferParams(NewTransferParamsError))?,
-            energy:    smart_contracts::DEFAULT_INVOKE_ENERGY,
-        };
-
-        let res = self.client.invoke_instance(bi, &context).await?;
-        match res.response {
+        let parameter = smart_contracts::OwnedParameter::from_serial(&parameter)
+            .map_err(|_| Cis2DryRunError::InvalidTransferParams(NewTransferParamsError))?;
+        let ir = self
+            .invoke_raw::<Cis2DryRunError>(
+                "updateOperator",
+                Amount::zero(),
+                Some(owner),
+                parameter,
+                bi,
+            )
+            .await?;
+        match ir {
             smart_contracts::InvokeContractResult::Success { used_energy, .. } => Ok(used_energy),
-            smart_contracts::InvokeContractResult::Failure { reason, .. } => {
-                Err(Cis2DryRunError::NodeRejected(reason))
-            }
+            smart_contracts::InvokeContractResult::Failure { reason, .. } => Err(reason.into()),
         }
     }
 
@@ -338,35 +262,11 @@ impl Cis2Contract {
         updates: Vec<UpdateOperator>,
     ) -> anyhow::Result<sdk_types::hashes::TransactionHash, Cis2TransactionError> {
         let parameter = UpdateOperatorParams::new(updates)?;
-        let bytes = concordium_contracts_common::to_bytes(&parameter);
-        let contract_name = self.contract_name.as_contract_name().contract_name();
-
-        let receive_name = smart_contracts::OwnedReceiveName::try_from(format!(
-            "{}.updateOperator",
-            contract_name
-        ))?;
-
-        let payload = transactions::Payload::Update {
-            payload: transactions::UpdateContractPayload {
-                amount: transaction_metadata.amount,
-                address: self.address,
-                receive_name,
-                message: smart_contracts::OwnedParameter::try_from(bytes).map_err(|_| {
-                    Cis2TransactionError::InvalidUpdateOperatorParams(NewUpdateOperatorParamsError)
-                })?,
-            },
-        };
-        let tx = transactions::send::make_and_sign_transaction(
-            signer,
-            transaction_metadata.sender_address,
-            transaction_metadata.nonce,
-            transaction_metadata.expiry,
-            transaction_metadata.energy,
-            payload,
-        );
-        let bi = transactions::BlockItem::AccountTransaction(tx);
-        let hash = self.client.send_block_item(&bi).await?;
-        Ok(hash)
+        let message = smart_contracts::OwnedParameter::from_serial(&parameter).map_err(|_| {
+            Cis2TransactionError::InvalidUpdateOperatorParams(NewUpdateOperatorParamsError)
+        })?;
+        self.update_raw(signer, &transaction_metadata, "updateOperator", message)
+            .await
     }
 
     /// Like [`update_operator`](Self::update_operator), but more ergonomic
@@ -401,35 +301,9 @@ impl Cis2Contract {
         queries: Vec<BalanceOfQuery>,
     ) -> Result<BalanceOfQueryResponse, Cis2QueryError> {
         let parameter = BalanceOfQueryParams::new(queries)?;
-        let bytes = concordium_contracts_common::to_bytes(&parameter);
-        let contract_name = self.contract_name.as_contract_name().contract_name();
-        let receive_name =
-            smart_contracts::OwnedReceiveName::try_from(format!("{}.balanceOf", contract_name))?;
-
-        let contract_context = smart_contracts::ContractContext {
-            invoker:   None,
-            contract:  self.address,
-            amount:    common::types::Amount::from_micro_ccd(0),
-            method:    receive_name,
-            parameter: smart_contracts::OwnedParameter::try_from(bytes).map_err(|_| {
-                Cis2QueryError::InvalidBalanceOfParams(NewBalanceOfQueryParamsError)
-            })?,
-            energy:    smart_contracts::MAX_ALLOWED_INVOKE_ENERGY,
-        };
-
-        let invoke_result = self.client.invoke_instance(bi, &contract_context).await?;
-
-        match invoke_result.response {
-            smart_contracts::InvokeContractResult::Success { return_value, .. } => {
-                let bytes: smart_contracts::ReturnValue = return_value.ok_or(
-                    Cis2QueryError::ResponseParseError(concordium_contracts_common::ParseError {}),
-                )?;
-                let response: BalanceOfQueryResponse =
-                    concordium_contracts_common::from_bytes(&bytes.value)?;
-                Ok(response)
-            }
-            smart_contracts::InvokeContractResult::Failure { reason, .. } => Err(reason.into()),
-        }
+        let parameter = smart_contracts::OwnedParameter::from_serial(&parameter)
+            .map_err(|_| Cis2QueryError::InvalidBalanceOfParams(NewBalanceOfQueryParamsError))?;
+        self.view_raw("balanceOf", parameter, bi).await
     }
 
     /// Like [`balance_of`](Self::balance_of), except for querying a single
@@ -463,35 +337,9 @@ impl Cis2Contract {
         queries: Vec<OperatorOfQuery>,
     ) -> Result<OperatorOfQueryResponse, Cis2QueryError> {
         let parameter = OperatorOfQueryParams::new(queries)?;
-        let bytes = concordium_contracts_common::to_bytes(&parameter);
-        let contract_name = self.contract_name.as_contract_name().contract_name();
-        let receive_name =
-            smart_contracts::OwnedReceiveName::try_from(format!("{}.operatorOf", contract_name))?;
-
-        let contract_context = smart_contracts::ContractContext {
-            invoker:   None,
-            contract:  self.address,
-            amount:    common::types::Amount::from_micro_ccd(0),
-            method:    receive_name,
-            parameter: smart_contracts::OwnedParameter::try_from(bytes).map_err(|_| {
-                Cis2QueryError::InvalidOperatorOfParams(NewOperatorOfQueryParamsError)
-            })?,
-            energy:    smart_contracts::MAX_ALLOWED_INVOKE_ENERGY,
-        };
-
-        let invoke_result = self.client.invoke_instance(bi, &contract_context).await?;
-
-        match invoke_result.response {
-            smart_contracts::InvokeContractResult::Success { return_value, .. } => {
-                let bytes: smart_contracts::ReturnValue = return_value.ok_or(
-                    Cis2QueryError::ResponseParseError(concordium_contracts_common::ParseError {}),
-                )?;
-                let response: OperatorOfQueryResponse =
-                    concordium_contracts_common::from_bytes(&bytes.value)?;
-                Ok(response)
-            }
-            smart_contracts::InvokeContractResult::Failure { reason, .. } => Err(reason.into()),
-        }
+        let parameter = smart_contracts::OwnedParameter::from_serial(&parameter)
+            .map_err(|_| Cis2QueryError::InvalidOperatorOfParams(NewOperatorOfQueryParamsError))?;
+        self.view_raw("operatorOf", parameter, bi).await
     }
 
     /// Like [`operator_of`](Self::operator_of), except for querying a single
@@ -528,37 +376,10 @@ impl Cis2Contract {
         queries: Vec<TokenId>,
     ) -> Result<TokenMetadataQueryResponse, Cis2QueryError> {
         let parameter = TokenMetadataQueryParams::new(queries)?;
-        let bytes = concordium_contracts_common::to_bytes(&parameter);
-        let contract_name = self.contract_name.as_contract_name().contract_name();
-        let receive_name = smart_contracts::OwnedReceiveName::try_from(format!(
-            "{}.tokenMetadata",
-            contract_name
-        ))?;
-
-        let contract_context = smart_contracts::ContractContext {
-            invoker:   None,
-            contract:  self.address,
-            amount:    common::types::Amount::from_micro_ccd(0),
-            method:    receive_name,
-            parameter: smart_contracts::OwnedParameter::try_from(bytes).map_err(|_| {
-                Cis2QueryError::InvalidTokenMetadataParams(NewTokenMetadataQueryParamsError)
-            })?,
-            energy:    smart_contracts::MAX_ALLOWED_INVOKE_ENERGY,
-        };
-
-        let invoke_result = self.client.invoke_instance(bi, &contract_context).await?;
-
-        match invoke_result.response {
-            smart_contracts::InvokeContractResult::Success { return_value, .. } => {
-                let bytes: smart_contracts::ReturnValue = return_value.ok_or(
-                    Cis2QueryError::ResponseParseError(concordium_contracts_common::ParseError {}),
-                )?;
-                let response: TokenMetadataQueryResponse =
-                    concordium_contracts_common::from_bytes(&bytes.value)?;
-                Ok(response)
-            }
-            smart_contracts::InvokeContractResult::Failure { reason, .. } => Err(reason.into()),
-        }
+        let parameter = smart_contracts::OwnedParameter::from_serial(&parameter).map_err(|_| {
+            Cis2QueryError::InvalidTokenMetadataParams(NewTokenMetadataQueryParamsError)
+        })?;
+        self.view_raw("tokenMetadata", parameter, bi).await
     }
 
     /// Like [`token_metadata`](Self::token_metadata), except for querying a

--- a/src/cis2/mod.rs
+++ b/src/cis2/mod.rs
@@ -17,8 +17,9 @@ use std::convert::From;
 use thiserror::*;
 pub use types::*;
 
-#[doc(hidden)]
 #[derive(Debug, Clone, Copy)]
+/// A marker type to indicate that a [`ContractClient`] is a client for a `CIS2`
+/// contract.
 pub enum Cis2Type {}
 
 /// A wrapper around the client representing a CIS2 token smart contract, which
@@ -26,6 +27,8 @@ pub enum Cis2Type {}
 ///
 /// Note that cloning is cheap and is, therefore, the intended way of sharing
 /// this type between multiple tasks.
+///
+/// See also [`ContractClient`] for generic methods available for any contract.
 pub type Cis2Contract = ContractClient<Cis2Type>;
 
 /// Error which can occur when submitting a transaction such as `transfer` and

--- a/src/contract_client.rs
+++ b/src/contract_client.rs
@@ -28,8 +28,11 @@ use std::{marker::PhantomData, sync::Arc};
 /// values of this type between multiple tasks.
 #[derive(Debug)]
 pub struct ContractClient<Type> {
+    /// The underlying network client.
     pub client:        Client,
+    /// The address of the instance.
     pub address:       ContractAddress,
+    /// The name of the contract at the address.
     pub contract_name: Arc<contracts_common::OwnedContractName>,
     phantom:           PhantomData<Type>,
 }

--- a/src/contract_client.rs
+++ b/src/contract_client.rs
@@ -1,0 +1,246 @@
+//! This module contains a generic client that provides conveniences for
+//! interacting with any smart contract instance.
+use crate::{
+    types::{
+        smart_contracts::{self, ContractContext, InvokeContractResult},
+        transactions, RejectReason,
+    },
+    v2::{self, BlockIdentifier, Client},
+};
+use concordium_base::{
+    base::Nonce,
+    common::types,
+    contracts_common::{
+        self, AccountAddress, Address, Amount, ContractAddress, NewReceiveNameError,
+    },
+    hashes::TransactionHash,
+    smart_contracts::{ExceedsParameterSize, OwnedContractName, OwnedParameter, OwnedReceiveName},
+    transactions::UpdateContractPayload,
+};
+pub use concordium_base::{cis2_types::MetadataUrl, cis4_types::*};
+use std::{marker::PhantomData, sync::Arc};
+
+/// A contract client that handles some of the boilerplate such as serialization
+/// and parsing of responses when sending transactions, or invoking smart
+/// contracts.
+///
+/// Note that cloning is cheap and is, therefore, the intended way of sharing
+/// values of this type between multiple tasks.
+#[derive(Debug)]
+pub struct ContractClient<Type> {
+    pub client:        Client,
+    pub address:       ContractAddress,
+    pub contract_name: Arc<contracts_common::OwnedContractName>,
+    phantom:           PhantomData<Type>,
+}
+
+impl<Type> Clone for ContractClient<Type> {
+    fn clone(&self) -> Self {
+        Self {
+            client:        self.client.clone(),
+            address:       self.address,
+            contract_name: self.contract_name.clone(),
+            phantom:       PhantomData,
+        }
+    }
+}
+
+/// Transaction metadata for CIS-4 update transactions.
+#[derive(Debug, Clone, Copy)]
+pub struct ContractTransactionMetadata {
+    /// The account address sending the transaction.
+    pub sender_address: AccountAddress,
+    /// The nonce to use for the transaction.
+    pub nonce:          Nonce,
+    /// Expiry date of the transaction.
+    pub expiry:         types::TransactionTime,
+    /// The limit on energy to use for the transaction.
+    pub energy:         transactions::send::GivenEnergy,
+    /// The amount of CCD to include in the transaction.
+    pub amount:         types::Amount,
+}
+
+#[derive(Debug, thiserror::Error)]
+/// An error that can be used as the error for the
+/// [`view`](ContractClient::view) family of functions.
+pub enum ViewError {
+    #[error("Invalid receive name: {0}")]
+    InvalidName(#[from] NewReceiveNameError),
+    #[error("Node rejected with reason: {0:#?}")]
+    QueryFailed(RejectReason),
+    #[error("Response was not as expected: {0}")]
+    InvalidResponse(#[from] contracts_common::ParseError),
+    #[error("Network error: {0}")]
+    NetworkError(#[from] v2::QueryError),
+    #[error("Parameter is too large: {0}")]
+    ParameterError(#[from] ExceedsParameterSize),
+}
+
+impl From<RejectReason> for ViewError {
+    fn from(value: RejectReason) -> Self { Self::QueryFailed(value) }
+}
+
+impl<Type> ContractClient<Type> {
+    /// Construct a [`ContractClient`] by looking up metadata from the chain.
+    ///
+    /// # Arguments
+    ///
+    /// * `client` - The RPC client for the concordium node.
+    /// * `address` - The contract address of the smart contract instance.
+    pub async fn create(mut client: Client, address: ContractAddress) -> v2::QueryResult<Self> {
+        let ci = client
+            .get_instance_info(address, BlockIdentifier::LastFinal)
+            .await?;
+        Ok(Self::new(client, address, ci.response.name().clone()))
+    }
+
+    /// Construct a [`ContractClient`] locally. In comparison to
+    /// [`create`](Self::create) this always succeeds and does not check
+    /// existence of the contract.
+    ///
+    /// # Arguments
+    ///
+    /// * `client` - The RPC client for the concordium node. Note that cloning
+    ///   [`Client`] is cheap and is therefore the intended way of sharing.
+    /// * `address` - The contract address of the smart contract.
+    /// * `contract_name` - The name of the contract. This must match the name
+    ///   on the chain,
+    /// otherwise the constructed client will not work.
+    pub fn new(client: Client, address: ContractAddress, contract_name: OwnedContractName) -> Self {
+        Self {
+            client,
+            address,
+            contract_name: Arc::new(contract_name),
+            phantom: PhantomData,
+        }
+    }
+
+    /// Invoke a contract and return the response.
+    ///
+    /// This will always fail for a V0 contract, and for V1 contracts it will
+    /// attempt to deserialize the response into the provided type `A`.
+    ///
+    /// The error `E` is left generic in order to support specialized errors
+    /// such as CIS2 or CIS4 specific errors for more specialized view functions
+    /// defined by those standards.
+    ///
+    /// For a general contract [`ViewError`] can be used as a concrete error
+    /// type `E`.
+    pub async fn view<P: contracts_common::Serial, A: contracts_common::Deserial, E>(
+        &mut self,
+        entrypoint: &str,
+        parameter: &P,
+        bi: impl v2::IntoBlockIdentifier,
+    ) -> Result<A, E>
+    where
+        E: From<NewReceiveNameError>
+            + From<RejectReason>
+            + From<contracts_common::ParseError>
+            + From<v2::QueryError>
+            + From<ExceedsParameterSize>, {
+        let parameter = OwnedParameter::from_serial(parameter)?;
+        self.view_raw::<A, E>(entrypoint, parameter, bi).await
+    }
+
+    /// Like [`view`](Self::view) but expects an already serialized parameter.
+    pub async fn view_raw<A: contracts_common::Deserial, E>(
+        &mut self,
+        entrypoint: &str,
+        parameter: OwnedParameter,
+        bi: impl v2::IntoBlockIdentifier,
+    ) -> Result<A, E>
+    where
+        E: From<NewReceiveNameError>
+            + From<RejectReason>
+            + From<contracts_common::ParseError>
+            + From<v2::QueryError>, {
+        let ir = self
+            .invoke_raw::<E>(entrypoint, Amount::zero(), None, parameter, bi)
+            .await?;
+        match ir {
+            smart_contracts::InvokeContractResult::Success { return_value, .. } => {
+                let Some(bytes) = return_value else {return Err(contracts_common::ParseError {}.into()
+            )};
+                let response: A = contracts_common::from_bytes(&bytes.value)?;
+                Ok(response)
+            }
+            smart_contracts::InvokeContractResult::Failure { reason, .. } => Err(reason.into()),
+        }
+    }
+
+    /// Invoke a contract instance and return the response without any
+    /// processing.
+    pub async fn invoke_raw<E>(
+        &mut self,
+        entrypoint: &str,
+        amount: Amount,
+        invoker: Option<Address>,
+        parameter: OwnedParameter,
+        bi: impl v2::IntoBlockIdentifier,
+    ) -> Result<InvokeContractResult, E>
+    where
+        E: From<NewReceiveNameError> + From<RejectReason> + From<v2::QueryError>, {
+        let contract_name = self.contract_name.as_contract_name().contract_name();
+        let method = OwnedReceiveName::try_from(format!("{contract_name}.{entrypoint}"))?;
+
+        let context = ContractContext {
+            invoker,
+            contract: self.address,
+            amount,
+            method,
+            parameter,
+            energy: 1_000_000.into(),
+        };
+
+        let invoke_result = self.client.invoke_instance(bi, &context).await?.response;
+        Ok(invoke_result)
+    }
+
+    /// Send a transaction with the specified parameter.
+    pub async fn update<P: contracts_common::Serial, E>(
+        &mut self,
+        signer: &impl transactions::ExactSizeTransactionSigner,
+        metadata: &ContractTransactionMetadata,
+        entrypoint: &str,
+        message: &P,
+    ) -> Result<TransactionHash, E>
+    where
+        E: From<NewReceiveNameError> + From<v2::RPCError> + From<ExceedsParameterSize>, {
+        let message = OwnedParameter::from_serial(message)?;
+        self.update_raw::<E>(signer, metadata, entrypoint, message)
+            .await
+    }
+
+    /// Like [`update`](Self::update) but expects a serialized parameter.
+    pub async fn update_raw<E>(
+        &mut self,
+        signer: &impl transactions::ExactSizeTransactionSigner,
+        metadata: &ContractTransactionMetadata,
+        entrypoint: &str,
+        message: OwnedParameter,
+    ) -> Result<TransactionHash, E>
+    where
+        E: From<NewReceiveNameError> + From<v2::RPCError>, {
+        let contract_name = self.contract_name.as_contract_name().contract_name();
+        let receive_name = OwnedReceiveName::try_from(format!("{contract_name}.{entrypoint}"))?;
+
+        let payload = UpdateContractPayload {
+            amount: metadata.amount,
+            address: self.address,
+            receive_name,
+            message,
+        };
+
+        let tx = transactions::send::make_and_sign_transaction(
+            signer,
+            metadata.sender_address,
+            metadata.nonce,
+            metadata.expiry,
+            metadata.energy,
+            transactions::Payload::Update { payload },
+        );
+
+        let hash = self.client.send_account_transaction(tx).await?;
+        Ok(hash)
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -47,6 +47,9 @@ pub mod postgres;
 /// Type definitions used throughout the rest of the SDK.
 pub mod types;
 
+/// A generic client for interacting with smart contracts.
+pub mod contract_client;
+
 /// Types and functions for working with CIS-0 smart contracts.
 pub mod cis0;
 /// Types and functions for working with CIS-2 smart contracts.

--- a/src/types/smart_contracts.rs
+++ b/src/types/smart_contracts.rs
@@ -258,6 +258,16 @@ pub enum InvokeContractResult {
     },
 }
 
+impl InvokeContractResult {
+    /// Retrieve the amount of energy used for the call.
+    pub fn used_energy(&self) -> Energy {
+        match self {
+            InvokeContractResult::Success { used_energy, .. } => *used_energy,
+            InvokeContractResult::Failure { used_energy, .. } => *used_energy,
+        }
+    }
+}
+
 mod contract_trace_via_events {
     use super::*;
     use serde::de::Error;


### PR DESCRIPTION
## Purpose

Restructure cis2 client to reduce code duplication.

## Changes

- Introduce a generic "contractclient" that has some helpers for sending transactions/invoking view functions.
- Use the new client in Cis2Contract to reduce code duplication.

## Checklist

- [ ] My code follows the style of this project.
- [ ] The code compiles without warnings.
- [ ] I have performed a self-review of the changes.
- [ ] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [ ] (If necessary) I have updated the CHANGELOG.
