### PR TITLE
Fix doc warnings and add lint

### DIFF
--- a/.github/workflows/build-and-test.yaml
+++ b/.github/workflows/build-and-test.yaml
@@ -38,6 +38,26 @@ jobs:
         run: |
           cargo fmt -- --color=always --check
 
+  "lint_doc":
+    name: lint:doc
+    # Don't run on draft pull requests
+    if: ${{ !github.event.pull_request.draft }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+        with:
+          submodules: recursive
+      - name: Install Rust
+        uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: ${{ env.RUST_VERSION }}
+          override: true
+      - name: Docs
+        run: |
+          RUSTDOCFLAGS="-D warnings" cargo doc --no-deps --all-features --color=always
+
   "lint_clippy":
     name: lint:clippy
     # Don't run on draft pull requests
@@ -78,4 +98,3 @@ jobs:
           components: rustfmt
       - name: Test
         run: cargo test
-

--- a/.github/workflows/build-and-test.yaml
+++ b/.github/workflows/build-and-test.yaml
@@ -44,6 +44,8 @@ jobs:
     if: ${{ !github.event.pull_request.draft }}
     runs-on: ubuntu-latest
     steps:
+      - name: Install protobuf
+        run: sudo apt-get install -y protobuf-compiler
       - name: Checkout
         uses: actions/checkout@v2
         with:

--- a/src/v2/mod.rs
+++ b/src/v2/mod.rs
@@ -2337,8 +2337,11 @@ impl Client {
         })
     }
 
-    /// For a non-genesis block, this returns the [`QuorumCertificate`], a
-    /// [`TimeoutCertificate`] (if present) and [`EpochFinalizationEntry`] (if
+    /// For a non-genesis block, this returns the
+    /// [`QuorumCertificate`](block_certificates::QuorumCertificate), a
+    /// [`TimeoutCertificate`](block_certificates::TimeoutCertificate) (if
+    /// present)
+    /// and [`EpochFinalizationEntry`](block_certificates::EpochFinalizationEntry) (if
     /// present).
     /// If the block being pointed to is *not* from protocol version 6 or
     /// above, then [`InvalidArgument`](`tonic::Code::InvalidArgument`)


### PR DESCRIPTION
## Purpose

Fixes the warnings when running `cargo doc` and adds a lint to the Github actions.

## Changes

Fixes a comment and adds the lint.

## Checklist

- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [x] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [ ] (If necessary) I have updated the CHANGELOG.