### PR TITLE
Add helper methods to construct transactions in contract clients.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@
 - Add Support for `GetBakerEarliestWinTime` endpoint. Requires a node version at least 6.1.
 - Add support for `GetBlockCertificates`. Requires a node version at least 6.1.
 - Update minimum supported rust version to `1.66`.
+- Add `make_update` and `make_update_raw` methods to the `ContractClient`. They
+  are like `update` and `update_raw` but instead of sending a transaction they
+  only construct it and return it.
+- Add `make_register_credential`, `make_revoke_credential_as_issuer` and
+  `make_revoke_credential_other` to the CIS4 client. These are like the methods
+  without the `make_` prefix, except that they only construct the transaction,
+  they do not send it.
 
 ## 3.0.1
 

--- a/src/contract_client.rs
+++ b/src/contract_client.rs
@@ -243,7 +243,8 @@ impl<Type> ContractClient<Type> {
         Ok(hash)
     }
 
-    /// Like [`make_update`](Self::make_update) but expects a serialized parameter.
+    /// Like [`make_update`](Self::make_update) but expects a serialized
+    /// parameter.
     pub fn make_update_raw<E>(
         &mut self,
         signer: &impl transactions::ExactSizeTransactionSigner,

--- a/src/contract_client.rs
+++ b/src/contract_client.rs
@@ -15,7 +15,7 @@ use concordium_base::{
     },
     hashes::TransactionHash,
     smart_contracts::{ExceedsParameterSize, OwnedContractName, OwnedParameter, OwnedReceiveName},
-    transactions::UpdateContractPayload,
+    transactions::{AccountTransaction, EncodedPayload, UpdateContractPayload},
 };
 pub use concordium_base::{cis2_types::MetadataUrl, cis4_types::*};
 use std::{marker::PhantomData, sync::Arc};
@@ -199,7 +199,21 @@ impl<Type> ContractClient<Type> {
         Ok(invoke_result)
     }
 
-    /// Send a transaction with the specified parameter.
+    /// Make the payload of a contract update with the specified parameter.
+    pub fn make_update<P: contracts_common::Serial, E>(
+        &mut self,
+        signer: &impl transactions::ExactSizeTransactionSigner,
+        metadata: &ContractTransactionMetadata,
+        entrypoint: &str,
+        message: &P,
+    ) -> Result<AccountTransaction<EncodedPayload>, E>
+    where
+        E: From<NewReceiveNameError> + From<ExceedsParameterSize>, {
+        let message = OwnedParameter::from_serial(message)?;
+        self.make_update_raw::<E>(signer, metadata, entrypoint, message)
+    }
+
+    /// Make **and send** a transaction with the specified parameter.
     pub async fn update<P: contracts_common::Serial, E>(
         &mut self,
         signer: &impl transactions::ExactSizeTransactionSigner,
@@ -224,6 +238,21 @@ impl<Type> ContractClient<Type> {
     ) -> Result<TransactionHash, E>
     where
         E: From<NewReceiveNameError> + From<v2::RPCError>, {
+        let tx = self.make_update_raw::<E>(signer, metadata, entrypoint, message)?;
+        let hash = self.client.send_account_transaction(tx).await?;
+        Ok(hash)
+    }
+
+    /// Like [`make_update`](Self::make_update) but expects a serialized parameter.
+    pub fn make_update_raw<E>(
+        &mut self,
+        signer: &impl transactions::ExactSizeTransactionSigner,
+        metadata: &ContractTransactionMetadata,
+        entrypoint: &str,
+        message: OwnedParameter,
+    ) -> Result<AccountTransaction<EncodedPayload>, E>
+    where
+        E: From<NewReceiveNameError>, {
         let contract_name = self.contract_name.as_contract_name().contract_name();
         let receive_name = OwnedReceiveName::try_from(format!("{contract_name}.{entrypoint}"))?;
 
@@ -242,8 +271,6 @@ impl<Type> ContractClient<Type> {
             metadata.energy,
             transactions::Payload::Update { payload },
         );
-
-        let hash = self.client.send_account_transaction(tx).await?;
-        Ok(hash)
+        Ok(tx)
     }
 }


### PR DESCRIPTION
## Purpose

Add helper methods to contract clients that only construct transactions, leaving sending to the client.

This is useful in cases where transactions have to be resubmitted in case of failure (e.g., network failure).

It came up in the work on the some-issuer service.

## Checklist

- [ ] My code follows the style of this project.
- [ ] The code compiles without warnings.
- [ ] I have performed a self-review of the changes.
- [ ] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [ ] (If necessary) I have updated the CHANGELOG.