### PR TITLE
Support for `GetWinningBakersEpoch`

### DIFF
--- a/examples/v2_get_winning_bakers.rs
+++ b/examples/v2_get_winning_bakers.rs
@@ -1,0 +1,37 @@
+//! Test the `GetWinningBakersEpoch` endpoint.
+use anyhow::Context;
+use clap::AppSettings;
+use concordium_rust_sdk::v2;
+use futures::StreamExt;
+use structopt::StructOpt;
+
+#[derive(StructOpt)]
+struct App {
+    #[structopt(
+        long = "node",
+        help = "GRPC interface of the node.",
+        default_value = "http://localhost:20000"
+    )]
+    endpoint: v2::Endpoint,
+
+    #[structopt(long = "epoch", help = "Epoch identifier", default_value = "%5,1")]
+    epoch: v2::EpochIdentifier,
+}
+
+#[tokio::main(flavor = "multi_thread")]
+async fn main() -> anyhow::Result<()> {
+    let app = {
+        let app = App::clap().global_setting(AppSettings::ColoredHelp);
+        let matches = app.get_matches();
+        App::from_clap(&matches)
+    };
+
+    let mut client = v2::Client::new(app.endpoint)
+        .await
+        .context("Cannot connect.")?;
+    let mut wbs = client.get_winning_bakers_epoch(app.epoch).await?;
+    while let Some(wb) = wbs.next().await {
+        println!("{:?}", wb?);
+    }
+    Ok(())
+}

--- a/src/types/mod.rs
+++ b/src/types/mod.rs
@@ -876,7 +876,7 @@ mod block_summary_parser {
         protocol_version: super::ProtocolVersion,
         #[serde(flatten)]
         // parse first into a value
-        data:             super::BlockSummaryData<serde_json::Value>,
+        data: super::BlockSummaryData<serde_json::Value>,
     }
 
     impl std::convert::TryFrom<BlockSummaryRaw> for super::BlockSummary {

--- a/src/types/mod.rs
+++ b/src/types/mod.rs
@@ -876,7 +876,7 @@ mod block_summary_parser {
         protocol_version: super::ProtocolVersion,
         #[serde(flatten)]
         // parse first into a value
-        data: super::BlockSummaryData<serde_json::Value>,
+        data:             super::BlockSummaryData<serde_json::Value>,
     }
 
     impl std::convert::TryFrom<BlockSummaryRaw> for super::BlockSummary {
@@ -2236,6 +2236,18 @@ pub struct NodeInfo {
     pub network_info: NetworkInfo,
     /// Information related to consensus for the node.
     pub details:      NodeDetails,
+}
+
+/// A baker that has won a round in consensus version 1.
+#[derive(Debug)]
+pub struct WinningBaker {
+    /// The round that was won.
+    pub round:   Round,
+    /// The id of the baker that won the round.
+    pub winner:  BakerId,
+    /// Whether the block that was made (if any) is
+    /// part of the authorative chain i.e. the block became finalized.
+    pub present: bool,
 }
 
 #[derive(Debug, SerdeDeserialize)]

--- a/src/v1/generated/concordium.rs
+++ b/src/v1/generated/concordium.rs
@@ -45,7 +45,7 @@ pub struct BytesResponse {
 pub struct PeerConnectRequest {
     /// The IP of the peer.
     #[prost(message, optional, tag = "1")]
-    pub ip:   ::core::option::Option<::prost::alloc::string::String>,
+    pub ip: ::core::option::Option<::prost::alloc::string::String>,
     /// The port of the peer.
     #[prost(message, optional, tag = "2")]
     pub port: ::core::option::Option<i32>,
@@ -56,47 +56,52 @@ pub struct PeerConnectRequest {
 pub struct PeerElement {
     /// The id of the node.
     #[prost(message, optional, tag = "1")]
-    pub node_id:        ::core::option::Option<::prost::alloc::string::String>,
+    pub node_id: ::core::option::Option<::prost::alloc::string::String>,
     /// The port of the node.
     #[prost(message, optional, tag = "2")]
-    pub port:           ::core::option::Option<u32>,
+    pub port: ::core::option::Option<u32>,
     /// The IP of the node.
     #[prost(message, optional, tag = "3")]
-    pub ip:             ::core::option::Option<::prost::alloc::string::String>,
+    pub ip: ::core::option::Option<::prost::alloc::string::String>,
     /// The current status of the peer.
     #[prost(enumeration = "peer_element::CatchupStatus", tag = "4")]
     pub catchup_status: i32,
 }
 /// Nested message and enum types in `PeerElement`.
 pub mod peer_element {
-    #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, ::prost::Enumeration)]
+    #[derive(
+        Clone,
+        Copy,
+        Debug,
+        PartialEq,
+        Eq,
+        Hash,
+        PartialOrd,
+        Ord,
+        ::prost::Enumeration
+    )]
     #[repr(i32)]
     pub enum CatchupStatus {
-        /// The peer does not have any data unknown to us. If we receive a
-        /// message from the peer that refers to unknown data (e.g., an
-        /// unknown block) the peer is marked as pending.
-        Uptodate   = 0,
-        /// The peer might have some data unknown to us. A peer can be in this
-        /// state either because it sent a message that refers to data
-        /// unknown to us, or before we have established a baseline with it.
-        /// The latter happens during node startup, as well as upon protocol
-        /// updates until the initial catchup handshake completes.
-        Pending    = 1,
-        /// The node is currently catching up by requesting blocks from this
-        /// peer. There will be at most one peer with this status at a
-        /// time. Once the peer has responded to the request, its status
-        /// will be changed to:
+        /// The peer does not have any data unknown to us. If we receive a message from the
+        /// peer that refers to unknown data (e.g., an unknown block) the peer is marked as pending.
+        Uptodate = 0,
+        /// The peer might have some data unknown to us. A peer can be in this state either because
+        /// it sent a message that refers to data unknown to us, or before we have established a baseline with it.
+        /// The latter happens during node startup, as well as upon protocol updates until the initial catchup handshake
+        /// completes.
+        Pending = 1,
+        /// The node is currently catching up by requesting blocks from this peer.
+        /// There will be at most one peer with this status at a time.
+        /// Once the peer has responded to the request, its status will be changed to:
         /// - 'UPTODATE' if the peer has no more data that is not known to us
         /// - 'PENDING' if the node has more data that is unknown to us.
         Catchingup = 2,
     }
     impl CatchupStatus {
-        /// String value of the enum field names used in the ProtoBuf
-        /// definition.
+        /// String value of the enum field names used in the ProtoBuf definition.
         ///
-        /// The values are not transformed in any way and thus are considered
-        /// stable (if the ProtoBuf definition does not change) and safe
-        /// for programmatic use.
+        /// The values are not transformed in any way and thus are considered stable
+        /// (if the ProtoBuf definition does not change) and safe for programmatic use.
         pub fn as_str_name(&self) -> &'static str {
             match self {
                 CatchupStatus::Uptodate => "UPTODATE",
@@ -104,7 +109,6 @@ pub mod peer_element {
                 CatchupStatus::Catchingup => "CATCHINGUP",
             }
         }
-
         /// Creates an enum from field names used in the ProtoBuf definition.
         pub fn from_str_name(value: &str) -> ::core::option::Option<Self> {
             match value {
@@ -126,7 +130,7 @@ pub struct PeerListResponse {
     pub peer_type: ::prost::alloc::string::String,
     /// A list of peers.
     #[prost(message, repeated, tag = "2")]
-    pub peers:     ::prost::alloc::vec::Vec<PeerElement>,
+    pub peers: ::prost::alloc::vec::Vec<PeerElement>,
 }
 /// A response containing information about a peer.
 #[allow(clippy::derive_partial_eq_without_eq)]
@@ -134,10 +138,10 @@ pub struct PeerListResponse {
 pub struct PeerStatsResponse {
     /// A list of stats for the peers.
     #[prost(message, repeated, tag = "1")]
-    pub peerstats:   ::prost::alloc::vec::Vec<peer_stats_response::PeerStats>,
+    pub peerstats: ::prost::alloc::vec::Vec<peer_stats_response::PeerStats>,
     /// Average outbound throughput in bytes per second.
     #[prost(uint64, tag = "2")]
-    pub avg_bps_in:  u64,
+    pub avg_bps_in: u64,
     /// Average inbound throughput in bytes per second.
     #[prost(uint64, tag = "3")]
     pub avg_bps_out: u64,
@@ -149,16 +153,16 @@ pub mod peer_stats_response {
     pub struct PeerStats {
         /// The node id.
         #[prost(string, tag = "1")]
-        pub node_id:          ::prost::alloc::string::String,
+        pub node_id: ::prost::alloc::string::String,
         /// The number of messages sent to the peer.
         #[prost(uint64, tag = "2")]
-        pub packets_sent:     u64,
+        pub packets_sent: u64,
         /// The number of messages received from the peer.
         #[prost(uint64, tag = "3")]
         pub packets_received: u64,
         /// The connection latency (i.e., ping time) in milliseconds.
         #[prost(uint64, tag = "4")]
-        pub latency:          u64,
+        pub latency: u64,
     }
 }
 /// A request to change the network.
@@ -186,15 +190,12 @@ pub struct NodeInfoResponse {
     #[prost(bool, tag = "4")]
     pub consensus_baker_running: bool,
     /// Whether consensus is running.
-    /// This is only false if the protocol was updated to a version which the
-    /// node software does not support.
+    /// This is only false if the protocol was updated to a version which the node software does not support.
     #[prost(bool, tag = "5")]
     pub consensus_running: bool,
     /// Whether the node is "Active" or "Passive".
-    /// - "Active": the node has baker credentials and can thus potentially
-    ///   participate in baking and finalization.
-    /// - "Passive": the node has no baker credentials is thus only an observer
-    ///   of the consensus protocol.
+    /// - "Active": the node has baker credentials and can thus potentially participate in baking and finalization.
+    /// - "Passive": the node has no baker credentials is thus only an observer of the consensus protocol.
     #[prost(string, tag = "6")]
     pub consensus_type: ::prost::alloc::string::String,
     /// The baking status of the node.
@@ -213,27 +214,33 @@ pub struct NodeInfoResponse {
 }
 /// Nested message and enum types in `NodeInfoResponse`.
 pub mod node_info_response {
-    #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, ::prost::Enumeration)]
+    #[derive(
+        Clone,
+        Copy,
+        Debug,
+        PartialEq,
+        Eq,
+        Hash,
+        PartialOrd,
+        Ord,
+        ::prost::Enumeration
+    )]
     #[repr(i32)]
     pub enum IsInBakingCommittee {
         /// The node is not the baking committee.
-        NotInCommittee    = 0,
-        /// The node has baker keys, but the account is not currently a baker
-        /// (and possibly never will be).
+        NotInCommittee = 0,
+        /// The node has baker keys, but the account is not currently a baker (and possibly never will be).
         AddedButNotActiveInCommittee = 1,
-        /// The node has baker keys, but they don't match the current keys on
-        /// the baker account.
+        /// The node has baker keys, but they don't match the current keys on the baker account.
         AddedButWrongKeys = 2,
         /// The node has valid baker keys and is active in the baker committee.
         ActiveInCommittee = 3,
     }
     impl IsInBakingCommittee {
-        /// String value of the enum field names used in the ProtoBuf
-        /// definition.
+        /// String value of the enum field names used in the ProtoBuf definition.
         ///
-        /// The values are not transformed in any way and thus are considered
-        /// stable (if the ProtoBuf definition does not change) and safe
-        /// for programmatic use.
+        /// The values are not transformed in any way and thus are considered stable
+        /// (if the ProtoBuf definition does not change) and safe for programmatic use.
         pub fn as_str_name(&self) -> &'static str {
             match self {
                 IsInBakingCommittee::NotInCommittee => "NOT_IN_COMMITTEE",
@@ -244,12 +251,13 @@ pub mod node_info_response {
                 IsInBakingCommittee::ActiveInCommittee => "ACTIVE_IN_COMMITTEE",
             }
         }
-
         /// Creates an enum from field names used in the ProtoBuf definition.
         pub fn from_str_name(value: &str) -> ::core::option::Option<Self> {
             match value {
                 "NOT_IN_COMMITTEE" => Some(Self::NotInCommittee),
-                "ADDED_BUT_NOT_ACTIVE_IN_COMMITTEE" => Some(Self::AddedButNotActiveInCommittee),
+                "ADDED_BUT_NOT_ACTIVE_IN_COMMITTEE" => {
+                    Some(Self::AddedButNotActiveInCommittee)
+                }
                 "ADDED_BUT_WRONG_KEYS" => Some(Self::AddedButWrongKeys),
                 "ACTIVE_IN_COMMITTEE" => Some(Self::ActiveInCommittee),
                 _ => None,
@@ -265,8 +273,7 @@ pub struct BlockHash {
     #[prost(string, tag = "1")]
     pub block_hash: ::prost::alloc::string::String,
 }
-/// An account address. Uses a base58-check encoding with a version byte set to
-/// 1. Is always 50 characters long.
+/// An account address. Uses a base58-check encoding with a version byte set to 1. Is always 50 characters long.
 /// Example: "3DJoe7aUwMwVmdFdRU2QsnJfsBbCmQu1QHvEg7YtWFZWmsoBXe"
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
@@ -291,10 +298,10 @@ pub struct BlockHashAndAmount {
     pub block_hash: ::prost::alloc::string::String,
     /// The maximum amount of ancestors that will be returned.
     #[prost(uint64, tag = "2")]
-    pub amount:     u64,
+    pub amount: u64,
 }
-/// Submit a transaction to the node. The transaction is subject to basic
-/// validation and is then relayed to all the peers.
+/// Submit a transaction to the node. The transaction is subject to basic validation
+/// and is then relayed to all the peers.
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct SendTransactionRequest {
@@ -302,22 +309,21 @@ pub struct SendTransactionRequest {
     #[prost(uint32, tag = "1")]
     pub network_id: u32,
     /// The transaction payload in binary encoding.
-    /// The encoding of certain transaction types, along with the general
-    /// payload structure, is described at: <https://developer.concordium.software/en/mainnet/net/references/grpc.html.>
+    /// The encoding of certain transaction types, along with the general payload structure,
+    /// is described at: <https://developer.concordium.software/en/mainnet/net/references/grpc.html.>
     #[prost(bytes = "vec", tag = "2")]
-    pub payload:    ::prost::alloc::vec::Vec<u8>,
+    pub payload: ::prost::alloc::vec::Vec<u8>,
 }
 /// Request for getting information about an account address.
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct GetAddressInfoRequest {
-    /// Hash of the block (encoded in hex) at which the information should be
-    /// gathered.
+    /// Hash of the block (encoded in hex) at which the information should be gathered.
     #[prost(string, tag = "1")]
     pub block_hash: ::prost::alloc::string::String,
     /// The account address to request information about.
     #[prost(string, tag = "2")]
-    pub address:    ::prost::alloc::string::String,
+    pub address: ::prost::alloc::string::String,
 }
 /// Request for invoking a contract without a transaction.
 #[allow(clippy::derive_partial_eq_without_eq)]
@@ -329,7 +335,7 @@ pub struct InvokeContractRequest {
     /// A JSON object that specifies which contract to invoke, and how.
     /// A JSON schema for the context is provided at: <https://developer.concordium.software/en/mainnet/net/references/grpc.html.>
     #[prost(string, tag = "2")]
-    pub context:    ::prost::alloc::string::String,
+    pub context: ::prost::alloc::string::String,
 }
 /// Request for getting the source of a smart contract module.
 #[allow(clippy::derive_partial_eq_without_eq)]
@@ -351,7 +357,7 @@ pub struct DumpRequest {
     pub file: ::prost::alloc::string::String,
     /// Whether the node should dump raw packages.
     #[prost(bool, tag = "2")]
-    pub raw:  bool,
+    pub raw: bool,
 }
 /// Request for getting (information about) the peers.
 #[allow(clippy::derive_partial_eq_without_eq)]
@@ -370,7 +376,7 @@ pub struct GetTransactionStatusInBlockRequest {
     pub transaction_hash: ::prost::alloc::string::String,
     /// The block hash.
     #[prost(string, tag = "2")]
-    pub block_hash:       ::prost::alloc::string::String,
+    pub block_hash: ::prost::alloc::string::String,
 }
 /// Request for getting the status of a pool.
 #[allow(clippy::derive_partial_eq_without_eq)]
@@ -378,14 +384,13 @@ pub struct GetTransactionStatusInBlockRequest {
 pub struct GetPoolStatusRequest {
     /// The block from which the query should be processed.
     #[prost(string, tag = "1")]
-    pub block_hash:         ::prost::alloc::string::String,
+    pub block_hash: ::prost::alloc::string::String,
     /// Whether the request is for passive delegation or a specific baker.
     #[prost(bool, tag = "2")]
     pub passive_delegation: bool,
-    /// The baker id to get the status of. This will be ignored if
-    /// 'passive_delegation' is 'true'.
+    /// The baker id to get the status of. This will be ignored if 'passive_delegation' is 'true'.
     #[prost(uint64, tag = "3")]
-    pub baker_id:           u64,
+    pub baker_id: u64,
 }
 /// Request for gettings the blocks at a specific height.
 #[allow(clippy::derive_partial_eq_without_eq)]
@@ -393,10 +398,10 @@ pub struct GetPoolStatusRequest {
 pub struct BlockHeight {
     /// The block height.
     #[prost(uint64, tag = "1")]
-    pub block_height:              u64,
+    pub block_height: u64,
     /// The block height is relative to the genesis block at this index.
     #[prost(uint32, tag = "2")]
-    pub from_genesis_index:        u32,
+    pub from_genesis_index: u32,
     /// If true, only return results from the specified genesis index.
     #[prost(bool, tag = "3")]
     pub restrict_to_genesis_index: bool,
@@ -404,7 +409,8 @@ pub struct BlockHeight {
 /// Generated client implementations.
 pub mod p2p_client {
     #![allow(unused_variables, dead_code, missing_docs, clippy::let_unit_value)]
-    use tonic::codegen::{http::Uri, *};
+    use tonic::codegen::*;
+    use tonic::codegen::http::Uri;
     #[derive(Debug, Clone)]
     pub struct P2pClient<T> {
         inner: tonic::client::Grpc<T>,
@@ -414,7 +420,8 @@ pub mod p2p_client {
         pub async fn connect<D>(dst: D) -> Result<Self, tonic::transport::Error>
         where
             D: std::convert::TryInto<tonic::transport::Endpoint>,
-            D::Error: Into<StdError>, {
+            D::Error: Into<StdError>,
+        {
             let conn = tonic::transport::Endpoint::new(dst)?.connect().await?;
             Ok(Self::new(conn))
         }
@@ -430,12 +437,10 @@ pub mod p2p_client {
             let inner = tonic::client::Grpc::new(inner);
             Self { inner }
         }
-
         pub fn with_origin(inner: T, origin: Uri) -> Self {
             let inner = tonic::client::Grpc::with_origin(inner, origin);
             Self { inner }
         }
-
         pub fn with_interceptor<F>(
             inner: T,
             interceptor: F,
@@ -449,763 +454,916 @@ pub mod p2p_client {
                     <T as tonic::client::GrpcService<tonic::body::BoxBody>>::ResponseBody,
                 >,
             >,
-            <T as tonic::codegen::Service<http::Request<tonic::body::BoxBody>>>::Error:
-                Into<StdError> + Send + Sync, {
+            <T as tonic::codegen::Service<
+                http::Request<tonic::body::BoxBody>,
+            >>::Error: Into<StdError> + Send + Sync,
+        {
             P2pClient::new(InterceptedService::new(inner, interceptor))
         }
-
         /// Compress requests with the given encoding.
         ///
-        /// This requires the server to support it otherwise it might respond
-        /// with an error.
+        /// This requires the server to support it otherwise it might respond with an
+        /// error.
         #[must_use]
         pub fn send_compressed(mut self, encoding: CompressionEncoding) -> Self {
             self.inner = self.inner.send_compressed(encoding);
             self
         }
-
         /// Enable decompressing responses.
         #[must_use]
         pub fn accept_compressed(mut self, encoding: CompressionEncoding) -> Self {
             self.inner = self.inner.accept_compressed(encoding);
             self
         }
-
         /// Suggest to a peer to connect to the submitted peer details.
         /// This, if successful, adds the peer to the list of given addresses.
         pub async fn peer_connect(
             &mut self,
             request: impl tonic::IntoRequest<super::PeerConnectRequest>,
         ) -> Result<tonic::Response<super::BoolResponse>, tonic::Status> {
-            self.inner.ready().await.map_err(|e| {
-                tonic::Status::new(
-                    tonic::Code::Unknown,
-                    format!("Service was not ready: {}", e.into()),
-                )
-            })?;
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::new(
+                        tonic::Code::Unknown,
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
             let codec = tonic::codec::ProstCodec::default();
-            let path = http::uri::PathAndQuery::from_static("/concordium.P2P/PeerConnect");
+            let path = http::uri::PathAndQuery::from_static(
+                "/concordium.P2P/PeerConnect",
+            );
             self.inner.unary(request.into_request(), path, codec).await
         }
-
-        /// Disconnect from the peer and remove them from the given addresses
-        /// list if they are on it. Return if the request was processed
-        /// successfully.
+        /// Disconnect from the peer and remove them from the given addresses list
+        /// if they are on it. Return if the request was processed successfully.
         pub async fn peer_disconnect(
             &mut self,
             request: impl tonic::IntoRequest<super::PeerConnectRequest>,
         ) -> Result<tonic::Response<super::BoolResponse>, tonic::Status> {
-            self.inner.ready().await.map_err(|e| {
-                tonic::Status::new(
-                    tonic::Code::Unknown,
-                    format!("Service was not ready: {}", e.into()),
-                )
-            })?;
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::new(
+                        tonic::Code::Unknown,
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
             let codec = tonic::codec::ProstCodec::default();
-            let path = http::uri::PathAndQuery::from_static("/concordium.P2P/PeerDisconnect");
+            let path = http::uri::PathAndQuery::from_static(
+                "/concordium.P2P/PeerDisconnect",
+            );
             self.inner.unary(request.into_request(), path, codec).await
         }
-
         /// Uptime of the *node* in milliseconds.
         pub async fn peer_uptime(
             &mut self,
             request: impl tonic::IntoRequest<super::Empty>,
         ) -> Result<tonic::Response<super::NumberResponse>, tonic::Status> {
-            self.inner.ready().await.map_err(|e| {
-                tonic::Status::new(
-                    tonic::Code::Unknown,
-                    format!("Service was not ready: {}", e.into()),
-                )
-            })?;
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::new(
+                        tonic::Code::Unknown,
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
             let codec = tonic::codec::ProstCodec::default();
-            let path = http::uri::PathAndQuery::from_static("/concordium.P2P/PeerUptime");
+            let path = http::uri::PathAndQuery::from_static(
+                "/concordium.P2P/PeerUptime",
+            );
             self.inner.unary(request.into_request(), path, codec).await
         }
-
         /// Total number of sent packets by the node.
         pub async fn peer_total_sent(
             &mut self,
             request: impl tonic::IntoRequest<super::Empty>,
         ) -> Result<tonic::Response<super::NumberResponse>, tonic::Status> {
-            self.inner.ready().await.map_err(|e| {
-                tonic::Status::new(
-                    tonic::Code::Unknown,
-                    format!("Service was not ready: {}", e.into()),
-                )
-            })?;
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::new(
+                        tonic::Code::Unknown,
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
             let codec = tonic::codec::ProstCodec::default();
-            let path = http::uri::PathAndQuery::from_static("/concordium.P2P/PeerTotalSent");
+            let path = http::uri::PathAndQuery::from_static(
+                "/concordium.P2P/PeerTotalSent",
+            );
             self.inner.unary(request.into_request(), path, codec).await
         }
-
         /// Total number of received packets by the node.
         pub async fn peer_total_received(
             &mut self,
             request: impl tonic::IntoRequest<super::Empty>,
         ) -> Result<tonic::Response<super::NumberResponse>, tonic::Status> {
-            self.inner.ready().await.map_err(|e| {
-                tonic::Status::new(
-                    tonic::Code::Unknown,
-                    format!("Service was not ready: {}", e.into()),
-                )
-            })?;
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::new(
+                        tonic::Code::Unknown,
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
             let codec = tonic::codec::ProstCodec::default();
-            let path = http::uri::PathAndQuery::from_static("/concordium.P2P/PeerTotalReceived");
+            let path = http::uri::PathAndQuery::from_static(
+                "/concordium.P2P/PeerTotalReceived",
+            );
             self.inner.unary(request.into_request(), path, codec).await
         }
-
         /// Node software version.
         pub async fn peer_version(
             &mut self,
             request: impl tonic::IntoRequest<super::Empty>,
         ) -> Result<tonic::Response<super::StringResponse>, tonic::Status> {
-            self.inner.ready().await.map_err(|e| {
-                tonic::Status::new(
-                    tonic::Code::Unknown,
-                    format!("Service was not ready: {}", e.into()),
-                )
-            })?;
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::new(
+                        tonic::Code::Unknown,
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
             let codec = tonic::codec::ProstCodec::default();
-            let path = http::uri::PathAndQuery::from_static("/concordium.P2P/PeerVersion");
+            let path = http::uri::PathAndQuery::from_static(
+                "/concordium.P2P/PeerVersion",
+            );
             self.inner.unary(request.into_request(), path, codec).await
         }
-
         /// Stats for connected peers.
         pub async fn peer_stats(
             &mut self,
             request: impl tonic::IntoRequest<super::PeersRequest>,
         ) -> Result<tonic::Response<super::PeerStatsResponse>, tonic::Status> {
-            self.inner.ready().await.map_err(|e| {
-                tonic::Status::new(
-                    tonic::Code::Unknown,
-                    format!("Service was not ready: {}", e.into()),
-                )
-            })?;
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::new(
+                        tonic::Code::Unknown,
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
             let codec = tonic::codec::ProstCodec::default();
             let path = http::uri::PathAndQuery::from_static("/concordium.P2P/PeerStats");
             self.inner.unary(request.into_request(), path, codec).await
         }
-
         /// List of connected peers.
         pub async fn peer_list(
             &mut self,
             request: impl tonic::IntoRequest<super::PeersRequest>,
         ) -> Result<tonic::Response<super::PeerListResponse>, tonic::Status> {
-            self.inner.ready().await.map_err(|e| {
-                tonic::Status::new(
-                    tonic::Code::Unknown,
-                    format!("Service was not ready: {}", e.into()),
-                )
-            })?;
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::new(
+                        tonic::Code::Unknown,
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
             let codec = tonic::codec::ProstCodec::default();
             let path = http::uri::PathAndQuery::from_static("/concordium.P2P/PeerList");
             self.inner.unary(request.into_request(), path, codec).await
         }
-
         /// Ban a the given peer.
         pub async fn ban_node(
             &mut self,
             request: impl tonic::IntoRequest<super::PeerElement>,
         ) -> Result<tonic::Response<super::BoolResponse>, tonic::Status> {
-            self.inner.ready().await.map_err(|e| {
-                tonic::Status::new(
-                    tonic::Code::Unknown,
-                    format!("Service was not ready: {}", e.into()),
-                )
-            })?;
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::new(
+                        tonic::Code::Unknown,
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
             let codec = tonic::codec::ProstCodec::default();
             let path = http::uri::PathAndQuery::from_static("/concordium.P2P/BanNode");
             self.inner.unary(request.into_request(), path, codec).await
         }
-
         /// Unban the given peer.
         pub async fn unban_node(
             &mut self,
             request: impl tonic::IntoRequest<super::PeerElement>,
         ) -> Result<tonic::Response<super::BoolResponse>, tonic::Status> {
-            self.inner.ready().await.map_err(|e| {
-                tonic::Status::new(
-                    tonic::Code::Unknown,
-                    format!("Service was not ready: {}", e.into()),
-                )
-            })?;
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::new(
+                        tonic::Code::Unknown,
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
             let codec = tonic::codec::ProstCodec::default();
             let path = http::uri::PathAndQuery::from_static("/concordium.P2P/UnbanNode");
             self.inner.unary(request.into_request(), path, codec).await
         }
-
         /// Join the provided network.
         pub async fn join_network(
             &mut self,
             request: impl tonic::IntoRequest<super::NetworkChangeRequest>,
         ) -> Result<tonic::Response<super::BoolResponse>, tonic::Status> {
-            self.inner.ready().await.map_err(|e| {
-                tonic::Status::new(
-                    tonic::Code::Unknown,
-                    format!("Service was not ready: {}", e.into()),
-                )
-            })?;
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::new(
+                        tonic::Code::Unknown,
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
             let codec = tonic::codec::ProstCodec::default();
-            let path = http::uri::PathAndQuery::from_static("/concordium.P2P/JoinNetwork");
+            let path = http::uri::PathAndQuery::from_static(
+                "/concordium.P2P/JoinNetwork",
+            );
             self.inner.unary(request.into_request(), path, codec).await
         }
-
         /// Leave the provided network.
         pub async fn leave_network(
             &mut self,
             request: impl tonic::IntoRequest<super::NetworkChangeRequest>,
         ) -> Result<tonic::Response<super::BoolResponse>, tonic::Status> {
-            self.inner.ready().await.map_err(|e| {
-                tonic::Status::new(
-                    tonic::Code::Unknown,
-                    format!("Service was not ready: {}", e.into()),
-                )
-            })?;
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::new(
+                        tonic::Code::Unknown,
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
             let codec = tonic::codec::ProstCodec::default();
-            let path = http::uri::PathAndQuery::from_static("/concordium.P2P/LeaveNetwork");
+            let path = http::uri::PathAndQuery::from_static(
+                "/concordium.P2P/LeaveNetwork",
+            );
             self.inner.unary(request.into_request(), path, codec).await
         }
-
         /// Get information about the running node.
         pub async fn node_info(
             &mut self,
             request: impl tonic::IntoRequest<super::Empty>,
         ) -> Result<tonic::Response<super::NodeInfoResponse>, tonic::Status> {
-            self.inner.ready().await.map_err(|e| {
-                tonic::Status::new(
-                    tonic::Code::Unknown,
-                    format!("Service was not ready: {}", e.into()),
-                )
-            })?;
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::new(
+                        tonic::Code::Unknown,
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
             let codec = tonic::codec::ProstCodec::default();
             let path = http::uri::PathAndQuery::from_static("/concordium.P2P/NodeInfo");
             self.inner.unary(request.into_request(), path, codec).await
         }
-
         /// Get information about the consensus.
         /// A JSON schema for the return type is provided at: https://developer.concordium.software/en/mainnet/net/references/grpc.html.
         pub async fn get_consensus_status(
             &mut self,
             request: impl tonic::IntoRequest<super::Empty>,
         ) -> Result<tonic::Response<super::JsonResponse>, tonic::Status> {
-            self.inner.ready().await.map_err(|e| {
-                tonic::Status::new(
-                    tonic::Code::Unknown,
-                    format!("Service was not ready: {}", e.into()),
-                )
-            })?;
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::new(
+                        tonic::Code::Unknown,
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
             let codec = tonic::codec::ProstCodec::default();
-            let path = http::uri::PathAndQuery::from_static("/concordium.P2P/GetConsensusStatus");
+            let path = http::uri::PathAndQuery::from_static(
+                "/concordium.P2P/GetConsensusStatus",
+            );
             self.inner.unary(request.into_request(), path, codec).await
         }
-
         /// Get information about the block.
         /// A JSON schema for the return type is provided at: https://developer.concordium.software/en/mainnet/net/references/grpc.html.
         pub async fn get_block_info(
             &mut self,
             request: impl tonic::IntoRequest<super::BlockHash>,
         ) -> Result<tonic::Response<super::JsonResponse>, tonic::Status> {
-            self.inner.ready().await.map_err(|e| {
-                tonic::Status::new(
-                    tonic::Code::Unknown,
-                    format!("Service was not ready: {}", e.into()),
-                )
-            })?;
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::new(
+                        tonic::Code::Unknown,
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
             let codec = tonic::codec::ProstCodec::default();
-            let path = http::uri::PathAndQuery::from_static("/concordium.P2P/GetBlockInfo");
+            let path = http::uri::PathAndQuery::from_static(
+                "/concordium.P2P/GetBlockInfo",
+            );
             self.inner.unary(request.into_request(), path, codec).await
         }
-
         /// Get ancestors for the provided block.
         /// A JSON schema for the return type is provided at: https://developer.concordium.software/en/mainnet/net/references/grpc.html.
         pub async fn get_ancestors(
             &mut self,
             request: impl tonic::IntoRequest<super::BlockHashAndAmount>,
         ) -> Result<tonic::Response<super::JsonResponse>, tonic::Status> {
-            self.inner.ready().await.map_err(|e| {
-                tonic::Status::new(
-                    tonic::Code::Unknown,
-                    format!("Service was not ready: {}", e.into()),
-                )
-            })?;
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::new(
+                        tonic::Code::Unknown,
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
             let codec = tonic::codec::ProstCodec::default();
-            let path = http::uri::PathAndQuery::from_static("/concordium.P2P/GetAncestors");
+            let path = http::uri::PathAndQuery::from_static(
+                "/concordium.P2P/GetAncestors",
+            );
             self.inner.unary(request.into_request(), path, codec).await
         }
-
         /// Get the current branches.
         /// A JSON schema for the return type is provided at: https://developer.concordium.software/en/mainnet/net/references/grpc.html.
         pub async fn get_branches(
             &mut self,
             request: impl tonic::IntoRequest<super::Empty>,
         ) -> Result<tonic::Response<super::JsonResponse>, tonic::Status> {
-            self.inner.ready().await.map_err(|e| {
-                tonic::Status::new(
-                    tonic::Code::Unknown,
-                    format!("Service was not ready: {}", e.into()),
-                )
-            })?;
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::new(
+                        tonic::Code::Unknown,
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
             let codec = tonic::codec::ProstCodec::default();
-            let path = http::uri::PathAndQuery::from_static("/concordium.P2P/GetBranches");
+            let path = http::uri::PathAndQuery::from_static(
+                "/concordium.P2P/GetBranches",
+            );
             self.inner.unary(request.into_request(), path, codec).await
         }
-
         /// Get the blocks at the given height.
         /// A JSON schema for the return type is provided at: https://developer.concordium.software/en/mainnet/net/references/grpc.html.
         pub async fn get_blocks_at_height(
             &mut self,
             request: impl tonic::IntoRequest<super::BlockHeight>,
         ) -> Result<tonic::Response<super::JsonResponse>, tonic::Status> {
-            self.inner.ready().await.map_err(|e| {
-                tonic::Status::new(
-                    tonic::Code::Unknown,
-                    format!("Service was not ready: {}", e.into()),
-                )
-            })?;
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::new(
+                        tonic::Code::Unknown,
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
             let codec = tonic::codec::ProstCodec::default();
-            let path = http::uri::PathAndQuery::from_static("/concordium.P2P/GetBlocksAtHeight");
+            let path = http::uri::PathAndQuery::from_static(
+                "/concordium.P2P/GetBlocksAtHeight",
+            );
             self.inner.unary(request.into_request(), path, codec).await
         }
-
         /// Submit a transaction.
         pub async fn send_transaction(
             &mut self,
             request: impl tonic::IntoRequest<super::SendTransactionRequest>,
         ) -> Result<tonic::Response<super::BoolResponse>, tonic::Status> {
-            self.inner.ready().await.map_err(|e| {
-                tonic::Status::new(
-                    tonic::Code::Unknown,
-                    format!("Service was not ready: {}", e.into()),
-                )
-            })?;
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::new(
+                        tonic::Code::Unknown,
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
             let codec = tonic::codec::ProstCodec::default();
-            let path = http::uri::PathAndQuery::from_static("/concordium.P2P/SendTransaction");
+            let path = http::uri::PathAndQuery::from_static(
+                "/concordium.P2P/SendTransaction",
+            );
             self.inner.unary(request.into_request(), path, codec).await
         }
-
         /// Start the baker in the consensus module.
         pub async fn start_baker(
             &mut self,
             request: impl tonic::IntoRequest<super::Empty>,
         ) -> Result<tonic::Response<super::BoolResponse>, tonic::Status> {
-            self.inner.ready().await.map_err(|e| {
-                tonic::Status::new(
-                    tonic::Code::Unknown,
-                    format!("Service was not ready: {}", e.into()),
-                )
-            })?;
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::new(
+                        tonic::Code::Unknown,
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
             let codec = tonic::codec::ProstCodec::default();
-            let path = http::uri::PathAndQuery::from_static("/concordium.P2P/StartBaker");
+            let path = http::uri::PathAndQuery::from_static(
+                "/concordium.P2P/StartBaker",
+            );
             self.inner.unary(request.into_request(), path, codec).await
         }
-
         /// Stop the baker in the consensus module.
         pub async fn stop_baker(
             &mut self,
             request: impl tonic::IntoRequest<super::Empty>,
         ) -> Result<tonic::Response<super::BoolResponse>, tonic::Status> {
-            self.inner.ready().await.map_err(|e| {
-                tonic::Status::new(
-                    tonic::Code::Unknown,
-                    format!("Service was not ready: {}", e.into()),
-                )
-            })?;
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::new(
+                        tonic::Code::Unknown,
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
             let codec = tonic::codec::ProstCodec::default();
             let path = http::uri::PathAndQuery::from_static("/concordium.P2P/StopBaker");
             self.inner.unary(request.into_request(), path, codec).await
         }
-
-        /// Get a list of accounts that exist in the state after the given
-        /// block. A JSON schema for the return type is provided at: https://developer.concordium.software/en/mainnet/net/references/grpc.html.
+        /// Get a list of accounts that exist in the state after the given block.
+        /// A JSON schema for the return type is provided at: https://developer.concordium.software/en/mainnet/net/references/grpc.html.
         pub async fn get_account_list(
             &mut self,
             request: impl tonic::IntoRequest<super::BlockHash>,
         ) -> Result<tonic::Response<super::JsonResponse>, tonic::Status> {
-            self.inner.ready().await.map_err(|e| {
-                tonic::Status::new(
-                    tonic::Code::Unknown,
-                    format!("Service was not ready: {}", e.into()),
-                )
-            })?;
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::new(
+                        tonic::Code::Unknown,
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
             let codec = tonic::codec::ProstCodec::default();
-            let path = http::uri::PathAndQuery::from_static("/concordium.P2P/GetAccountList");
+            let path = http::uri::PathAndQuery::from_static(
+                "/concordium.P2P/GetAccountList",
+            );
             self.inner.unary(request.into_request(), path, codec).await
         }
-
-        /// Get all smart contract instances that exist in the state after the
-        /// given block. A JSON schema for the return type is provided at: https://developer.concordium.software/en/mainnet/net/references/grpc.html.
+        /// Get all smart contract instances that exist in the state after the given block.
+        /// A JSON schema for the return type is provided at: https://developer.concordium.software/en/mainnet/net/references/grpc.html.
         pub async fn get_instances(
             &mut self,
             request: impl tonic::IntoRequest<super::BlockHash>,
         ) -> Result<tonic::Response<super::JsonResponse>, tonic::Status> {
-            self.inner.ready().await.map_err(|e| {
-                tonic::Status::new(
-                    tonic::Code::Unknown,
-                    format!("Service was not ready: {}", e.into()),
-                )
-            })?;
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::new(
+                        tonic::Code::Unknown,
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
             let codec = tonic::codec::ProstCodec::default();
-            let path = http::uri::PathAndQuery::from_static("/concordium.P2P/GetInstances");
+            let path = http::uri::PathAndQuery::from_static(
+                "/concordium.P2P/GetInstances",
+            );
             self.inner.unary(request.into_request(), path, codec).await
         }
-
         /// Get information about an account.
         /// A JSON schema for the return type is provided at: https://developer.concordium.software/en/mainnet/net/references/grpc.html.
         pub async fn get_account_info(
             &mut self,
             request: impl tonic::IntoRequest<super::GetAddressInfoRequest>,
         ) -> Result<tonic::Response<super::JsonResponse>, tonic::Status> {
-            self.inner.ready().await.map_err(|e| {
-                tonic::Status::new(
-                    tonic::Code::Unknown,
-                    format!("Service was not ready: {}", e.into()),
-                )
-            })?;
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::new(
+                        tonic::Code::Unknown,
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
             let codec = tonic::codec::ProstCodec::default();
-            let path = http::uri::PathAndQuery::from_static("/concordium.P2P/GetAccountInfo");
+            let path = http::uri::PathAndQuery::from_static(
+                "/concordium.P2P/GetAccountInfo",
+            );
             self.inner.unary(request.into_request(), path, codec).await
         }
-
         /// Get information about a smart contract instance.
         /// A JSON schema for the return type is provided at: https://developer.concordium.software/en/mainnet/net/references/grpc.html.
         pub async fn get_instance_info(
             &mut self,
             request: impl tonic::IntoRequest<super::GetAddressInfoRequest>,
         ) -> Result<tonic::Response<super::JsonResponse>, tonic::Status> {
-            self.inner.ready().await.map_err(|e| {
-                tonic::Status::new(
-                    tonic::Code::Unknown,
-                    format!("Service was not ready: {}", e.into()),
-                )
-            })?;
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::new(
+                        tonic::Code::Unknown,
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
             let codec = tonic::codec::ProstCodec::default();
-            let path = http::uri::PathAndQuery::from_static("/concordium.P2P/GetInstanceInfo");
+            let path = http::uri::PathAndQuery::from_static(
+                "/concordium.P2P/GetInstanceInfo",
+            );
             self.inner.unary(request.into_request(), path, codec).await
         }
-
-        /// Invoke a smart contract instance and view the result *as if* it had
-        /// been updated at the end of the provided block. This is *not*
-        /// a transaction. A JSON schema for the return type is provided at: https://developer.concordium.software/en/mainnet/net/references/grpc.html.
+        /// Invoke a smart contract instance and view the result *as if* it had been updated at the end of the provided block.
+        /// This is *not* a transaction.
+        /// A JSON schema for the return type is provided at: https://developer.concordium.software/en/mainnet/net/references/grpc.html.
         pub async fn invoke_contract(
             &mut self,
             request: impl tonic::IntoRequest<super::InvokeContractRequest>,
         ) -> Result<tonic::Response<super::JsonResponse>, tonic::Status> {
-            self.inner.ready().await.map_err(|e| {
-                tonic::Status::new(
-                    tonic::Code::Unknown,
-                    format!("Service was not ready: {}", e.into()),
-                )
-            })?;
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::new(
+                        tonic::Code::Unknown,
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
             let codec = tonic::codec::ProstCodec::default();
-            let path = http::uri::PathAndQuery::from_static("/concordium.P2P/InvokeContract");
+            let path = http::uri::PathAndQuery::from_static(
+                "/concordium.P2P/InvokeContract",
+            );
             self.inner.unary(request.into_request(), path, codec).await
         }
-
-        /// Get an overview of the balance of special accounts in the given
-        /// block. A JSON schema for the return type is provided at: https://developer.concordium.software/en/mainnet/net/references/grpc.html.
+        /// Get an overview of the balance of special accounts in the given block.
+        /// A JSON schema for the return type is provided at: https://developer.concordium.software/en/mainnet/net/references/grpc.html.
         pub async fn get_reward_status(
             &mut self,
             request: impl tonic::IntoRequest<super::BlockHash>,
         ) -> Result<tonic::Response<super::JsonResponse>, tonic::Status> {
-            self.inner.ready().await.map_err(|e| {
-                tonic::Status::new(
-                    tonic::Code::Unknown,
-                    format!("Service was not ready: {}", e.into()),
-                )
-            })?;
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::new(
+                        tonic::Code::Unknown,
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
             let codec = tonic::codec::ProstCodec::default();
-            let path = http::uri::PathAndQuery::from_static("/concordium.P2P/GetRewardStatus");
+            let path = http::uri::PathAndQuery::from_static(
+                "/concordium.P2P/GetRewardStatus",
+            );
             self.inner.unary(request.into_request(), path, codec).await
         }
-
         /// Get an overview of the parameters used for baking.
         /// A JSON schema for the return type is provided at: https://developer.concordium.software/en/mainnet/net/references/grpc.html.
         pub async fn get_birk_parameters(
             &mut self,
             request: impl tonic::IntoRequest<super::BlockHash>,
         ) -> Result<tonic::Response<super::JsonResponse>, tonic::Status> {
-            self.inner.ready().await.map_err(|e| {
-                tonic::Status::new(
-                    tonic::Code::Unknown,
-                    format!("Service was not ready: {}", e.into()),
-                )
-            })?;
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::new(
+                        tonic::Code::Unknown,
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
             let codec = tonic::codec::ProstCodec::default();
-            let path = http::uri::PathAndQuery::from_static("/concordium.P2P/GetBirkParameters");
+            let path = http::uri::PathAndQuery::from_static(
+                "/concordium.P2P/GetBirkParameters",
+            );
             self.inner.unary(request.into_request(), path, codec).await
         }
-
-        /// Get a list of smart contract modules that exist in the state after
-        /// the given block. A JSON schema for the return type is provided at: https://developer.concordium.software/en/mainnet/net/references/grpc.html.
+        /// Get a list of smart contract modules that exist in the state after the given block.
+        /// A JSON schema for the return type is provided at: https://developer.concordium.software/en/mainnet/net/references/grpc.html.
         pub async fn get_module_list(
             &mut self,
             request: impl tonic::IntoRequest<super::BlockHash>,
         ) -> Result<tonic::Response<super::JsonResponse>, tonic::Status> {
-            self.inner.ready().await.map_err(|e| {
-                tonic::Status::new(
-                    tonic::Code::Unknown,
-                    format!("Service was not ready: {}", e.into()),
-                )
-            })?;
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::new(
+                        tonic::Code::Unknown,
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
             let codec = tonic::codec::ProstCodec::default();
-            let path = http::uri::PathAndQuery::from_static("/concordium.P2P/GetModuleList");
+            let path = http::uri::PathAndQuery::from_static(
+                "/concordium.P2P/GetModuleList",
+            );
             self.inner.unary(request.into_request(), path, codec).await
         }
-
         /// Get the source of a smart contract module.
         pub async fn get_module_source(
             &mut self,
             request: impl tonic::IntoRequest<super::GetModuleSourceRequest>,
         ) -> Result<tonic::Response<super::BytesResponse>, tonic::Status> {
-            self.inner.ready().await.map_err(|e| {
-                tonic::Status::new(
-                    tonic::Code::Unknown,
-                    format!("Service was not ready: {}", e.into()),
-                )
-            })?;
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::new(
+                        tonic::Code::Unknown,
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
             let codec = tonic::codec::ProstCodec::default();
-            let path = http::uri::PathAndQuery::from_static("/concordium.P2P/GetModuleSource");
+            let path = http::uri::PathAndQuery::from_static(
+                "/concordium.P2P/GetModuleSource",
+            );
             self.inner.unary(request.into_request(), path, codec).await
         }
-
-        /// Get a list of all identity providers that exist in the state after
-        /// the given block. A JSON schema for the return type is provided at: https://developer.concordium.software/en/mainnet/net/references/grpc.html.
+        /// Get a list of all identity providers that exist in the state after the given block.
+        /// A JSON schema for the return type is provided at: https://developer.concordium.software/en/mainnet/net/references/grpc.html.
         pub async fn get_identity_providers(
             &mut self,
             request: impl tonic::IntoRequest<super::BlockHash>,
         ) -> Result<tonic::Response<super::JsonResponse>, tonic::Status> {
-            self.inner.ready().await.map_err(|e| {
-                tonic::Status::new(
-                    tonic::Code::Unknown,
-                    format!("Service was not ready: {}", e.into()),
-                )
-            })?;
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::new(
+                        tonic::Code::Unknown,
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
             let codec = tonic::codec::ProstCodec::default();
-            let path = http::uri::PathAndQuery::from_static("/concordium.P2P/GetIdentityProviders");
+            let path = http::uri::PathAndQuery::from_static(
+                "/concordium.P2P/GetIdentityProviders",
+            );
             self.inner.unary(request.into_request(), path, codec).await
         }
-
-        /// Get a list of all anonymity revokers that exist in the state after
-        /// the given block. A JSON schema for the return type is provided at: https://developer.concordium.software/en/mainnet/net/references/grpc.html.
+        /// Get a list of all anonymity revokers that exist in the state after the given block.
+        /// A JSON schema for the return type is provided at: https://developer.concordium.software/en/mainnet/net/references/grpc.html.
         pub async fn get_anonymity_revokers(
             &mut self,
             request: impl tonic::IntoRequest<super::BlockHash>,
         ) -> Result<tonic::Response<super::JsonResponse>, tonic::Status> {
-            self.inner.ready().await.map_err(|e| {
-                tonic::Status::new(
-                    tonic::Code::Unknown,
-                    format!("Service was not ready: {}", e.into()),
-                )
-            })?;
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::new(
+                        tonic::Code::Unknown,
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
             let codec = tonic::codec::ProstCodec::default();
-            let path = http::uri::PathAndQuery::from_static("/concordium.P2P/GetAnonymityRevokers");
+            let path = http::uri::PathAndQuery::from_static(
+                "/concordium.P2P/GetAnonymityRevokers",
+            );
             self.inner.unary(request.into_request(), path, codec).await
         }
-
         /// Get the cryptographic parameters used in the given block.
         /// A JSON schema for the return type is provided at: https://developer.concordium.software/en/mainnet/net/references/grpc.html.
         pub async fn get_cryptographic_parameters(
             &mut self,
             request: impl tonic::IntoRequest<super::BlockHash>,
         ) -> Result<tonic::Response<super::JsonResponse>, tonic::Status> {
-            self.inner.ready().await.map_err(|e| {
-                tonic::Status::new(
-                    tonic::Code::Unknown,
-                    format!("Service was not ready: {}", e.into()),
-                )
-            })?;
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::new(
+                        tonic::Code::Unknown,
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
             let codec = tonic::codec::ProstCodec::default();
-            let path =
-                http::uri::PathAndQuery::from_static("/concordium.P2P/GetCryptographicParameters");
+            let path = http::uri::PathAndQuery::from_static(
+                "/concordium.P2P/GetCryptographicParameters",
+            );
             self.inner.unary(request.into_request(), path, codec).await
         }
-
-        /// Get a list of all baker IDs registered at that block in ascending
-        /// order. Or null, if the block is invalid. A JSON schema for the return type is provided at: https://developer.concordium.software/en/mainnet/net/references/grpc.html.
+        /// Get a list of all baker IDs registered at that block in ascending order. Or null, if the block is invalid.
+        /// A JSON schema for the return type is provided at: https://developer.concordium.software/en/mainnet/net/references/grpc.html.
         pub async fn get_baker_list(
             &mut self,
             request: impl tonic::IntoRequest<super::BlockHash>,
         ) -> Result<tonic::Response<super::JsonResponse>, tonic::Status> {
-            self.inner.ready().await.map_err(|e| {
-                tonic::Status::new(
-                    tonic::Code::Unknown,
-                    format!("Service was not ready: {}", e.into()),
-                )
-            })?;
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::new(
+                        tonic::Code::Unknown,
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
             let codec = tonic::codec::ProstCodec::default();
-            let path = http::uri::PathAndQuery::from_static("/concordium.P2P/GetBakerList");
+            let path = http::uri::PathAndQuery::from_static(
+                "/concordium.P2P/GetBakerList",
+            );
             self.inner.unary(request.into_request(), path, codec).await
         }
-
-        /// Get the status of a pool. If passiveDelegation == true, this returns
-        /// the status for the passive delegators. Otherwise, it returns
-        /// the status for the baker with the specified ID (if it exists). A JSON schema for the return type is provided at: https://developer.concordium.software/en/mainnet/net/references/grpc.html.
+        /// Get the status of a pool. If passiveDelegation == true, this returns the status for the passive delegators.
+        /// Otherwise, it returns the status for the baker with the specified ID (if it exists).
+        /// A JSON schema for the return type is provided at: https://developer.concordium.software/en/mainnet/net/references/grpc.html.
         pub async fn get_pool_status(
             &mut self,
             request: impl tonic::IntoRequest<super::GetPoolStatusRequest>,
         ) -> Result<tonic::Response<super::JsonResponse>, tonic::Status> {
-            self.inner.ready().await.map_err(|e| {
-                tonic::Status::new(
-                    tonic::Code::Unknown,
-                    format!("Service was not ready: {}", e.into()),
-                )
-            })?;
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::new(
+                        tonic::Code::Unknown,
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
             let codec = tonic::codec::ProstCodec::default();
-            let path = http::uri::PathAndQuery::from_static("/concordium.P2P/GetPoolStatus");
+            let path = http::uri::PathAndQuery::from_static(
+                "/concordium.P2P/GetPoolStatus",
+            );
             self.inner.unary(request.into_request(), path, codec).await
         }
-
         /// Get a list of banned peers.
         pub async fn get_banned_peers(
             &mut self,
             request: impl tonic::IntoRequest<super::Empty>,
         ) -> Result<tonic::Response<super::PeerListResponse>, tonic::Status> {
-            self.inner.ready().await.map_err(|e| {
-                tonic::Status::new(
-                    tonic::Code::Unknown,
-                    format!("Service was not ready: {}", e.into()),
-                )
-            })?;
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::new(
+                        tonic::Code::Unknown,
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
             let codec = tonic::codec::ProstCodec::default();
-            let path = http::uri::PathAndQuery::from_static("/concordium.P2P/GetBannedPeers");
+            let path = http::uri::PathAndQuery::from_static(
+                "/concordium.P2P/GetBannedPeers",
+            );
             self.inner.unary(request.into_request(), path, codec).await
         }
-
         /// Shut down the node.
         pub async fn shutdown(
             &mut self,
             request: impl tonic::IntoRequest<super::Empty>,
         ) -> Result<tonic::Response<super::BoolResponse>, tonic::Status> {
-            self.inner.ready().await.map_err(|e| {
-                tonic::Status::new(
-                    tonic::Code::Unknown,
-                    format!("Service was not ready: {}", e.into()),
-                )
-            })?;
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::new(
+                        tonic::Code::Unknown,
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
             let codec = tonic::codec::ProstCodec::default();
             let path = http::uri::PathAndQuery::from_static("/concordium.P2P/Shutdown");
             self.inner.unary(request.into_request(), path, codec).await
         }
-
         /// Start dumping packages into the specified file.
         /// Only enabled if the node was built with the `network_dump` feature.
         pub async fn dump_start(
             &mut self,
             request: impl tonic::IntoRequest<super::DumpRequest>,
         ) -> Result<tonic::Response<super::BoolResponse>, tonic::Status> {
-            self.inner.ready().await.map_err(|e| {
-                tonic::Status::new(
-                    tonic::Code::Unknown,
-                    format!("Service was not ready: {}", e.into()),
-                )
-            })?;
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::new(
+                        tonic::Code::Unknown,
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
             let codec = tonic::codec::ProstCodec::default();
             let path = http::uri::PathAndQuery::from_static("/concordium.P2P/DumpStart");
             self.inner.unary(request.into_request(), path, codec).await
         }
-
         /// Stop dumping packages.
         /// Only enabled if the node was built with the `network_dump` feature.
         pub async fn dump_stop(
             &mut self,
             request: impl tonic::IntoRequest<super::Empty>,
         ) -> Result<tonic::Response<super::BoolResponse>, tonic::Status> {
-            self.inner.ready().await.map_err(|e| {
-                tonic::Status::new(
-                    tonic::Code::Unknown,
-                    format!("Service was not ready: {}", e.into()),
-                )
-            })?;
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::new(
+                        tonic::Code::Unknown,
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
             let codec = tonic::codec::ProstCodec::default();
             let path = http::uri::PathAndQuery::from_static("/concordium.P2P/DumpStop");
             self.inner.unary(request.into_request(), path, codec).await
         }
-
         /// Query for the status of a transaction by its hash.
         /// A JSON schema for the return type is provided at: https://developer.concordium.software/en/mainnet/net/references/grpc.html.
         pub async fn get_transaction_status(
             &mut self,
             request: impl tonic::IntoRequest<super::TransactionHash>,
         ) -> Result<tonic::Response<super::JsonResponse>, tonic::Status> {
-            self.inner.ready().await.map_err(|e| {
-                tonic::Status::new(
-                    tonic::Code::Unknown,
-                    format!("Service was not ready: {}", e.into()),
-                )
-            })?;
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::new(
+                        tonic::Code::Unknown,
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
             let codec = tonic::codec::ProstCodec::default();
-            let path = http::uri::PathAndQuery::from_static("/concordium.P2P/GetTransactionStatus");
+            let path = http::uri::PathAndQuery::from_static(
+                "/concordium.P2P/GetTransactionStatus",
+            );
             self.inner.unary(request.into_request(), path, codec).await
         }
-
         /// Query for transactions in a block by its hash.
         /// A JSON schema for the return type is provided at: https://developer.concordium.software/en/mainnet/net/references/grpc.html.
         pub async fn get_transaction_status_in_block(
             &mut self,
             request: impl tonic::IntoRequest<super::GetTransactionStatusInBlockRequest>,
         ) -> Result<tonic::Response<super::JsonResponse>, tonic::Status> {
-            self.inner.ready().await.map_err(|e| {
-                tonic::Status::new(
-                    tonic::Code::Unknown,
-                    format!("Service was not ready: {}", e.into()),
-                )
-            })?;
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::new(
+                        tonic::Code::Unknown,
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
             let codec = tonic::codec::ProstCodec::default();
-            let path =
-                http::uri::PathAndQuery::from_static("/concordium.P2P/GetTransactionStatusInBlock");
+            let path = http::uri::PathAndQuery::from_static(
+                "/concordium.P2P/GetTransactionStatusInBlock",
+            );
             self.inner.unary(request.into_request(), path, codec).await
         }
-
-        /// Query for non-finalized transactions present on an account by the
-        /// account address. A JSON schema for the return type is provided at: https://developer.concordium.software/en/mainnet/net/references/grpc.html.
+        /// Query for non-finalized transactions present on an account by the account address.
+        /// A JSON schema for the return type is provided at: https://developer.concordium.software/en/mainnet/net/references/grpc.html.
         pub async fn get_account_non_finalized_transactions(
             &mut self,
             request: impl tonic::IntoRequest<super::AccountAddress>,
         ) -> Result<tonic::Response<super::JsonResponse>, tonic::Status> {
-            self.inner.ready().await.map_err(|e| {
-                tonic::Status::new(
-                    tonic::Code::Unknown,
-                    format!("Service was not ready: {}", e.into()),
-                )
-            })?;
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::new(
+                        tonic::Code::Unknown,
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
             let codec = tonic::codec::ProstCodec::default();
             let path = http::uri::PathAndQuery::from_static(
                 "/concordium.P2P/GetAccountNonFinalizedTransactions",
             );
             self.inner.unary(request.into_request(), path, codec).await
         }
-
         /// Request a summary for a block by its hash.
         /// A JSON schema for the return type is provided at: https://developer.concordium.software/en/mainnet/net/references/grpc.html.
         pub async fn get_block_summary(
             &mut self,
             request: impl tonic::IntoRequest<super::BlockHash>,
         ) -> Result<tonic::Response<super::JsonResponse>, tonic::Status> {
-            self.inner.ready().await.map_err(|e| {
-                tonic::Status::new(
-                    tonic::Code::Unknown,
-                    format!("Service was not ready: {}", e.into()),
-                )
-            })?;
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::new(
+                        tonic::Code::Unknown,
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
             let codec = tonic::codec::ProstCodec::default();
-            let path = http::uri::PathAndQuery::from_static("/concordium.P2P/GetBlockSummary");
+            let path = http::uri::PathAndQuery::from_static(
+                "/concordium.P2P/GetBlockSummary",
+            );
             self.inner.unary(request.into_request(), path, codec).await
         }
-
         /// Request next nonce information for an account.
         /// A JSON schema for the return type is provided at: https://developer.concordium.software/en/mainnet/net/references/grpc.html.
         pub async fn get_next_account_nonce(
             &mut self,
             request: impl tonic::IntoRequest<super::AccountAddress>,
         ) -> Result<tonic::Response<super::JsonResponse>, tonic::Status> {
-            self.inner.ready().await.map_err(|e| {
-                tonic::Status::new(
-                    tonic::Code::Unknown,
-                    format!("Service was not ready: {}", e.into()),
-                )
-            })?;
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::new(
+                        tonic::Code::Unknown,
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
             let codec = tonic::codec::ProstCodec::default();
-            let path = http::uri::PathAndQuery::from_static("/concordium.P2P/GetNextAccountNonce");
+            let path = http::uri::PathAndQuery::from_static(
+                "/concordium.P2P/GetNextAccountNonce",
+            );
             self.inner.unary(request.into_request(), path, codec).await
         }
     }

--- a/src/v1/generated/concordium.rs
+++ b/src/v1/generated/concordium.rs
@@ -45,7 +45,7 @@ pub struct BytesResponse {
 pub struct PeerConnectRequest {
     /// The IP of the peer.
     #[prost(message, optional, tag = "1")]
-    pub ip: ::core::option::Option<::prost::alloc::string::String>,
+    pub ip:   ::core::option::Option<::prost::alloc::string::String>,
     /// The port of the peer.
     #[prost(message, optional, tag = "2")]
     pub port: ::core::option::Option<i32>,
@@ -56,52 +56,47 @@ pub struct PeerConnectRequest {
 pub struct PeerElement {
     /// The id of the node.
     #[prost(message, optional, tag = "1")]
-    pub node_id: ::core::option::Option<::prost::alloc::string::String>,
+    pub node_id:        ::core::option::Option<::prost::alloc::string::String>,
     /// The port of the node.
     #[prost(message, optional, tag = "2")]
-    pub port: ::core::option::Option<u32>,
+    pub port:           ::core::option::Option<u32>,
     /// The IP of the node.
     #[prost(message, optional, tag = "3")]
-    pub ip: ::core::option::Option<::prost::alloc::string::String>,
+    pub ip:             ::core::option::Option<::prost::alloc::string::String>,
     /// The current status of the peer.
     #[prost(enumeration = "peer_element::CatchupStatus", tag = "4")]
     pub catchup_status: i32,
 }
 /// Nested message and enum types in `PeerElement`.
 pub mod peer_element {
-    #[derive(
-        Clone,
-        Copy,
-        Debug,
-        PartialEq,
-        Eq,
-        Hash,
-        PartialOrd,
-        Ord,
-        ::prost::Enumeration
-    )]
+    #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, ::prost::Enumeration)]
     #[repr(i32)]
     pub enum CatchupStatus {
-        /// The peer does not have any data unknown to us. If we receive a message from the
-        /// peer that refers to unknown data (e.g., an unknown block) the peer is marked as pending.
-        Uptodate = 0,
-        /// The peer might have some data unknown to us. A peer can be in this state either because
-        /// it sent a message that refers to data unknown to us, or before we have established a baseline with it.
-        /// The latter happens during node startup, as well as upon protocol updates until the initial catchup handshake
-        /// completes.
-        Pending = 1,
-        /// The node is currently catching up by requesting blocks from this peer.
-        /// There will be at most one peer with this status at a time.
-        /// Once the peer has responded to the request, its status will be changed to:
+        /// The peer does not have any data unknown to us. If we receive a
+        /// message from the peer that refers to unknown data (e.g., an
+        /// unknown block) the peer is marked as pending.
+        Uptodate   = 0,
+        /// The peer might have some data unknown to us. A peer can be in this
+        /// state either because it sent a message that refers to data
+        /// unknown to us, or before we have established a baseline with it.
+        /// The latter happens during node startup, as well as upon protocol
+        /// updates until the initial catchup handshake completes.
+        Pending    = 1,
+        /// The node is currently catching up by requesting blocks from this
+        /// peer. There will be at most one peer with this status at a
+        /// time. Once the peer has responded to the request, its status
+        /// will be changed to:
         /// - 'UPTODATE' if the peer has no more data that is not known to us
         /// - 'PENDING' if the node has more data that is unknown to us.
         Catchingup = 2,
     }
     impl CatchupStatus {
-        /// String value of the enum field names used in the ProtoBuf definition.
+        /// String value of the enum field names used in the ProtoBuf
+        /// definition.
         ///
-        /// The values are not transformed in any way and thus are considered stable
-        /// (if the ProtoBuf definition does not change) and safe for programmatic use.
+        /// The values are not transformed in any way and thus are considered
+        /// stable (if the ProtoBuf definition does not change) and safe
+        /// for programmatic use.
         pub fn as_str_name(&self) -> &'static str {
             match self {
                 CatchupStatus::Uptodate => "UPTODATE",
@@ -109,6 +104,7 @@ pub mod peer_element {
                 CatchupStatus::Catchingup => "CATCHINGUP",
             }
         }
+
         /// Creates an enum from field names used in the ProtoBuf definition.
         pub fn from_str_name(value: &str) -> ::core::option::Option<Self> {
             match value {
@@ -130,7 +126,7 @@ pub struct PeerListResponse {
     pub peer_type: ::prost::alloc::string::String,
     /// A list of peers.
     #[prost(message, repeated, tag = "2")]
-    pub peers: ::prost::alloc::vec::Vec<PeerElement>,
+    pub peers:     ::prost::alloc::vec::Vec<PeerElement>,
 }
 /// A response containing information about a peer.
 #[allow(clippy::derive_partial_eq_without_eq)]
@@ -138,10 +134,10 @@ pub struct PeerListResponse {
 pub struct PeerStatsResponse {
     /// A list of stats for the peers.
     #[prost(message, repeated, tag = "1")]
-    pub peerstats: ::prost::alloc::vec::Vec<peer_stats_response::PeerStats>,
+    pub peerstats:   ::prost::alloc::vec::Vec<peer_stats_response::PeerStats>,
     /// Average outbound throughput in bytes per second.
     #[prost(uint64, tag = "2")]
-    pub avg_bps_in: u64,
+    pub avg_bps_in:  u64,
     /// Average inbound throughput in bytes per second.
     #[prost(uint64, tag = "3")]
     pub avg_bps_out: u64,
@@ -153,16 +149,16 @@ pub mod peer_stats_response {
     pub struct PeerStats {
         /// The node id.
         #[prost(string, tag = "1")]
-        pub node_id: ::prost::alloc::string::String,
+        pub node_id:          ::prost::alloc::string::String,
         /// The number of messages sent to the peer.
         #[prost(uint64, tag = "2")]
-        pub packets_sent: u64,
+        pub packets_sent:     u64,
         /// The number of messages received from the peer.
         #[prost(uint64, tag = "3")]
         pub packets_received: u64,
         /// The connection latency (i.e., ping time) in milliseconds.
         #[prost(uint64, tag = "4")]
-        pub latency: u64,
+        pub latency:          u64,
     }
 }
 /// A request to change the network.
@@ -190,12 +186,15 @@ pub struct NodeInfoResponse {
     #[prost(bool, tag = "4")]
     pub consensus_baker_running: bool,
     /// Whether consensus is running.
-    /// This is only false if the protocol was updated to a version which the node software does not support.
+    /// This is only false if the protocol was updated to a version which the
+    /// node software does not support.
     #[prost(bool, tag = "5")]
     pub consensus_running: bool,
     /// Whether the node is "Active" or "Passive".
-    /// - "Active": the node has baker credentials and can thus potentially participate in baking and finalization.
-    /// - "Passive": the node has no baker credentials is thus only an observer of the consensus protocol.
+    /// - "Active": the node has baker credentials and can thus potentially
+    ///   participate in baking and finalization.
+    /// - "Passive": the node has no baker credentials is thus only an observer
+    ///   of the consensus protocol.
     #[prost(string, tag = "6")]
     pub consensus_type: ::prost::alloc::string::String,
     /// The baking status of the node.
@@ -214,33 +213,27 @@ pub struct NodeInfoResponse {
 }
 /// Nested message and enum types in `NodeInfoResponse`.
 pub mod node_info_response {
-    #[derive(
-        Clone,
-        Copy,
-        Debug,
-        PartialEq,
-        Eq,
-        Hash,
-        PartialOrd,
-        Ord,
-        ::prost::Enumeration
-    )]
+    #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, ::prost::Enumeration)]
     #[repr(i32)]
     pub enum IsInBakingCommittee {
         /// The node is not the baking committee.
-        NotInCommittee = 0,
-        /// The node has baker keys, but the account is not currently a baker (and possibly never will be).
+        NotInCommittee    = 0,
+        /// The node has baker keys, but the account is not currently a baker
+        /// (and possibly never will be).
         AddedButNotActiveInCommittee = 1,
-        /// The node has baker keys, but they don't match the current keys on the baker account.
+        /// The node has baker keys, but they don't match the current keys on
+        /// the baker account.
         AddedButWrongKeys = 2,
         /// The node has valid baker keys and is active in the baker committee.
         ActiveInCommittee = 3,
     }
     impl IsInBakingCommittee {
-        /// String value of the enum field names used in the ProtoBuf definition.
+        /// String value of the enum field names used in the ProtoBuf
+        /// definition.
         ///
-        /// The values are not transformed in any way and thus are considered stable
-        /// (if the ProtoBuf definition does not change) and safe for programmatic use.
+        /// The values are not transformed in any way and thus are considered
+        /// stable (if the ProtoBuf definition does not change) and safe
+        /// for programmatic use.
         pub fn as_str_name(&self) -> &'static str {
             match self {
                 IsInBakingCommittee::NotInCommittee => "NOT_IN_COMMITTEE",
@@ -251,13 +244,12 @@ pub mod node_info_response {
                 IsInBakingCommittee::ActiveInCommittee => "ACTIVE_IN_COMMITTEE",
             }
         }
+
         /// Creates an enum from field names used in the ProtoBuf definition.
         pub fn from_str_name(value: &str) -> ::core::option::Option<Self> {
             match value {
                 "NOT_IN_COMMITTEE" => Some(Self::NotInCommittee),
-                "ADDED_BUT_NOT_ACTIVE_IN_COMMITTEE" => {
-                    Some(Self::AddedButNotActiveInCommittee)
-                }
+                "ADDED_BUT_NOT_ACTIVE_IN_COMMITTEE" => Some(Self::AddedButNotActiveInCommittee),
                 "ADDED_BUT_WRONG_KEYS" => Some(Self::AddedButWrongKeys),
                 "ACTIVE_IN_COMMITTEE" => Some(Self::ActiveInCommittee),
                 _ => None,
@@ -273,7 +265,8 @@ pub struct BlockHash {
     #[prost(string, tag = "1")]
     pub block_hash: ::prost::alloc::string::String,
 }
-/// An account address. Uses a base58-check encoding with a version byte set to 1. Is always 50 characters long.
+/// An account address. Uses a base58-check encoding with a version byte set to
+/// 1. Is always 50 characters long.
 /// Example: "3DJoe7aUwMwVmdFdRU2QsnJfsBbCmQu1QHvEg7YtWFZWmsoBXe"
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
@@ -298,10 +291,10 @@ pub struct BlockHashAndAmount {
     pub block_hash: ::prost::alloc::string::String,
     /// The maximum amount of ancestors that will be returned.
     #[prost(uint64, tag = "2")]
-    pub amount: u64,
+    pub amount:     u64,
 }
-/// Submit a transaction to the node. The transaction is subject to basic validation
-/// and is then relayed to all the peers.
+/// Submit a transaction to the node. The transaction is subject to basic
+/// validation and is then relayed to all the peers.
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct SendTransactionRequest {
@@ -309,21 +302,22 @@ pub struct SendTransactionRequest {
     #[prost(uint32, tag = "1")]
     pub network_id: u32,
     /// The transaction payload in binary encoding.
-    /// The encoding of certain transaction types, along with the general payload structure,
-    /// is described at: <https://developer.concordium.software/en/mainnet/net/references/grpc.html.>
+    /// The encoding of certain transaction types, along with the general
+    /// payload structure, is described at: <https://developer.concordium.software/en/mainnet/net/references/grpc.html.>
     #[prost(bytes = "vec", tag = "2")]
-    pub payload: ::prost::alloc::vec::Vec<u8>,
+    pub payload:    ::prost::alloc::vec::Vec<u8>,
 }
 /// Request for getting information about an account address.
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct GetAddressInfoRequest {
-    /// Hash of the block (encoded in hex) at which the information should be gathered.
+    /// Hash of the block (encoded in hex) at which the information should be
+    /// gathered.
     #[prost(string, tag = "1")]
     pub block_hash: ::prost::alloc::string::String,
     /// The account address to request information about.
     #[prost(string, tag = "2")]
-    pub address: ::prost::alloc::string::String,
+    pub address:    ::prost::alloc::string::String,
 }
 /// Request for invoking a contract without a transaction.
 #[allow(clippy::derive_partial_eq_without_eq)]
@@ -335,7 +329,7 @@ pub struct InvokeContractRequest {
     /// A JSON object that specifies which contract to invoke, and how.
     /// A JSON schema for the context is provided at: <https://developer.concordium.software/en/mainnet/net/references/grpc.html.>
     #[prost(string, tag = "2")]
-    pub context: ::prost::alloc::string::String,
+    pub context:    ::prost::alloc::string::String,
 }
 /// Request for getting the source of a smart contract module.
 #[allow(clippy::derive_partial_eq_without_eq)]
@@ -357,7 +351,7 @@ pub struct DumpRequest {
     pub file: ::prost::alloc::string::String,
     /// Whether the node should dump raw packages.
     #[prost(bool, tag = "2")]
-    pub raw: bool,
+    pub raw:  bool,
 }
 /// Request for getting (information about) the peers.
 #[allow(clippy::derive_partial_eq_without_eq)]
@@ -376,7 +370,7 @@ pub struct GetTransactionStatusInBlockRequest {
     pub transaction_hash: ::prost::alloc::string::String,
     /// The block hash.
     #[prost(string, tag = "2")]
-    pub block_hash: ::prost::alloc::string::String,
+    pub block_hash:       ::prost::alloc::string::String,
 }
 /// Request for getting the status of a pool.
 #[allow(clippy::derive_partial_eq_without_eq)]
@@ -384,13 +378,14 @@ pub struct GetTransactionStatusInBlockRequest {
 pub struct GetPoolStatusRequest {
     /// The block from which the query should be processed.
     #[prost(string, tag = "1")]
-    pub block_hash: ::prost::alloc::string::String,
+    pub block_hash:         ::prost::alloc::string::String,
     /// Whether the request is for passive delegation or a specific baker.
     #[prost(bool, tag = "2")]
     pub passive_delegation: bool,
-    /// The baker id to get the status of. This will be ignored if 'passive_delegation' is 'true'.
+    /// The baker id to get the status of. This will be ignored if
+    /// 'passive_delegation' is 'true'.
     #[prost(uint64, tag = "3")]
-    pub baker_id: u64,
+    pub baker_id:           u64,
 }
 /// Request for gettings the blocks at a specific height.
 #[allow(clippy::derive_partial_eq_without_eq)]
@@ -398,10 +393,10 @@ pub struct GetPoolStatusRequest {
 pub struct BlockHeight {
     /// The block height.
     #[prost(uint64, tag = "1")]
-    pub block_height: u64,
+    pub block_height:              u64,
     /// The block height is relative to the genesis block at this index.
     #[prost(uint32, tag = "2")]
-    pub from_genesis_index: u32,
+    pub from_genesis_index:        u32,
     /// If true, only return results from the specified genesis index.
     #[prost(bool, tag = "3")]
     pub restrict_to_genesis_index: bool,
@@ -409,8 +404,7 @@ pub struct BlockHeight {
 /// Generated client implementations.
 pub mod p2p_client {
     #![allow(unused_variables, dead_code, missing_docs, clippy::let_unit_value)]
-    use tonic::codegen::*;
-    use tonic::codegen::http::Uri;
+    use tonic::codegen::{http::Uri, *};
     #[derive(Debug, Clone)]
     pub struct P2pClient<T> {
         inner: tonic::client::Grpc<T>,
@@ -420,8 +414,7 @@ pub mod p2p_client {
         pub async fn connect<D>(dst: D) -> Result<Self, tonic::transport::Error>
         where
             D: std::convert::TryInto<tonic::transport::Endpoint>,
-            D::Error: Into<StdError>,
-        {
+            D::Error: Into<StdError>, {
             let conn = tonic::transport::Endpoint::new(dst)?.connect().await?;
             Ok(Self::new(conn))
         }
@@ -437,10 +430,12 @@ pub mod p2p_client {
             let inner = tonic::client::Grpc::new(inner);
             Self { inner }
         }
+
         pub fn with_origin(inner: T, origin: Uri) -> Self {
             let inner = tonic::client::Grpc::with_origin(inner, origin);
             Self { inner }
         }
+
         pub fn with_interceptor<F>(
             inner: T,
             interceptor: F,
@@ -454,916 +449,763 @@ pub mod p2p_client {
                     <T as tonic::client::GrpcService<tonic::body::BoxBody>>::ResponseBody,
                 >,
             >,
-            <T as tonic::codegen::Service<
-                http::Request<tonic::body::BoxBody>,
-            >>::Error: Into<StdError> + Send + Sync,
-        {
+            <T as tonic::codegen::Service<http::Request<tonic::body::BoxBody>>>::Error:
+                Into<StdError> + Send + Sync, {
             P2pClient::new(InterceptedService::new(inner, interceptor))
         }
+
         /// Compress requests with the given encoding.
         ///
-        /// This requires the server to support it otherwise it might respond with an
-        /// error.
+        /// This requires the server to support it otherwise it might respond
+        /// with an error.
         #[must_use]
         pub fn send_compressed(mut self, encoding: CompressionEncoding) -> Self {
             self.inner = self.inner.send_compressed(encoding);
             self
         }
+
         /// Enable decompressing responses.
         #[must_use]
         pub fn accept_compressed(mut self, encoding: CompressionEncoding) -> Self {
             self.inner = self.inner.accept_compressed(encoding);
             self
         }
+
         /// Suggest to a peer to connect to the submitted peer details.
         /// This, if successful, adds the peer to the list of given addresses.
         pub async fn peer_connect(
             &mut self,
             request: impl tonic::IntoRequest<super::PeerConnectRequest>,
         ) -> Result<tonic::Response<super::BoolResponse>, tonic::Status> {
-            self.inner
-                .ready()
-                .await
-                .map_err(|e| {
-                    tonic::Status::new(
-                        tonic::Code::Unknown,
-                        format!("Service was not ready: {}", e.into()),
-                    )
-                })?;
+            self.inner.ready().await.map_err(|e| {
+                tonic::Status::new(
+                    tonic::Code::Unknown,
+                    format!("Service was not ready: {}", e.into()),
+                )
+            })?;
             let codec = tonic::codec::ProstCodec::default();
-            let path = http::uri::PathAndQuery::from_static(
-                "/concordium.P2P/PeerConnect",
-            );
+            let path = http::uri::PathAndQuery::from_static("/concordium.P2P/PeerConnect");
             self.inner.unary(request.into_request(), path, codec).await
         }
-        /// Disconnect from the peer and remove them from the given addresses list
-        /// if they are on it. Return if the request was processed successfully.
+
+        /// Disconnect from the peer and remove them from the given addresses
+        /// list if they are on it. Return if the request was processed
+        /// successfully.
         pub async fn peer_disconnect(
             &mut self,
             request: impl tonic::IntoRequest<super::PeerConnectRequest>,
         ) -> Result<tonic::Response<super::BoolResponse>, tonic::Status> {
-            self.inner
-                .ready()
-                .await
-                .map_err(|e| {
-                    tonic::Status::new(
-                        tonic::Code::Unknown,
-                        format!("Service was not ready: {}", e.into()),
-                    )
-                })?;
+            self.inner.ready().await.map_err(|e| {
+                tonic::Status::new(
+                    tonic::Code::Unknown,
+                    format!("Service was not ready: {}", e.into()),
+                )
+            })?;
             let codec = tonic::codec::ProstCodec::default();
-            let path = http::uri::PathAndQuery::from_static(
-                "/concordium.P2P/PeerDisconnect",
-            );
+            let path = http::uri::PathAndQuery::from_static("/concordium.P2P/PeerDisconnect");
             self.inner.unary(request.into_request(), path, codec).await
         }
+
         /// Uptime of the *node* in milliseconds.
         pub async fn peer_uptime(
             &mut self,
             request: impl tonic::IntoRequest<super::Empty>,
         ) -> Result<tonic::Response<super::NumberResponse>, tonic::Status> {
-            self.inner
-                .ready()
-                .await
-                .map_err(|e| {
-                    tonic::Status::new(
-                        tonic::Code::Unknown,
-                        format!("Service was not ready: {}", e.into()),
-                    )
-                })?;
+            self.inner.ready().await.map_err(|e| {
+                tonic::Status::new(
+                    tonic::Code::Unknown,
+                    format!("Service was not ready: {}", e.into()),
+                )
+            })?;
             let codec = tonic::codec::ProstCodec::default();
-            let path = http::uri::PathAndQuery::from_static(
-                "/concordium.P2P/PeerUptime",
-            );
+            let path = http::uri::PathAndQuery::from_static("/concordium.P2P/PeerUptime");
             self.inner.unary(request.into_request(), path, codec).await
         }
+
         /// Total number of sent packets by the node.
         pub async fn peer_total_sent(
             &mut self,
             request: impl tonic::IntoRequest<super::Empty>,
         ) -> Result<tonic::Response<super::NumberResponse>, tonic::Status> {
-            self.inner
-                .ready()
-                .await
-                .map_err(|e| {
-                    tonic::Status::new(
-                        tonic::Code::Unknown,
-                        format!("Service was not ready: {}", e.into()),
-                    )
-                })?;
+            self.inner.ready().await.map_err(|e| {
+                tonic::Status::new(
+                    tonic::Code::Unknown,
+                    format!("Service was not ready: {}", e.into()),
+                )
+            })?;
             let codec = tonic::codec::ProstCodec::default();
-            let path = http::uri::PathAndQuery::from_static(
-                "/concordium.P2P/PeerTotalSent",
-            );
+            let path = http::uri::PathAndQuery::from_static("/concordium.P2P/PeerTotalSent");
             self.inner.unary(request.into_request(), path, codec).await
         }
+
         /// Total number of received packets by the node.
         pub async fn peer_total_received(
             &mut self,
             request: impl tonic::IntoRequest<super::Empty>,
         ) -> Result<tonic::Response<super::NumberResponse>, tonic::Status> {
-            self.inner
-                .ready()
-                .await
-                .map_err(|e| {
-                    tonic::Status::new(
-                        tonic::Code::Unknown,
-                        format!("Service was not ready: {}", e.into()),
-                    )
-                })?;
+            self.inner.ready().await.map_err(|e| {
+                tonic::Status::new(
+                    tonic::Code::Unknown,
+                    format!("Service was not ready: {}", e.into()),
+                )
+            })?;
             let codec = tonic::codec::ProstCodec::default();
-            let path = http::uri::PathAndQuery::from_static(
-                "/concordium.P2P/PeerTotalReceived",
-            );
+            let path = http::uri::PathAndQuery::from_static("/concordium.P2P/PeerTotalReceived");
             self.inner.unary(request.into_request(), path, codec).await
         }
+
         /// Node software version.
         pub async fn peer_version(
             &mut self,
             request: impl tonic::IntoRequest<super::Empty>,
         ) -> Result<tonic::Response<super::StringResponse>, tonic::Status> {
-            self.inner
-                .ready()
-                .await
-                .map_err(|e| {
-                    tonic::Status::new(
-                        tonic::Code::Unknown,
-                        format!("Service was not ready: {}", e.into()),
-                    )
-                })?;
+            self.inner.ready().await.map_err(|e| {
+                tonic::Status::new(
+                    tonic::Code::Unknown,
+                    format!("Service was not ready: {}", e.into()),
+                )
+            })?;
             let codec = tonic::codec::ProstCodec::default();
-            let path = http::uri::PathAndQuery::from_static(
-                "/concordium.P2P/PeerVersion",
-            );
+            let path = http::uri::PathAndQuery::from_static("/concordium.P2P/PeerVersion");
             self.inner.unary(request.into_request(), path, codec).await
         }
+
         /// Stats for connected peers.
         pub async fn peer_stats(
             &mut self,
             request: impl tonic::IntoRequest<super::PeersRequest>,
         ) -> Result<tonic::Response<super::PeerStatsResponse>, tonic::Status> {
-            self.inner
-                .ready()
-                .await
-                .map_err(|e| {
-                    tonic::Status::new(
-                        tonic::Code::Unknown,
-                        format!("Service was not ready: {}", e.into()),
-                    )
-                })?;
+            self.inner.ready().await.map_err(|e| {
+                tonic::Status::new(
+                    tonic::Code::Unknown,
+                    format!("Service was not ready: {}", e.into()),
+                )
+            })?;
             let codec = tonic::codec::ProstCodec::default();
             let path = http::uri::PathAndQuery::from_static("/concordium.P2P/PeerStats");
             self.inner.unary(request.into_request(), path, codec).await
         }
+
         /// List of connected peers.
         pub async fn peer_list(
             &mut self,
             request: impl tonic::IntoRequest<super::PeersRequest>,
         ) -> Result<tonic::Response<super::PeerListResponse>, tonic::Status> {
-            self.inner
-                .ready()
-                .await
-                .map_err(|e| {
-                    tonic::Status::new(
-                        tonic::Code::Unknown,
-                        format!("Service was not ready: {}", e.into()),
-                    )
-                })?;
+            self.inner.ready().await.map_err(|e| {
+                tonic::Status::new(
+                    tonic::Code::Unknown,
+                    format!("Service was not ready: {}", e.into()),
+                )
+            })?;
             let codec = tonic::codec::ProstCodec::default();
             let path = http::uri::PathAndQuery::from_static("/concordium.P2P/PeerList");
             self.inner.unary(request.into_request(), path, codec).await
         }
+
         /// Ban a the given peer.
         pub async fn ban_node(
             &mut self,
             request: impl tonic::IntoRequest<super::PeerElement>,
         ) -> Result<tonic::Response<super::BoolResponse>, tonic::Status> {
-            self.inner
-                .ready()
-                .await
-                .map_err(|e| {
-                    tonic::Status::new(
-                        tonic::Code::Unknown,
-                        format!("Service was not ready: {}", e.into()),
-                    )
-                })?;
+            self.inner.ready().await.map_err(|e| {
+                tonic::Status::new(
+                    tonic::Code::Unknown,
+                    format!("Service was not ready: {}", e.into()),
+                )
+            })?;
             let codec = tonic::codec::ProstCodec::default();
             let path = http::uri::PathAndQuery::from_static("/concordium.P2P/BanNode");
             self.inner.unary(request.into_request(), path, codec).await
         }
+
         /// Unban the given peer.
         pub async fn unban_node(
             &mut self,
             request: impl tonic::IntoRequest<super::PeerElement>,
         ) -> Result<tonic::Response<super::BoolResponse>, tonic::Status> {
-            self.inner
-                .ready()
-                .await
-                .map_err(|e| {
-                    tonic::Status::new(
-                        tonic::Code::Unknown,
-                        format!("Service was not ready: {}", e.into()),
-                    )
-                })?;
+            self.inner.ready().await.map_err(|e| {
+                tonic::Status::new(
+                    tonic::Code::Unknown,
+                    format!("Service was not ready: {}", e.into()),
+                )
+            })?;
             let codec = tonic::codec::ProstCodec::default();
             let path = http::uri::PathAndQuery::from_static("/concordium.P2P/UnbanNode");
             self.inner.unary(request.into_request(), path, codec).await
         }
+
         /// Join the provided network.
         pub async fn join_network(
             &mut self,
             request: impl tonic::IntoRequest<super::NetworkChangeRequest>,
         ) -> Result<tonic::Response<super::BoolResponse>, tonic::Status> {
-            self.inner
-                .ready()
-                .await
-                .map_err(|e| {
-                    tonic::Status::new(
-                        tonic::Code::Unknown,
-                        format!("Service was not ready: {}", e.into()),
-                    )
-                })?;
+            self.inner.ready().await.map_err(|e| {
+                tonic::Status::new(
+                    tonic::Code::Unknown,
+                    format!("Service was not ready: {}", e.into()),
+                )
+            })?;
             let codec = tonic::codec::ProstCodec::default();
-            let path = http::uri::PathAndQuery::from_static(
-                "/concordium.P2P/JoinNetwork",
-            );
+            let path = http::uri::PathAndQuery::from_static("/concordium.P2P/JoinNetwork");
             self.inner.unary(request.into_request(), path, codec).await
         }
+
         /// Leave the provided network.
         pub async fn leave_network(
             &mut self,
             request: impl tonic::IntoRequest<super::NetworkChangeRequest>,
         ) -> Result<tonic::Response<super::BoolResponse>, tonic::Status> {
-            self.inner
-                .ready()
-                .await
-                .map_err(|e| {
-                    tonic::Status::new(
-                        tonic::Code::Unknown,
-                        format!("Service was not ready: {}", e.into()),
-                    )
-                })?;
+            self.inner.ready().await.map_err(|e| {
+                tonic::Status::new(
+                    tonic::Code::Unknown,
+                    format!("Service was not ready: {}", e.into()),
+                )
+            })?;
             let codec = tonic::codec::ProstCodec::default();
-            let path = http::uri::PathAndQuery::from_static(
-                "/concordium.P2P/LeaveNetwork",
-            );
+            let path = http::uri::PathAndQuery::from_static("/concordium.P2P/LeaveNetwork");
             self.inner.unary(request.into_request(), path, codec).await
         }
+
         /// Get information about the running node.
         pub async fn node_info(
             &mut self,
             request: impl tonic::IntoRequest<super::Empty>,
         ) -> Result<tonic::Response<super::NodeInfoResponse>, tonic::Status> {
-            self.inner
-                .ready()
-                .await
-                .map_err(|e| {
-                    tonic::Status::new(
-                        tonic::Code::Unknown,
-                        format!("Service was not ready: {}", e.into()),
-                    )
-                })?;
+            self.inner.ready().await.map_err(|e| {
+                tonic::Status::new(
+                    tonic::Code::Unknown,
+                    format!("Service was not ready: {}", e.into()),
+                )
+            })?;
             let codec = tonic::codec::ProstCodec::default();
             let path = http::uri::PathAndQuery::from_static("/concordium.P2P/NodeInfo");
             self.inner.unary(request.into_request(), path, codec).await
         }
+
         /// Get information about the consensus.
         /// A JSON schema for the return type is provided at: https://developer.concordium.software/en/mainnet/net/references/grpc.html.
         pub async fn get_consensus_status(
             &mut self,
             request: impl tonic::IntoRequest<super::Empty>,
         ) -> Result<tonic::Response<super::JsonResponse>, tonic::Status> {
-            self.inner
-                .ready()
-                .await
-                .map_err(|e| {
-                    tonic::Status::new(
-                        tonic::Code::Unknown,
-                        format!("Service was not ready: {}", e.into()),
-                    )
-                })?;
+            self.inner.ready().await.map_err(|e| {
+                tonic::Status::new(
+                    tonic::Code::Unknown,
+                    format!("Service was not ready: {}", e.into()),
+                )
+            })?;
             let codec = tonic::codec::ProstCodec::default();
-            let path = http::uri::PathAndQuery::from_static(
-                "/concordium.P2P/GetConsensusStatus",
-            );
+            let path = http::uri::PathAndQuery::from_static("/concordium.P2P/GetConsensusStatus");
             self.inner.unary(request.into_request(), path, codec).await
         }
+
         /// Get information about the block.
         /// A JSON schema for the return type is provided at: https://developer.concordium.software/en/mainnet/net/references/grpc.html.
         pub async fn get_block_info(
             &mut self,
             request: impl tonic::IntoRequest<super::BlockHash>,
         ) -> Result<tonic::Response<super::JsonResponse>, tonic::Status> {
-            self.inner
-                .ready()
-                .await
-                .map_err(|e| {
-                    tonic::Status::new(
-                        tonic::Code::Unknown,
-                        format!("Service was not ready: {}", e.into()),
-                    )
-                })?;
+            self.inner.ready().await.map_err(|e| {
+                tonic::Status::new(
+                    tonic::Code::Unknown,
+                    format!("Service was not ready: {}", e.into()),
+                )
+            })?;
             let codec = tonic::codec::ProstCodec::default();
-            let path = http::uri::PathAndQuery::from_static(
-                "/concordium.P2P/GetBlockInfo",
-            );
+            let path = http::uri::PathAndQuery::from_static("/concordium.P2P/GetBlockInfo");
             self.inner.unary(request.into_request(), path, codec).await
         }
+
         /// Get ancestors for the provided block.
         /// A JSON schema for the return type is provided at: https://developer.concordium.software/en/mainnet/net/references/grpc.html.
         pub async fn get_ancestors(
             &mut self,
             request: impl tonic::IntoRequest<super::BlockHashAndAmount>,
         ) -> Result<tonic::Response<super::JsonResponse>, tonic::Status> {
-            self.inner
-                .ready()
-                .await
-                .map_err(|e| {
-                    tonic::Status::new(
-                        tonic::Code::Unknown,
-                        format!("Service was not ready: {}", e.into()),
-                    )
-                })?;
+            self.inner.ready().await.map_err(|e| {
+                tonic::Status::new(
+                    tonic::Code::Unknown,
+                    format!("Service was not ready: {}", e.into()),
+                )
+            })?;
             let codec = tonic::codec::ProstCodec::default();
-            let path = http::uri::PathAndQuery::from_static(
-                "/concordium.P2P/GetAncestors",
-            );
+            let path = http::uri::PathAndQuery::from_static("/concordium.P2P/GetAncestors");
             self.inner.unary(request.into_request(), path, codec).await
         }
+
         /// Get the current branches.
         /// A JSON schema for the return type is provided at: https://developer.concordium.software/en/mainnet/net/references/grpc.html.
         pub async fn get_branches(
             &mut self,
             request: impl tonic::IntoRequest<super::Empty>,
         ) -> Result<tonic::Response<super::JsonResponse>, tonic::Status> {
-            self.inner
-                .ready()
-                .await
-                .map_err(|e| {
-                    tonic::Status::new(
-                        tonic::Code::Unknown,
-                        format!("Service was not ready: {}", e.into()),
-                    )
-                })?;
+            self.inner.ready().await.map_err(|e| {
+                tonic::Status::new(
+                    tonic::Code::Unknown,
+                    format!("Service was not ready: {}", e.into()),
+                )
+            })?;
             let codec = tonic::codec::ProstCodec::default();
-            let path = http::uri::PathAndQuery::from_static(
-                "/concordium.P2P/GetBranches",
-            );
+            let path = http::uri::PathAndQuery::from_static("/concordium.P2P/GetBranches");
             self.inner.unary(request.into_request(), path, codec).await
         }
+
         /// Get the blocks at the given height.
         /// A JSON schema for the return type is provided at: https://developer.concordium.software/en/mainnet/net/references/grpc.html.
         pub async fn get_blocks_at_height(
             &mut self,
             request: impl tonic::IntoRequest<super::BlockHeight>,
         ) -> Result<tonic::Response<super::JsonResponse>, tonic::Status> {
-            self.inner
-                .ready()
-                .await
-                .map_err(|e| {
-                    tonic::Status::new(
-                        tonic::Code::Unknown,
-                        format!("Service was not ready: {}", e.into()),
-                    )
-                })?;
+            self.inner.ready().await.map_err(|e| {
+                tonic::Status::new(
+                    tonic::Code::Unknown,
+                    format!("Service was not ready: {}", e.into()),
+                )
+            })?;
             let codec = tonic::codec::ProstCodec::default();
-            let path = http::uri::PathAndQuery::from_static(
-                "/concordium.P2P/GetBlocksAtHeight",
-            );
+            let path = http::uri::PathAndQuery::from_static("/concordium.P2P/GetBlocksAtHeight");
             self.inner.unary(request.into_request(), path, codec).await
         }
+
         /// Submit a transaction.
         pub async fn send_transaction(
             &mut self,
             request: impl tonic::IntoRequest<super::SendTransactionRequest>,
         ) -> Result<tonic::Response<super::BoolResponse>, tonic::Status> {
-            self.inner
-                .ready()
-                .await
-                .map_err(|e| {
-                    tonic::Status::new(
-                        tonic::Code::Unknown,
-                        format!("Service was not ready: {}", e.into()),
-                    )
-                })?;
+            self.inner.ready().await.map_err(|e| {
+                tonic::Status::new(
+                    tonic::Code::Unknown,
+                    format!("Service was not ready: {}", e.into()),
+                )
+            })?;
             let codec = tonic::codec::ProstCodec::default();
-            let path = http::uri::PathAndQuery::from_static(
-                "/concordium.P2P/SendTransaction",
-            );
+            let path = http::uri::PathAndQuery::from_static("/concordium.P2P/SendTransaction");
             self.inner.unary(request.into_request(), path, codec).await
         }
+
         /// Start the baker in the consensus module.
         pub async fn start_baker(
             &mut self,
             request: impl tonic::IntoRequest<super::Empty>,
         ) -> Result<tonic::Response<super::BoolResponse>, tonic::Status> {
-            self.inner
-                .ready()
-                .await
-                .map_err(|e| {
-                    tonic::Status::new(
-                        tonic::Code::Unknown,
-                        format!("Service was not ready: {}", e.into()),
-                    )
-                })?;
+            self.inner.ready().await.map_err(|e| {
+                tonic::Status::new(
+                    tonic::Code::Unknown,
+                    format!("Service was not ready: {}", e.into()),
+                )
+            })?;
             let codec = tonic::codec::ProstCodec::default();
-            let path = http::uri::PathAndQuery::from_static(
-                "/concordium.P2P/StartBaker",
-            );
+            let path = http::uri::PathAndQuery::from_static("/concordium.P2P/StartBaker");
             self.inner.unary(request.into_request(), path, codec).await
         }
+
         /// Stop the baker in the consensus module.
         pub async fn stop_baker(
             &mut self,
             request: impl tonic::IntoRequest<super::Empty>,
         ) -> Result<tonic::Response<super::BoolResponse>, tonic::Status> {
-            self.inner
-                .ready()
-                .await
-                .map_err(|e| {
-                    tonic::Status::new(
-                        tonic::Code::Unknown,
-                        format!("Service was not ready: {}", e.into()),
-                    )
-                })?;
+            self.inner.ready().await.map_err(|e| {
+                tonic::Status::new(
+                    tonic::Code::Unknown,
+                    format!("Service was not ready: {}", e.into()),
+                )
+            })?;
             let codec = tonic::codec::ProstCodec::default();
             let path = http::uri::PathAndQuery::from_static("/concordium.P2P/StopBaker");
             self.inner.unary(request.into_request(), path, codec).await
         }
-        /// Get a list of accounts that exist in the state after the given block.
-        /// A JSON schema for the return type is provided at: https://developer.concordium.software/en/mainnet/net/references/grpc.html.
+
+        /// Get a list of accounts that exist in the state after the given
+        /// block. A JSON schema for the return type is provided at: https://developer.concordium.software/en/mainnet/net/references/grpc.html.
         pub async fn get_account_list(
             &mut self,
             request: impl tonic::IntoRequest<super::BlockHash>,
         ) -> Result<tonic::Response<super::JsonResponse>, tonic::Status> {
-            self.inner
-                .ready()
-                .await
-                .map_err(|e| {
-                    tonic::Status::new(
-                        tonic::Code::Unknown,
-                        format!("Service was not ready: {}", e.into()),
-                    )
-                })?;
+            self.inner.ready().await.map_err(|e| {
+                tonic::Status::new(
+                    tonic::Code::Unknown,
+                    format!("Service was not ready: {}", e.into()),
+                )
+            })?;
             let codec = tonic::codec::ProstCodec::default();
-            let path = http::uri::PathAndQuery::from_static(
-                "/concordium.P2P/GetAccountList",
-            );
+            let path = http::uri::PathAndQuery::from_static("/concordium.P2P/GetAccountList");
             self.inner.unary(request.into_request(), path, codec).await
         }
-        /// Get all smart contract instances that exist in the state after the given block.
-        /// A JSON schema for the return type is provided at: https://developer.concordium.software/en/mainnet/net/references/grpc.html.
+
+        /// Get all smart contract instances that exist in the state after the
+        /// given block. A JSON schema for the return type is provided at: https://developer.concordium.software/en/mainnet/net/references/grpc.html.
         pub async fn get_instances(
             &mut self,
             request: impl tonic::IntoRequest<super::BlockHash>,
         ) -> Result<tonic::Response<super::JsonResponse>, tonic::Status> {
-            self.inner
-                .ready()
-                .await
-                .map_err(|e| {
-                    tonic::Status::new(
-                        tonic::Code::Unknown,
-                        format!("Service was not ready: {}", e.into()),
-                    )
-                })?;
+            self.inner.ready().await.map_err(|e| {
+                tonic::Status::new(
+                    tonic::Code::Unknown,
+                    format!("Service was not ready: {}", e.into()),
+                )
+            })?;
             let codec = tonic::codec::ProstCodec::default();
-            let path = http::uri::PathAndQuery::from_static(
-                "/concordium.P2P/GetInstances",
-            );
+            let path = http::uri::PathAndQuery::from_static("/concordium.P2P/GetInstances");
             self.inner.unary(request.into_request(), path, codec).await
         }
+
         /// Get information about an account.
         /// A JSON schema for the return type is provided at: https://developer.concordium.software/en/mainnet/net/references/grpc.html.
         pub async fn get_account_info(
             &mut self,
             request: impl tonic::IntoRequest<super::GetAddressInfoRequest>,
         ) -> Result<tonic::Response<super::JsonResponse>, tonic::Status> {
-            self.inner
-                .ready()
-                .await
-                .map_err(|e| {
-                    tonic::Status::new(
-                        tonic::Code::Unknown,
-                        format!("Service was not ready: {}", e.into()),
-                    )
-                })?;
+            self.inner.ready().await.map_err(|e| {
+                tonic::Status::new(
+                    tonic::Code::Unknown,
+                    format!("Service was not ready: {}", e.into()),
+                )
+            })?;
             let codec = tonic::codec::ProstCodec::default();
-            let path = http::uri::PathAndQuery::from_static(
-                "/concordium.P2P/GetAccountInfo",
-            );
+            let path = http::uri::PathAndQuery::from_static("/concordium.P2P/GetAccountInfo");
             self.inner.unary(request.into_request(), path, codec).await
         }
+
         /// Get information about a smart contract instance.
         /// A JSON schema for the return type is provided at: https://developer.concordium.software/en/mainnet/net/references/grpc.html.
         pub async fn get_instance_info(
             &mut self,
             request: impl tonic::IntoRequest<super::GetAddressInfoRequest>,
         ) -> Result<tonic::Response<super::JsonResponse>, tonic::Status> {
-            self.inner
-                .ready()
-                .await
-                .map_err(|e| {
-                    tonic::Status::new(
-                        tonic::Code::Unknown,
-                        format!("Service was not ready: {}", e.into()),
-                    )
-                })?;
+            self.inner.ready().await.map_err(|e| {
+                tonic::Status::new(
+                    tonic::Code::Unknown,
+                    format!("Service was not ready: {}", e.into()),
+                )
+            })?;
             let codec = tonic::codec::ProstCodec::default();
-            let path = http::uri::PathAndQuery::from_static(
-                "/concordium.P2P/GetInstanceInfo",
-            );
+            let path = http::uri::PathAndQuery::from_static("/concordium.P2P/GetInstanceInfo");
             self.inner.unary(request.into_request(), path, codec).await
         }
-        /// Invoke a smart contract instance and view the result *as if* it had been updated at the end of the provided block.
-        /// This is *not* a transaction.
-        /// A JSON schema for the return type is provided at: https://developer.concordium.software/en/mainnet/net/references/grpc.html.
+
+        /// Invoke a smart contract instance and view the result *as if* it had
+        /// been updated at the end of the provided block. This is *not*
+        /// a transaction. A JSON schema for the return type is provided at: https://developer.concordium.software/en/mainnet/net/references/grpc.html.
         pub async fn invoke_contract(
             &mut self,
             request: impl tonic::IntoRequest<super::InvokeContractRequest>,
         ) -> Result<tonic::Response<super::JsonResponse>, tonic::Status> {
-            self.inner
-                .ready()
-                .await
-                .map_err(|e| {
-                    tonic::Status::new(
-                        tonic::Code::Unknown,
-                        format!("Service was not ready: {}", e.into()),
-                    )
-                })?;
+            self.inner.ready().await.map_err(|e| {
+                tonic::Status::new(
+                    tonic::Code::Unknown,
+                    format!("Service was not ready: {}", e.into()),
+                )
+            })?;
             let codec = tonic::codec::ProstCodec::default();
-            let path = http::uri::PathAndQuery::from_static(
-                "/concordium.P2P/InvokeContract",
-            );
+            let path = http::uri::PathAndQuery::from_static("/concordium.P2P/InvokeContract");
             self.inner.unary(request.into_request(), path, codec).await
         }
-        /// Get an overview of the balance of special accounts in the given block.
-        /// A JSON schema for the return type is provided at: https://developer.concordium.software/en/mainnet/net/references/grpc.html.
+
+        /// Get an overview of the balance of special accounts in the given
+        /// block. A JSON schema for the return type is provided at: https://developer.concordium.software/en/mainnet/net/references/grpc.html.
         pub async fn get_reward_status(
             &mut self,
             request: impl tonic::IntoRequest<super::BlockHash>,
         ) -> Result<tonic::Response<super::JsonResponse>, tonic::Status> {
-            self.inner
-                .ready()
-                .await
-                .map_err(|e| {
-                    tonic::Status::new(
-                        tonic::Code::Unknown,
-                        format!("Service was not ready: {}", e.into()),
-                    )
-                })?;
+            self.inner.ready().await.map_err(|e| {
+                tonic::Status::new(
+                    tonic::Code::Unknown,
+                    format!("Service was not ready: {}", e.into()),
+                )
+            })?;
             let codec = tonic::codec::ProstCodec::default();
-            let path = http::uri::PathAndQuery::from_static(
-                "/concordium.P2P/GetRewardStatus",
-            );
+            let path = http::uri::PathAndQuery::from_static("/concordium.P2P/GetRewardStatus");
             self.inner.unary(request.into_request(), path, codec).await
         }
+
         /// Get an overview of the parameters used for baking.
         /// A JSON schema for the return type is provided at: https://developer.concordium.software/en/mainnet/net/references/grpc.html.
         pub async fn get_birk_parameters(
             &mut self,
             request: impl tonic::IntoRequest<super::BlockHash>,
         ) -> Result<tonic::Response<super::JsonResponse>, tonic::Status> {
-            self.inner
-                .ready()
-                .await
-                .map_err(|e| {
-                    tonic::Status::new(
-                        tonic::Code::Unknown,
-                        format!("Service was not ready: {}", e.into()),
-                    )
-                })?;
+            self.inner.ready().await.map_err(|e| {
+                tonic::Status::new(
+                    tonic::Code::Unknown,
+                    format!("Service was not ready: {}", e.into()),
+                )
+            })?;
             let codec = tonic::codec::ProstCodec::default();
-            let path = http::uri::PathAndQuery::from_static(
-                "/concordium.P2P/GetBirkParameters",
-            );
+            let path = http::uri::PathAndQuery::from_static("/concordium.P2P/GetBirkParameters");
             self.inner.unary(request.into_request(), path, codec).await
         }
-        /// Get a list of smart contract modules that exist in the state after the given block.
-        /// A JSON schema for the return type is provided at: https://developer.concordium.software/en/mainnet/net/references/grpc.html.
+
+        /// Get a list of smart contract modules that exist in the state after
+        /// the given block. A JSON schema for the return type is provided at: https://developer.concordium.software/en/mainnet/net/references/grpc.html.
         pub async fn get_module_list(
             &mut self,
             request: impl tonic::IntoRequest<super::BlockHash>,
         ) -> Result<tonic::Response<super::JsonResponse>, tonic::Status> {
-            self.inner
-                .ready()
-                .await
-                .map_err(|e| {
-                    tonic::Status::new(
-                        tonic::Code::Unknown,
-                        format!("Service was not ready: {}", e.into()),
-                    )
-                })?;
+            self.inner.ready().await.map_err(|e| {
+                tonic::Status::new(
+                    tonic::Code::Unknown,
+                    format!("Service was not ready: {}", e.into()),
+                )
+            })?;
             let codec = tonic::codec::ProstCodec::default();
-            let path = http::uri::PathAndQuery::from_static(
-                "/concordium.P2P/GetModuleList",
-            );
+            let path = http::uri::PathAndQuery::from_static("/concordium.P2P/GetModuleList");
             self.inner.unary(request.into_request(), path, codec).await
         }
+
         /// Get the source of a smart contract module.
         pub async fn get_module_source(
             &mut self,
             request: impl tonic::IntoRequest<super::GetModuleSourceRequest>,
         ) -> Result<tonic::Response<super::BytesResponse>, tonic::Status> {
-            self.inner
-                .ready()
-                .await
-                .map_err(|e| {
-                    tonic::Status::new(
-                        tonic::Code::Unknown,
-                        format!("Service was not ready: {}", e.into()),
-                    )
-                })?;
+            self.inner.ready().await.map_err(|e| {
+                tonic::Status::new(
+                    tonic::Code::Unknown,
+                    format!("Service was not ready: {}", e.into()),
+                )
+            })?;
             let codec = tonic::codec::ProstCodec::default();
-            let path = http::uri::PathAndQuery::from_static(
-                "/concordium.P2P/GetModuleSource",
-            );
+            let path = http::uri::PathAndQuery::from_static("/concordium.P2P/GetModuleSource");
             self.inner.unary(request.into_request(), path, codec).await
         }
-        /// Get a list of all identity providers that exist in the state after the given block.
-        /// A JSON schema for the return type is provided at: https://developer.concordium.software/en/mainnet/net/references/grpc.html.
+
+        /// Get a list of all identity providers that exist in the state after
+        /// the given block. A JSON schema for the return type is provided at: https://developer.concordium.software/en/mainnet/net/references/grpc.html.
         pub async fn get_identity_providers(
             &mut self,
             request: impl tonic::IntoRequest<super::BlockHash>,
         ) -> Result<tonic::Response<super::JsonResponse>, tonic::Status> {
-            self.inner
-                .ready()
-                .await
-                .map_err(|e| {
-                    tonic::Status::new(
-                        tonic::Code::Unknown,
-                        format!("Service was not ready: {}", e.into()),
-                    )
-                })?;
+            self.inner.ready().await.map_err(|e| {
+                tonic::Status::new(
+                    tonic::Code::Unknown,
+                    format!("Service was not ready: {}", e.into()),
+                )
+            })?;
             let codec = tonic::codec::ProstCodec::default();
-            let path = http::uri::PathAndQuery::from_static(
-                "/concordium.P2P/GetIdentityProviders",
-            );
+            let path = http::uri::PathAndQuery::from_static("/concordium.P2P/GetIdentityProviders");
             self.inner.unary(request.into_request(), path, codec).await
         }
-        /// Get a list of all anonymity revokers that exist in the state after the given block.
-        /// A JSON schema for the return type is provided at: https://developer.concordium.software/en/mainnet/net/references/grpc.html.
+
+        /// Get a list of all anonymity revokers that exist in the state after
+        /// the given block. A JSON schema for the return type is provided at: https://developer.concordium.software/en/mainnet/net/references/grpc.html.
         pub async fn get_anonymity_revokers(
             &mut self,
             request: impl tonic::IntoRequest<super::BlockHash>,
         ) -> Result<tonic::Response<super::JsonResponse>, tonic::Status> {
-            self.inner
-                .ready()
-                .await
-                .map_err(|e| {
-                    tonic::Status::new(
-                        tonic::Code::Unknown,
-                        format!("Service was not ready: {}", e.into()),
-                    )
-                })?;
+            self.inner.ready().await.map_err(|e| {
+                tonic::Status::new(
+                    tonic::Code::Unknown,
+                    format!("Service was not ready: {}", e.into()),
+                )
+            })?;
             let codec = tonic::codec::ProstCodec::default();
-            let path = http::uri::PathAndQuery::from_static(
-                "/concordium.P2P/GetAnonymityRevokers",
-            );
+            let path = http::uri::PathAndQuery::from_static("/concordium.P2P/GetAnonymityRevokers");
             self.inner.unary(request.into_request(), path, codec).await
         }
+
         /// Get the cryptographic parameters used in the given block.
         /// A JSON schema for the return type is provided at: https://developer.concordium.software/en/mainnet/net/references/grpc.html.
         pub async fn get_cryptographic_parameters(
             &mut self,
             request: impl tonic::IntoRequest<super::BlockHash>,
         ) -> Result<tonic::Response<super::JsonResponse>, tonic::Status> {
-            self.inner
-                .ready()
-                .await
-                .map_err(|e| {
-                    tonic::Status::new(
-                        tonic::Code::Unknown,
-                        format!("Service was not ready: {}", e.into()),
-                    )
-                })?;
+            self.inner.ready().await.map_err(|e| {
+                tonic::Status::new(
+                    tonic::Code::Unknown,
+                    format!("Service was not ready: {}", e.into()),
+                )
+            })?;
             let codec = tonic::codec::ProstCodec::default();
-            let path = http::uri::PathAndQuery::from_static(
-                "/concordium.P2P/GetCryptographicParameters",
-            );
+            let path =
+                http::uri::PathAndQuery::from_static("/concordium.P2P/GetCryptographicParameters");
             self.inner.unary(request.into_request(), path, codec).await
         }
-        /// Get a list of all baker IDs registered at that block in ascending order. Or null, if the block is invalid.
-        /// A JSON schema for the return type is provided at: https://developer.concordium.software/en/mainnet/net/references/grpc.html.
+
+        /// Get a list of all baker IDs registered at that block in ascending
+        /// order. Or null, if the block is invalid. A JSON schema for the return type is provided at: https://developer.concordium.software/en/mainnet/net/references/grpc.html.
         pub async fn get_baker_list(
             &mut self,
             request: impl tonic::IntoRequest<super::BlockHash>,
         ) -> Result<tonic::Response<super::JsonResponse>, tonic::Status> {
-            self.inner
-                .ready()
-                .await
-                .map_err(|e| {
-                    tonic::Status::new(
-                        tonic::Code::Unknown,
-                        format!("Service was not ready: {}", e.into()),
-                    )
-                })?;
+            self.inner.ready().await.map_err(|e| {
+                tonic::Status::new(
+                    tonic::Code::Unknown,
+                    format!("Service was not ready: {}", e.into()),
+                )
+            })?;
             let codec = tonic::codec::ProstCodec::default();
-            let path = http::uri::PathAndQuery::from_static(
-                "/concordium.P2P/GetBakerList",
-            );
+            let path = http::uri::PathAndQuery::from_static("/concordium.P2P/GetBakerList");
             self.inner.unary(request.into_request(), path, codec).await
         }
-        /// Get the status of a pool. If passiveDelegation == true, this returns the status for the passive delegators.
-        /// Otherwise, it returns the status for the baker with the specified ID (if it exists).
-        /// A JSON schema for the return type is provided at: https://developer.concordium.software/en/mainnet/net/references/grpc.html.
+
+        /// Get the status of a pool. If passiveDelegation == true, this returns
+        /// the status for the passive delegators. Otherwise, it returns
+        /// the status for the baker with the specified ID (if it exists). A JSON schema for the return type is provided at: https://developer.concordium.software/en/mainnet/net/references/grpc.html.
         pub async fn get_pool_status(
             &mut self,
             request: impl tonic::IntoRequest<super::GetPoolStatusRequest>,
         ) -> Result<tonic::Response<super::JsonResponse>, tonic::Status> {
-            self.inner
-                .ready()
-                .await
-                .map_err(|e| {
-                    tonic::Status::new(
-                        tonic::Code::Unknown,
-                        format!("Service was not ready: {}", e.into()),
-                    )
-                })?;
+            self.inner.ready().await.map_err(|e| {
+                tonic::Status::new(
+                    tonic::Code::Unknown,
+                    format!("Service was not ready: {}", e.into()),
+                )
+            })?;
             let codec = tonic::codec::ProstCodec::default();
-            let path = http::uri::PathAndQuery::from_static(
-                "/concordium.P2P/GetPoolStatus",
-            );
+            let path = http::uri::PathAndQuery::from_static("/concordium.P2P/GetPoolStatus");
             self.inner.unary(request.into_request(), path, codec).await
         }
+
         /// Get a list of banned peers.
         pub async fn get_banned_peers(
             &mut self,
             request: impl tonic::IntoRequest<super::Empty>,
         ) -> Result<tonic::Response<super::PeerListResponse>, tonic::Status> {
-            self.inner
-                .ready()
-                .await
-                .map_err(|e| {
-                    tonic::Status::new(
-                        tonic::Code::Unknown,
-                        format!("Service was not ready: {}", e.into()),
-                    )
-                })?;
+            self.inner.ready().await.map_err(|e| {
+                tonic::Status::new(
+                    tonic::Code::Unknown,
+                    format!("Service was not ready: {}", e.into()),
+                )
+            })?;
             let codec = tonic::codec::ProstCodec::default();
-            let path = http::uri::PathAndQuery::from_static(
-                "/concordium.P2P/GetBannedPeers",
-            );
+            let path = http::uri::PathAndQuery::from_static("/concordium.P2P/GetBannedPeers");
             self.inner.unary(request.into_request(), path, codec).await
         }
+
         /// Shut down the node.
         pub async fn shutdown(
             &mut self,
             request: impl tonic::IntoRequest<super::Empty>,
         ) -> Result<tonic::Response<super::BoolResponse>, tonic::Status> {
-            self.inner
-                .ready()
-                .await
-                .map_err(|e| {
-                    tonic::Status::new(
-                        tonic::Code::Unknown,
-                        format!("Service was not ready: {}", e.into()),
-                    )
-                })?;
+            self.inner.ready().await.map_err(|e| {
+                tonic::Status::new(
+                    tonic::Code::Unknown,
+                    format!("Service was not ready: {}", e.into()),
+                )
+            })?;
             let codec = tonic::codec::ProstCodec::default();
             let path = http::uri::PathAndQuery::from_static("/concordium.P2P/Shutdown");
             self.inner.unary(request.into_request(), path, codec).await
         }
+
         /// Start dumping packages into the specified file.
         /// Only enabled if the node was built with the `network_dump` feature.
         pub async fn dump_start(
             &mut self,
             request: impl tonic::IntoRequest<super::DumpRequest>,
         ) -> Result<tonic::Response<super::BoolResponse>, tonic::Status> {
-            self.inner
-                .ready()
-                .await
-                .map_err(|e| {
-                    tonic::Status::new(
-                        tonic::Code::Unknown,
-                        format!("Service was not ready: {}", e.into()),
-                    )
-                })?;
+            self.inner.ready().await.map_err(|e| {
+                tonic::Status::new(
+                    tonic::Code::Unknown,
+                    format!("Service was not ready: {}", e.into()),
+                )
+            })?;
             let codec = tonic::codec::ProstCodec::default();
             let path = http::uri::PathAndQuery::from_static("/concordium.P2P/DumpStart");
             self.inner.unary(request.into_request(), path, codec).await
         }
+
         /// Stop dumping packages.
         /// Only enabled if the node was built with the `network_dump` feature.
         pub async fn dump_stop(
             &mut self,
             request: impl tonic::IntoRequest<super::Empty>,
         ) -> Result<tonic::Response<super::BoolResponse>, tonic::Status> {
-            self.inner
-                .ready()
-                .await
-                .map_err(|e| {
-                    tonic::Status::new(
-                        tonic::Code::Unknown,
-                        format!("Service was not ready: {}", e.into()),
-                    )
-                })?;
+            self.inner.ready().await.map_err(|e| {
+                tonic::Status::new(
+                    tonic::Code::Unknown,
+                    format!("Service was not ready: {}", e.into()),
+                )
+            })?;
             let codec = tonic::codec::ProstCodec::default();
             let path = http::uri::PathAndQuery::from_static("/concordium.P2P/DumpStop");
             self.inner.unary(request.into_request(), path, codec).await
         }
+
         /// Query for the status of a transaction by its hash.
         /// A JSON schema for the return type is provided at: https://developer.concordium.software/en/mainnet/net/references/grpc.html.
         pub async fn get_transaction_status(
             &mut self,
             request: impl tonic::IntoRequest<super::TransactionHash>,
         ) -> Result<tonic::Response<super::JsonResponse>, tonic::Status> {
-            self.inner
-                .ready()
-                .await
-                .map_err(|e| {
-                    tonic::Status::new(
-                        tonic::Code::Unknown,
-                        format!("Service was not ready: {}", e.into()),
-                    )
-                })?;
+            self.inner.ready().await.map_err(|e| {
+                tonic::Status::new(
+                    tonic::Code::Unknown,
+                    format!("Service was not ready: {}", e.into()),
+                )
+            })?;
             let codec = tonic::codec::ProstCodec::default();
-            let path = http::uri::PathAndQuery::from_static(
-                "/concordium.P2P/GetTransactionStatus",
-            );
+            let path = http::uri::PathAndQuery::from_static("/concordium.P2P/GetTransactionStatus");
             self.inner.unary(request.into_request(), path, codec).await
         }
+
         /// Query for transactions in a block by its hash.
         /// A JSON schema for the return type is provided at: https://developer.concordium.software/en/mainnet/net/references/grpc.html.
         pub async fn get_transaction_status_in_block(
             &mut self,
             request: impl tonic::IntoRequest<super::GetTransactionStatusInBlockRequest>,
         ) -> Result<tonic::Response<super::JsonResponse>, tonic::Status> {
-            self.inner
-                .ready()
-                .await
-                .map_err(|e| {
-                    tonic::Status::new(
-                        tonic::Code::Unknown,
-                        format!("Service was not ready: {}", e.into()),
-                    )
-                })?;
+            self.inner.ready().await.map_err(|e| {
+                tonic::Status::new(
+                    tonic::Code::Unknown,
+                    format!("Service was not ready: {}", e.into()),
+                )
+            })?;
             let codec = tonic::codec::ProstCodec::default();
-            let path = http::uri::PathAndQuery::from_static(
-                "/concordium.P2P/GetTransactionStatusInBlock",
-            );
+            let path =
+                http::uri::PathAndQuery::from_static("/concordium.P2P/GetTransactionStatusInBlock");
             self.inner.unary(request.into_request(), path, codec).await
         }
-        /// Query for non-finalized transactions present on an account by the account address.
-        /// A JSON schema for the return type is provided at: https://developer.concordium.software/en/mainnet/net/references/grpc.html.
+
+        /// Query for non-finalized transactions present on an account by the
+        /// account address. A JSON schema for the return type is provided at: https://developer.concordium.software/en/mainnet/net/references/grpc.html.
         pub async fn get_account_non_finalized_transactions(
             &mut self,
             request: impl tonic::IntoRequest<super::AccountAddress>,
         ) -> Result<tonic::Response<super::JsonResponse>, tonic::Status> {
-            self.inner
-                .ready()
-                .await
-                .map_err(|e| {
-                    tonic::Status::new(
-                        tonic::Code::Unknown,
-                        format!("Service was not ready: {}", e.into()),
-                    )
-                })?;
+            self.inner.ready().await.map_err(|e| {
+                tonic::Status::new(
+                    tonic::Code::Unknown,
+                    format!("Service was not ready: {}", e.into()),
+                )
+            })?;
             let codec = tonic::codec::ProstCodec::default();
             let path = http::uri::PathAndQuery::from_static(
                 "/concordium.P2P/GetAccountNonFinalizedTransactions",
             );
             self.inner.unary(request.into_request(), path, codec).await
         }
+
         /// Request a summary for a block by its hash.
         /// A JSON schema for the return type is provided at: https://developer.concordium.software/en/mainnet/net/references/grpc.html.
         pub async fn get_block_summary(
             &mut self,
             request: impl tonic::IntoRequest<super::BlockHash>,
         ) -> Result<tonic::Response<super::JsonResponse>, tonic::Status> {
-            self.inner
-                .ready()
-                .await
-                .map_err(|e| {
-                    tonic::Status::new(
-                        tonic::Code::Unknown,
-                        format!("Service was not ready: {}", e.into()),
-                    )
-                })?;
+            self.inner.ready().await.map_err(|e| {
+                tonic::Status::new(
+                    tonic::Code::Unknown,
+                    format!("Service was not ready: {}", e.into()),
+                )
+            })?;
             let codec = tonic::codec::ProstCodec::default();
-            let path = http::uri::PathAndQuery::from_static(
-                "/concordium.P2P/GetBlockSummary",
-            );
+            let path = http::uri::PathAndQuery::from_static("/concordium.P2P/GetBlockSummary");
             self.inner.unary(request.into_request(), path, codec).await
         }
+
         /// Request next nonce information for an account.
         /// A JSON schema for the return type is provided at: https://developer.concordium.software/en/mainnet/net/references/grpc.html.
         pub async fn get_next_account_nonce(
             &mut self,
             request: impl tonic::IntoRequest<super::AccountAddress>,
         ) -> Result<tonic::Response<super::JsonResponse>, tonic::Status> {
-            self.inner
-                .ready()
-                .await
-                .map_err(|e| {
-                    tonic::Status::new(
-                        tonic::Code::Unknown,
-                        format!("Service was not ready: {}", e.into()),
-                    )
-                })?;
+            self.inner.ready().await.map_err(|e| {
+                tonic::Status::new(
+                    tonic::Code::Unknown,
+                    format!("Service was not ready: {}", e.into()),
+                )
+            })?;
             let codec = tonic::codec::ProstCodec::default();
-            let path = http::uri::PathAndQuery::from_static(
-                "/concordium.P2P/GetNextAccountNonce",
-            );
+            let path = http::uri::PathAndQuery::from_static("/concordium.P2P/GetNextAccountNonce");
             self.inner.unary(request.into_request(), path, codec).await
         }
     }

--- a/src/v2/conversions.rs
+++ b/src/v2/conversions.rs
@@ -3134,6 +3134,20 @@ impl TryFrom<NextUpdateSequenceNumbers> for super::types::queries::NextUpdateSeq
     }
 }
 
+impl TryFrom<WinningBaker> for super::types::WinningBaker {
+    type Error = tonic::Status;
+
+    fn try_from(wb: WinningBaker) -> Result<Self, Self::Error> {
+        Ok(Self {
+            round:   wb.round.require()?.value.into(),
+            winner:  super::types::BakerId {
+                id: wb.winner.require()?.value.into(),
+            },
+            present: wb.present,
+        })
+    }
+}
+
 #[cfg(test)]
 mod test {
 

--- a/src/v2/generated/concordium.v2.rs
+++ b/src/v2/generated/concordium.v2.rs
@@ -738,6 +738,39 @@ pub mod block_hash_input {
         RelativeHeight(RelativeHeight),
     }
 }
+/// Input to queries which take an epoch as a parameter.
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct EpochRequest {
+    #[prost(oneof = "epoch_request::EpochRequestInput", tags = "1, 2")]
+    pub epoch_request_input: ::core::option::Option<epoch_request::EpochRequestInput>,
+}
+/// Nested message and enum types in `EpochRequest`.
+pub mod epoch_request {
+    /// Request an epoch by number at a given genesis index.
+    #[allow(clippy::derive_partial_eq_without_eq)]
+    #[derive(Clone, PartialEq, ::prost::Message)]
+    pub struct RelativeEpoch {
+        /// The genesis index to query at. The query is restricted to this
+        /// genesis index, and will not return results for other indices
+        /// even if the epoch number is out of bounds.
+        #[prost(message, optional, tag = "1")]
+        pub genesis_index: ::core::option::Option<super::GenesisIndex>,
+        /// The epoch number to query at.
+        #[prost(message, optional, tag = "2")]
+        pub epoch:         ::core::option::Option<super::Epoch>,
+    }
+    #[allow(clippy::derive_partial_eq_without_eq)]
+    #[derive(Clone, PartialEq, ::prost::Oneof)]
+    pub enum EpochRequestInput {
+        /// Query by genesis index and epoch number.
+        #[prost(message, tag = "1")]
+        RelativeEpoch(RelativeEpoch),
+        /// Query for the epoch of a specified block.
+        #[prost(message, tag = "2")]
+        BlockHash(super::BlockHashInput),
+    }
+}
 /// Input to queries which take an account as a parameter.
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
@@ -3009,6 +3042,9 @@ pub struct PoolCurrentPaydayInfo {
     /// period.
     #[prost(message, optional, tag = "7")]
     pub delegated_capital:       ::core::option::Option<Amount>,
+    /// The commission rates that apply for the current reward period.
+    #[prost(message, optional, tag = "8")]
+    pub commission_rates:        ::core::option::Option<CommissionRates>,
 }
 /// Type for the response of GetPoolInfo.
 /// Contains information about a given pool at the end of a given block.
@@ -4655,6 +4691,182 @@ pub mod block_item {
         UpdateInstruction(super::UpdateInstruction),
     }
 }
+/// Information about a particular baker with respect to
+/// the current reward period.
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct BakerRewardPeriodInfo {
+    /// The baker id and public keys for the baker.
+    #[prost(message, optional, tag = "1")]
+    pub baker:             ::core::option::Option<BakerInfo>,
+    /// The effective stake of the baker for the consensus protocol.
+    /// The returned amount accounts for delegation, capital bounds and leverage
+    /// bounds.
+    #[prost(message, optional, tag = "2")]
+    pub effective_stake:   ::core::option::Option<Amount>,
+    /// The effective commission rate for the baker that applies for the reward
+    /// period.
+    #[prost(message, optional, tag = "3")]
+    pub commission_rates:  ::core::option::Option<CommissionRates>,
+    /// The amount staked by the baker itself.
+    #[prost(message, optional, tag = "4")]
+    pub equity_capital:    ::core::option::Option<Amount>,
+    /// The total amount of capital delegated to this baker pool.
+    #[prost(message, optional, tag = "5")]
+    pub delegated_capital: ::core::option::Option<Amount>,
+    /// Whether the baker is a finalizer or not.
+    #[prost(bool, tag = "6")]
+    pub is_finalizer:      bool,
+}
+/// The signature of a 'QuorumCertificate'.
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct QuorumSignature {
+    /// The bytes representing the raw aggregate signature.
+    /// The bytes have a fixed length of 48 bytes.
+    #[prost(bytes = "vec", tag = "1")]
+    pub value: ::prost::alloc::vec::Vec<u8>,
+}
+/// A quorum certificate is the certificate that the
+/// finalization comittee issues in order to certify a block.
+/// A block must be certified before it will be part of the
+/// authorative part of the chain.
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct QuorumCertificate {
+    /// The hash of the block that the quorum certificate refers to.
+    #[prost(message, optional, tag = "1")]
+    pub block_hash:          ::core::option::Option<BlockHash>,
+    /// The round of the block.
+    #[prost(message, optional, tag = "2")]
+    pub round:               ::core::option::Option<Round>,
+    /// The epoch of the block.
+    #[prost(message, optional, tag = "3")]
+    pub epoch:               ::core::option::Option<Epoch>,
+    /// The aggregated signature by the finalization committee on the block.
+    #[prost(message, optional, tag = "4")]
+    pub aggregate_signature: ::core::option::Option<QuorumSignature>,
+    /// A list of the finalizers that formed the quorum certificate
+    /// i.e., the ones who have contributed to the 'aggregate_siganture'.
+    /// The finalizers are identified by their baker id as this is stable
+    /// across protocols and epochs.
+    #[prost(message, repeated, tag = "5")]
+    pub signatories:         ::prost::alloc::vec::Vec<BakerId>,
+}
+/// The finalizer round is a map from a 'Round'
+/// to the list of finalizers (identified by their 'BakerId') that signed
+/// off the round.
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct FinalizerRound {
+    /// The round that was signed off.
+    #[prost(message, optional, tag = "1")]
+    pub round:      ::core::option::Option<Round>,
+    /// The finalizers (identified by their 'BakerId' that
+    /// signed off the in 'round'.
+    #[prost(message, repeated, tag = "2")]
+    pub finalizers: ::prost::alloc::vec::Vec<BakerId>,
+}
+/// The signature of a 'TimeoutCertificate'.
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct TimeoutSignature {
+    /// The bytes representing the raw aggregate signature.
+    /// The bytes have a fixed length of 48 bytes.
+    #[prost(bytes = "vec", tag = "1")]
+    pub value: ::prost::alloc::vec::Vec<u8>,
+}
+/// A timeout certificate is the certificate that the
+/// finalization committee issues when a round times out,
+/// thus making it possible for the protocol to proceed to the
+/// next round.
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct TimeoutCertificate {
+    /// The round that timed out.
+    #[prost(message, optional, tag = "1")]
+    pub round:                  ::core::option::Option<Round>,
+    /// The minimum epoch of which signatures are included
+    /// in the 'aggregate_signature'.
+    #[prost(message, optional, tag = "2")]
+    pub min_epoch:              ::core::option::Option<Epoch>,
+    /// The rounds of which finalizers have their best
+    /// QCs in the 'min_epoch'.
+    #[prost(message, repeated, tag = "3")]
+    pub qc_rounds_first_epoch:  ::prost::alloc::vec::Vec<FinalizerRound>,
+    /// The rounds of which finalizers have their best
+    /// QCs in the epoch 'min_epoch' + 1.
+    #[prost(message, repeated, tag = "4")]
+    pub qc_rounds_second_epoch: ::prost::alloc::vec::Vec<FinalizerRound>,
+    /// The aggregated signature by the finalization committee that witnessed
+    /// the 'round' timed out.
+    #[prost(message, optional, tag = "5")]
+    pub aggregate_signature:    ::core::option::Option<TimeoutSignature>,
+}
+/// A proof that establishes that the successor block of
+/// a 'EpochFinalizationEntry' is the immediate successor of
+/// the finalized block.
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct SuccessorProof {
+    /// The proof represented as raw bytes.
+    /// The bytes have a fixed length of 32 bytes.
+    #[prost(bytes = "vec", tag = "1")]
+    pub value: ::prost::alloc::vec::Vec<u8>,
+}
+/// The epoch finalization entry is the proof that
+/// makes the protocol able to advance to a new epoch.
+/// I.e. the 'EpochFinalizationEntry' is present if and only if
+/// the block is the first block of a new 'Epoch'.
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct EpochFinalizationEntry {
+    /// The quorum certificate for the finalized block.
+    #[prost(message, optional, tag = "1")]
+    pub finalized_qc:    ::core::option::Option<QuorumCertificate>,
+    /// The quorum certificate for the block that finalizes
+    /// the block that 'finalized_qc' points to.
+    #[prost(message, optional, tag = "2")]
+    pub successor_qc:    ::core::option::Option<QuorumCertificate>,
+    /// A proof that the successor block is an immediate
+    /// successor of the finalized block.
+    #[prost(message, optional, tag = "3")]
+    pub successor_proof: ::core::option::Option<SuccessorProof>,
+}
+/// Certificates for a block for protocols supporting
+/// ConcordiumBFT.
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct BlockCertificates {
+    /// The quorum certificate. Is present if and only if the block is
+    /// not a genesis block.
+    #[prost(message, optional, tag = "1")]
+    pub quorum_certificate:       ::core::option::Option<QuorumCertificate>,
+    /// The timeout certificate. Is present only if the round prior to the
+    /// round of the block timed out.
+    #[prost(message, optional, tag = "2")]
+    pub timeout_certificate:      ::core::option::Option<TimeoutCertificate>,
+    /// The epoch finalization entry. Is present only if the block initiates
+    /// a new epoch.
+    #[prost(message, optional, tag = "3")]
+    pub epoch_finalization_entry: ::core::option::Option<EpochFinalizationEntry>,
+}
+/// Details of which baker won the lottery in a given round in consensus version
+/// 1.
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct WinningBaker {
+    /// The round number.
+    #[prost(message, optional, tag = "1")]
+    pub round:   ::core::option::Option<Round>,
+    /// The baker that won the round.
+    #[prost(message, optional, tag = "2")]
+    pub winner:  ::core::option::Option<BakerId>,
+    /// True if the baker produced a block in this round on the finalized chain,
+    /// and False otherwise.
+    #[prost(bool, tag = "3")]
+    pub present: bool,
+}
 /// Information about how open the pool is to new delegators.
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, ::prost::Enumeration)]
 #[repr(i32)]
@@ -5761,6 +5973,43 @@ pub mod queries_client {
             self.inner.unary(request.into_request(), path, codec).await
         }
 
+        /// Get the projected earliest time at which a particular baker will be
+        /// required to bake a block. If the current consensus version
+        /// is 0, this returns the status 'Unavailable', as the endpoint
+        /// is only supported by consensus version 1.
+        ///
+        /// If the baker is not a baker for the current reward period, this
+        /// returns a timestamp at the start of the next reward period.
+        /// If the baker is a baker for the current reward period, the
+        /// earliest win time is projected from the current round forward,
+        /// assuming that each round after the last finalized round will
+        /// take the minimum block time. (If blocks take longer, or timeouts
+        /// occur, the actual time may be later, and the reported time in
+        /// subsequent queries may reflect this.) At the end of an epoch
+        /// (or if the baker is not projected to bake before the end of the
+        /// epoch) the earliest win time for a (current) baker will be projected
+        /// as the start of the next epoch. This is because the seed for
+        /// the leader election is updated at the epoch boundary, and so
+        /// the winners cannot be predicted beyond that. Note that in some
+        /// circumstances the returned timestamp can be in the past,
+        /// especially at the end of an epoch.
+        pub async fn get_baker_earliest_win_time(
+            &mut self,
+            request: impl tonic::IntoRequest<super::BakerId>,
+        ) -> Result<tonic::Response<super::Timestamp>, tonic::Status> {
+            self.inner.ready().await.map_err(|e| {
+                tonic::Status::new(
+                    tonic::Code::Unknown,
+                    format!("Service was not ready: {}", e.into()),
+                )
+            })?;
+            let codec = tonic::codec::ProstCodec::default();
+            let path = http::uri::PathAndQuery::from_static(
+                "/concordium.v2.Queries/GetBakerEarliestWinTime",
+            );
+            self.inner.unary(request.into_request(), path, codec).await
+        }
+
         /// Shut down the node.
         /// Return a GRPC error if the shutdown failed.
         pub async fn shutdown(
@@ -6049,6 +6298,117 @@ pub mod queries_client {
             self.inner
                 .server_streaming(request.into_request(), path, codec)
                 .await
+        }
+
+        /// Get all bakers in the reward period of a block.
+        /// This endpoint is only supported for protocol version 6 and onwards.
+        /// If the protocol does not support the endpoint then an
+        /// 'IllegalArgument' error is returned.
+        pub async fn get_bakers_reward_period(
+            &mut self,
+            request: impl tonic::IntoRequest<super::BlockHashInput>,
+        ) -> Result<
+            tonic::Response<tonic::codec::Streaming<super::BakerRewardPeriodInfo>>,
+            tonic::Status,
+        > {
+            self.inner.ready().await.map_err(|e| {
+                tonic::Status::new(
+                    tonic::Code::Unknown,
+                    format!("Service was not ready: {}", e.into()),
+                )
+            })?;
+            let codec = tonic::codec::ProstCodec::default();
+            let path = http::uri::PathAndQuery::from_static(
+                "/concordium.v2.Queries/GetBakersRewardPeriod",
+            );
+            self.inner
+                .server_streaming(request.into_request(), path, codec)
+                .await
+        }
+
+        /// For a non-genesis block, this returns the quorum certificate, a
+        /// timeout certificate (if present) and epoch finalization
+        /// entry (if present). Note that, if the block being pointed to
+        /// is not a product of ConcordiumBFT, then the response will be
+        /// a grpc error (invalid argument). If the endpoint is not
+        /// enabled by the node, then an 'unimplemented' error
+        /// will be returned.
+        pub async fn get_block_certificates(
+            &mut self,
+            request: impl tonic::IntoRequest<super::BlockHashInput>,
+        ) -> Result<tonic::Response<super::BlockCertificates>, tonic::Status> {
+            self.inner.ready().await.map_err(|e| {
+                tonic::Status::new(
+                    tonic::Code::Unknown,
+                    format!("Service was not ready: {}", e.into()),
+                )
+            })?;
+            let codec = tonic::codec::ProstCodec::default();
+            let path =
+                http::uri::PathAndQuery::from_static("/concordium.v2.Queries/GetBlockCertificates");
+            self.inner.unary(request.into_request(), path, codec).await
+        }
+
+        /// Get the list of bakers that won the lottery in a particular
+        /// historical epoch (i.e. the last finalized block is in a
+        /// later epoch). This lists the winners for each round in the
+        /// epoch, starting from the round after the last block in the previous
+        /// epoch, running to the round before the first block in the
+        /// next epoch. It also indicates if a block in each
+        /// round was included in the finalized chain.
+        ///
+        /// The following error cases are possible:
+        ///  * `NOT_FOUND` if the query specifies an unknown block.
+        ///  * `UNAVAILABLE` if the query is for an epoch that is not finalized
+        ///    in the current genesis
+        /// /    index, or is for a future genesis index.
+        ///  * `INVALID_ARGUMENT` if the query is for an epoch that is not
+        ///    finalized for a past genesis index.
+        ///  * `INVALID_ARGUMENT` if the query is for a genesis index at
+        ///    consensus version 0.
+        pub async fn get_winning_bakers_epoch(
+            &mut self,
+            request: impl tonic::IntoRequest<super::EpochRequest>,
+        ) -> Result<tonic::Response<tonic::codec::Streaming<super::WinningBaker>>, tonic::Status>
+        {
+            self.inner.ready().await.map_err(|e| {
+                tonic::Status::new(
+                    tonic::Code::Unknown,
+                    format!("Service was not ready: {}", e.into()),
+                )
+            })?;
+            let codec = tonic::codec::ProstCodec::default();
+            let path = http::uri::PathAndQuery::from_static(
+                "/concordium.v2.Queries/GetWinningBakersEpoch",
+            );
+            self.inner
+                .server_streaming(request.into_request(), path, codec)
+                .await
+        }
+
+        /// Get the block hash of the first finalized block in a specified
+        /// epoch.
+        ///
+        /// The following error cases are possible:
+        ///  * `NOT_FOUND` if the query specifies an unknown block.
+        ///  * `UNAVAILABLE` if the query is for an epoch that is not finalized
+        ///    in the current genesis index, or is for a future genesis index.
+        ///  * `INVALID_ARGUMENT` if the query is for an epoch with no finalized
+        ///    blocks for a past genesis index.
+        pub async fn get_first_block_epoch(
+            &mut self,
+            request: impl tonic::IntoRequest<super::EpochRequest>,
+        ) -> Result<tonic::Response<super::BlockHash>, tonic::Status> {
+            self.inner.ready().await.map_err(|e| {
+                tonic::Status::new(
+                    tonic::Code::Unknown,
+                    format!("Service was not ready: {}", e.into()),
+                )
+            })?;
+            let codec = tonic::codec::ProstCodec::default();
+            let path =
+                http::uri::PathAndQuery::from_static("/concordium.v2.Queries/GetFirstBlockEpoch");
+            self.inner.unary(request.into_request(), path, codec).await
         }
     }
 }

--- a/src/v2/proto_schema_version.rs
+++ b/src/v2/proto_schema_version.rs
@@ -1,1 +1,1 @@
-pub const PROTO_SCHEMA_VERSION: &str = "e67aa923ef5f0bd31138a5c87a6fefe87101873c";
+pub const PROTO_SCHEMA_VERSION: &str = "2becdb07c49722d9d41313252fd2e3070534aa0d";


### PR DESCRIPTION
## Purpose

Solve https://github.com/Concordium/concordium-rust-sdk/issues/115

Implemented support for the `GetWinningBakersEpoch` query and introduced a new `EpochIdentifier` which is used for the query.

## Changes

_Describe the changes that were needed.

## Checklist

- [ ] My code follows the style of this project.
- [ ] The code compiles without warnings.
- [ ] I have performed a self-review of the changes.
- [ ] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [ ] (If necessary) I have updated the CHANGELOG.
