### PR TITLE
Fix web3id attribute parsing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## Unreleased changes
 
+## 3.0.1
+
+- Update `concordium_base` dependency to 3.0.1.
+
 ## 3.0.0
 
 - The SDK requires node version 6 or later.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "concordium-rust-sdk"
-version = "3.0.0"
+version = "3.0.1"
 authors = ["Concordium <developers@concordium.com>"]
 edition = "2021"
 rust-version = "1.65"
@@ -37,7 +37,7 @@ num-traits = "0.2"
 tokio-postgres = { version = "^0.7.8", features = ["with-serde_json-1"], optional = true }
 http = "0.2"
 
-concordium_base = { version = "3.0", path = "./concordium-base/rust-src/concordium_base/", features = ["encryption"] }
+concordium_base = { version = "3.0.1", path = "./concordium-base/rust-src/concordium_base/", features = ["encryption"] }
 concordium-smart-contract-engine = { version = "3.0", path = "./concordium-base/smart-contracts/wasm-chain-integration/", default-features = false, features = ["async"]}
 aes-gcm = { version = "0.10", features = ["std"] }
 


### PR DESCRIPTION
## Purpose

Bump concordium-base and SDK version to fix web3id attribute timestamp parsing.

## Checklist

- [ ] My code follows the style of this project.
- [ ] The code compiles without warnings.
- [ ] I have performed a self-review of the changes.
- [ ] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [ ] (If necessary) I have updated the CHANGELOG.