### PR TITLE
Implement support for `GetFirstBlockEpoch`.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@
 - Add a new `web3id` module that contains types and functionality for
   construcing Web3ID credentials and verifying Web3ID proofs.
 - Support for `GetWinningBakersEpoch`.
+- Support for `GetFirstBlockEpoch`.
 
 ### Breaking changes in types
 - `ConsensusInfo`

--- a/examples/v2_get_first_block_epoch.rs
+++ b/examples/v2_get_first_block_epoch.rs
@@ -1,0 +1,34 @@
+//! Test the `GetFirstBlockEpoch` endpoint.
+use anyhow::Context;
+use clap::AppSettings;
+use concordium_rust_sdk::v2;
+use structopt::StructOpt;
+
+#[derive(StructOpt)]
+struct App {
+    #[structopt(
+        long = "node",
+        help = "GRPC interface of the node.",
+        default_value = "http://localhost:20000"
+    )]
+    endpoint: v2::Endpoint,
+
+    #[structopt(long = "epoch", help = "Epoch identifier", default_value = "%5,0")]
+    epoch: v2::EpochIdentifier,
+}
+
+#[tokio::main(flavor = "multi_thread")]
+async fn main() -> anyhow::Result<()> {
+    let app = {
+        let app = App::clap().global_setting(AppSettings::ColoredHelp);
+        let matches = app.get_matches();
+        App::from_clap(&matches)
+    };
+
+    let mut client = v2::Client::new(app.endpoint)
+        .await
+        .context("Cannot connect.")?;
+    let fb = client.get_first_block_epoch(app.epoch).await?;
+    println!("{:?}", fb);
+    Ok(())
+}

--- a/src/v2/mod.rs
+++ b/src/v2/mod.rs
@@ -2275,6 +2275,18 @@ impl Client {
         Ok(stream)
     }
 
+    /// Get the first block of the epoch.
+    pub async fn get_first_block_epoch(
+        &mut self,
+        ei: impl IntoEpochIdentifier,
+    ) -> endpoints::QueryResult<BlockHash> {
+        let response = self
+            .client
+            .get_first_block_epoch(&ei.into_epoch_identifier())
+            .await?;
+        Ok(response.into_inner().try_into()?)
+    }
+
     /// Get next available sequence numbers for updating chain parameters after
     /// a given block. If the block does not exist then [`QueryError::NotFound`]
     /// is returned.


### PR DESCRIPTION
## Purpose

Solve https://github.com/Concordium/concordium-rust-sdk/issues/118

Support for `GetFirstBlockEpoch` in the v2 client.


## Checklist

- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [x] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [x] (If necessary) I have updated the CHANGELOG.

