### PR TITLE
Add dry-run support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 ## Unreleased changes
+- Add support for `DryRun`. Requires a node version at least 6.2.
 - Add a `commission_rates` field to `CurrentPaydayBakerPoolStatus` which yields the commission rates
   of the baker for the reward period. Requires a node version at least 6.1.
 - Add support for `GetWinningBakersEpoch`. Requires a node version at least 6.1.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,7 +36,7 @@ num-bigint = "0.4"
 num-traits = "0.2"
 tokio-postgres = { version = "^0.7.8", features = ["with-serde_json-1"], optional = true }
 http = "0.2"
-queues = "1.1"
+oneshot = "0.1"
 
 concordium_base = { version = "3.0.1", path = "./concordium-base/rust-src/concordium_base/", features = ["encryption"] }
 concordium-smart-contract-engine = { version = "3.0", path = "./concordium-base/smart-contracts/wasm-chain-integration/", default-features = false, features = ["async"]}

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,6 +36,7 @@ num-bigint = "0.4"
 num-traits = "0.2"
 tokio-postgres = { version = "^0.7.8", features = ["with-serde_json-1"], optional = true }
 http = "0.2"
+tokio-stream = "0.1"
 
 concordium_base = { version = "3.0.1", path = "./concordium-base/rust-src/concordium_base/", features = ["encryption"] }
 concordium-smart-contract-engine = { version = "3.0", path = "./concordium-base/smart-contracts/wasm-chain-integration/", default-features = false, features = ["async"]}

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,7 +36,6 @@ num-bigint = "0.4"
 num-traits = "0.2"
 tokio-postgres = { version = "^0.7.8", features = ["with-serde_json-1"], optional = true }
 http = "0.2"
-oneshot = "0.1"
 
 concordium_base = { version = "3.0.1", path = "./concordium-base/rust-src/concordium_base/", features = ["encryption"] }
 concordium-smart-contract-engine = { version = "3.0", path = "./concordium-base/smart-contracts/wasm-chain-integration/", default-features = false, features = ["async"]}

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,6 +36,7 @@ num-bigint = "0.4"
 num-traits = "0.2"
 tokio-postgres = { version = "^0.7.8", features = ["with-serde_json-1"], optional = true }
 http = "0.2"
+queues = "1.1"
 
 concordium_base = { version = "3.0.1", path = "./concordium-base/rust-src/concordium_base/", features = ["encryption"] }
 concordium-smart-contract-engine = { version = "3.0", path = "./concordium-base/smart-contracts/wasm-chain-integration/", default-features = false, features = ["async"]}

--- a/examples/v2_dry_run.rs
+++ b/examples/v2_dry_run.rs
@@ -1,0 +1,115 @@
+//! Example of dry-run functionality of the node.
+
+use std::time::Duration;
+
+use anyhow::Context;
+use clap::AppSettings;
+use concordium_base::{
+    base::Energy,
+    common::types::Timestamp,
+    contracts_common::{Address, Amount, ContractAddress, EntrypointName},
+    smart_contracts::{OwnedParameter, OwnedReceiveName},
+    transactions::Payload,
+};
+use concordium_rust_sdk::{
+    types::smart_contracts::ContractContext,
+    v2::{self, dry_run::DryRunTransaction, BlockIdentifier},
+};
+use structopt::StructOpt;
+
+#[derive(StructOpt)]
+struct App {
+    #[structopt(
+        long = "node",
+        help = "GRPC interface of the node.",
+        default_value = "http://localhost:25162"
+    )]
+    endpoint: v2::Endpoint,
+}
+
+#[tokio::main(flavor = "multi_thread")]
+async fn main() -> anyhow::Result<()> {
+    let app = {
+        let app = App::clap().global_setting(AppSettings::ColoredHelp);
+        let matches = app.get_matches();
+        App::from_clap(&matches)
+    };
+
+    let mut client = v2::Client::new(app.endpoint)
+        .await
+        .context("Cannot connect.")?;
+
+    let mut dry_run = client.dry_run().await?;
+
+    let fut1 = dry_run.load_block_state(BlockIdentifier::Best).await?;
+    tokio::time::sleep(Duration::from_millis(2500)).await;
+
+    let fut2 = dry_run.load_block_state(BlockIdentifier::LastFinal).await?;
+
+    let res2 = fut2.await?;
+    let res1 = fut1.await?;
+    println!(
+        "Best block: {} ({:?})",
+        res1.inner.block_hash, res1.inner.current_timestamp
+    );
+    println!(
+        "Last final: {} ({:?})",
+        res2.inner.block_hash, res2.inner.current_timestamp
+    );
+
+    let res3 = dry_run
+        .get_account_info(&v2::AccountIdentifier::Index(0.into()))
+        .await?
+        .await?;
+
+    println!("Account 0: {}", res3.inner.account_address);
+
+    let contract_addr = ContractAddress {
+        index:    0,
+        subindex: 0,
+    };
+
+    let res4 = dry_run.get_instance_info(&contract_addr).await?.await?;
+
+    println!(
+        "Instance <0,0>: {} {:?}",
+        res4.inner.name(),
+        res4.inner.entrypoints()
+    );
+
+    let invoke_target = OwnedReceiveName::construct(
+        res4.inner.name().as_contract_name(),
+        EntrypointName::new(&"view")?,
+    )?;
+    let parameter = OwnedParameter::empty();
+
+    let context = ContractContext {
+        invoker:   Some(Address::Account(res3.inner.account_address)),
+        contract:  contract_addr,
+        amount:    Amount::zero(),
+        method:    invoke_target,
+        parameter,
+        energy:    10000.into(),
+    };
+
+    let res5 = dry_run.invoke_instance(&context).await?.await;
+
+    println!("Invoked view on <0,0>: {:?}", res5);
+
+    let _res6 = dry_run
+        .mint_to_account(&res3.inner.account_address, Amount::from_ccd(20))
+        .await?
+        .await?;
+
+    let _res7 = dry_run.set_timestamp(Timestamp::now()).await?.await?;
+
+    let payload = Payload::TransferToEncrypted {
+        amount: Amount::from_ccd(20),
+    };
+    let transaction =
+        DryRunTransaction::new(res3.inner.account_address, Energy::from(5000), &payload);
+    let res8 = dry_run.run_transaction(transaction).await?.await?;
+    println!("Transferred to encrypted: {:?}", res8);
+
+    Ok(())
+}

--- a/examples/v2_dry_run.rs
+++ b/examples/v2_dry_run.rs
@@ -1,7 +1,5 @@
 //! Example of dry-run functionality of the node.
 
-use std::time::Duration;
-
 use anyhow::Context;
 use clap::AppSettings;
 use concordium_base::{
@@ -22,30 +20,27 @@ struct App {
     #[structopt(
         long = "node",
         help = "GRPC interface of the node.",
-        default_value = "http://localhost:25162"
+        default_value = "http://localhost:20000"
     )]
     endpoint: v2::Endpoint,
 }
 
-#[tokio::main(flavor = "multi_thread")]
-async fn main() -> anyhow::Result<()> {
-    let app = {
-        let app = App::clap().global_setting(AppSettings::ColoredHelp);
-        let matches = app.get_matches();
-        App::from_clap(&matches)
-    };
-
-    let mut client = v2::Client::new(app.endpoint)
-        .await
-        .context("Cannot connect.")?;
-
+/// Test all dry run operations.
+async fn test_all(endpoint: v2::Endpoint) -> anyhow::Result<()> {
+    // Connect to endpoint.
+    let mut client = v2::Client::new(endpoint).await.context("Cannot connect.")?;
+    // Start the dry run session.
     let mut dry_run = client.dry_run().await?;
-
+    println!(
+        "Timeout: {:?}\nEnergy quota: {:?}",
+        dry_run.timeout(),
+        dry_run.energy_quota()
+    );
+    // Load the best block.
     let fut1 = dry_run.load_block_state(BlockIdentifier::Best).await?;
-    tokio::time::sleep(Duration::from_millis(2500)).await;
-
+    // Load the last finalized block.
     let fut2 = dry_run.load_block_state(BlockIdentifier::LastFinal).await?;
-
+    // Await the results of the loads in the reverse order.
     let res2 = fut2.await?;
     let res1 = fut1.await?;
     println!(
@@ -56,60 +51,67 @@ async fn main() -> anyhow::Result<()> {
         "Last final: {} ({:?})",
         res2.inner.block_hash, res2.inner.current_timestamp
     );
-
+    // Get account info for account at index 0.
     let res3 = dry_run
         .get_account_info(&v2::AccountIdentifier::Index(0.into()))
         .await?
         .await?;
-
     println!("Account 0: {}", res3.inner.account_address);
-
+    // Get contract info for contract at address <0,0>.
     let contract_addr = ContractAddress {
         index:    0,
         subindex: 0,
     };
-
     let res4 = dry_run.get_instance_info(&contract_addr).await?.await?;
-
     println!(
         "Instance <0,0>: {} {:?}",
         res4.inner.name(),
         res4.inner.entrypoints()
     );
-
+    // Try to invoke the entrypoint "view" on the <0,0> contract.
     let invoke_target = OwnedReceiveName::construct(
         res4.inner.name().as_contract_name(),
         EntrypointName::new(&"view")?,
     )?;
     let parameter = OwnedParameter::empty();
-
     let context = ContractContext {
-        invoker:   Some(Address::Account(res3.inner.account_address)),
-        contract:  contract_addr,
-        amount:    Amount::zero(),
-        method:    invoke_target,
+        invoker: Some(Address::Account(res3.inner.account_address)),
+        contract: contract_addr,
+        amount: Amount::zero(),
+        method: invoke_target,
         parameter,
-        energy:    10000.into(),
+        energy: 10000.into(),
     };
-
     let res5 = dry_run.invoke_instance(&context).await?.await;
-
     println!("Invoked view on <0,0>: {:?}", res5);
-
+    // Mint to account 0.
     let _res6 = dry_run
-        .mint_to_account(&res3.inner.account_address, Amount::from_ccd(20))
+        .mint_to_account(&res3.inner.account_address, Amount::from_ccd(21))
         .await?
         .await?;
-
+    // Update the timestamp to now.
     let _res7 = dry_run.set_timestamp(Timestamp::now()).await?.await?;
-
+    // Execute a transfer to the encrypted balance on account 0.
     let payload = Payload::TransferToEncrypted {
         amount: Amount::from_ccd(20),
     };
     let transaction =
         DryRunTransaction::new(res3.inner.account_address, Energy::from(5000), &payload);
-    let res8 = dry_run.run_transaction(transaction).await?.await?;
+    let fut8 = dry_run.run_transaction(transaction).await?;
+    dry_run.close();
+    let res8 = fut8.await?;
     println!("Transferred to encrypted: {:?}", res8);
 
     Ok(())
+}
+
+#[tokio::main(flavor = "multi_thread")]
+async fn main() -> anyhow::Result<()> {
+    let app = {
+        let app = App::clap().global_setting(AppSettings::ColoredHelp);
+        let matches = app.get_matches();
+        App::from_clap(&matches)
+    };
+
+    test_all(app.endpoint.clone()).await
 }

--- a/examples/v2_dry_run.rs
+++ b/examples/v2_dry_run.rs
@@ -30,7 +30,7 @@ async fn test_all(endpoint: v2::Endpoint) -> anyhow::Result<()> {
     // Connect to endpoint.
     let mut client = v2::Client::new(endpoint).await.context("Cannot connect.")?;
     // Start the dry run session.
-    let mut dry_run = client.dry_run().await?;
+    let mut dry_run = client.begin_dry_run().await?;
     println!(
         "Timeout: {:?}\nEnergy quota: {:?}",
         dry_run.timeout(),
@@ -74,7 +74,7 @@ async fn test_all(endpoint: v2::Endpoint) -> anyhow::Result<()> {
     // Try to invoke the entrypoint "view" on the <0,0> contract.
     let invoke_target = OwnedReceiveName::construct(
         res4.inner.name().as_contract_name(),
-        EntrypointName::new(&"view")?,
+        EntrypointName::new("view")?,
     )?;
     let parameter = OwnedParameter::empty();
     let context = ContractContext {

--- a/examples/v2_dry_run.rs
+++ b/examples/v2_dry_run.rs
@@ -20,7 +20,7 @@ struct App {
     #[structopt(
         long = "node",
         help = "GRPC interface of the node.",
-        default_value = "http://localhost:25162"
+        default_value = "http://localhost:20000"
     )]
     endpoint: v2::Endpoint,
 }

--- a/src/types/smart_contracts.rs
+++ b/src/types/smart_contracts.rs
@@ -233,7 +233,7 @@ impl ContractContext {
 fn return_zero_amount() -> Amount { Amount::from_micro_ccd(0) }
 fn return_default_invoke_energy() -> Energy { DEFAULT_INVOKE_ENERGY }
 
-#[derive(SerdeDeserialize, SerdeSerialize, Debug, Clone, Into)]
+#[derive(SerdeDeserialize, SerdeSerialize, Debug, Clone, Into, From)]
 #[serde(transparent)]
 pub struct ReturnValue {
     #[serde(with = "crate::internal::byte_array_hex")]

--- a/src/v1/generated/concordium.rs
+++ b/src/v1/generated/concordium.rs
@@ -1,23 +1,19 @@
 /// An empty message.
-#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct Empty {}
 /// A numeric response.
-#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct NumberResponse {
     #[prost(uint64, tag = "1")]
     pub value: u64,
 }
 /// A response consisting of a boolean.
-#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct BoolResponse {
     #[prost(bool, tag = "1")]
     pub value: bool,
 }
 /// A response in string format.
-#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct StringResponse {
     #[prost(string, tag = "1")]
@@ -25,7 +21,6 @@ pub struct StringResponse {
 }
 /// A response that is encoded in JSON.
 /// JSON schemas are available at <https://developer.concordium.software/en/mainnet/net/references/grpc.html.>
-#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct JsonResponse {
     #[prost(string, tag = "1")]
@@ -33,14 +28,12 @@ pub struct JsonResponse {
 }
 /// A response in binary format.
 /// The encoding of the data is dependent on the endpoint.
-#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct BytesResponse {
     #[prost(bytes = "vec", tag = "1")]
     pub value: ::prost::alloc::vec::Vec<u8>,
 }
 /// A request that suggests the node to connect to the specified peer.
-#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct PeerConnectRequest {
     /// The IP of the peer.
@@ -51,7 +44,6 @@ pub struct PeerConnectRequest {
     pub port: ::core::option::Option<i32>,
 }
 /// A peer node.
-#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct PeerElement {
     /// The id of the node.
@@ -104,20 +96,9 @@ pub mod peer_element {
                 CatchupStatus::Catchingup => "CATCHINGUP",
             }
         }
-
-        /// Creates an enum from field names used in the ProtoBuf definition.
-        pub fn from_str_name(value: &str) -> ::core::option::Option<Self> {
-            match value {
-                "UPTODATE" => Some(Self::Uptodate),
-                "PENDING" => Some(Self::Pending),
-                "CATCHINGUP" => Some(Self::Catchingup),
-                _ => None,
-            }
-        }
     }
 }
 /// A response containing a list of peers.
-#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct PeerListResponse {
     /// The type of the queried node.
@@ -129,7 +110,6 @@ pub struct PeerListResponse {
     pub peers:     ::prost::alloc::vec::Vec<PeerElement>,
 }
 /// A response containing information about a peer.
-#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct PeerStatsResponse {
     /// A list of stats for the peers.
@@ -144,7 +124,6 @@ pub struct PeerStatsResponse {
 }
 /// Nested message and enum types in `PeerStatsResponse`.
 pub mod peer_stats_response {
-    #[allow(clippy::derive_partial_eq_without_eq)]
     #[derive(Clone, PartialEq, ::prost::Message)]
     pub struct PeerStats {
         /// The node id.
@@ -162,7 +141,6 @@ pub mod peer_stats_response {
     }
 }
 /// A request to change the network.
-#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct NetworkChangeRequest {
     /// The identifier for the network.
@@ -170,7 +148,6 @@ pub struct NetworkChangeRequest {
     pub network_id: ::core::option::Option<i32>,
 }
 /// A response containing information about the node.
-#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct NodeInfoResponse {
     /// The unique node identifier.
@@ -244,22 +221,10 @@ pub mod node_info_response {
                 IsInBakingCommittee::ActiveInCommittee => "ACTIVE_IN_COMMITTEE",
             }
         }
-
-        /// Creates an enum from field names used in the ProtoBuf definition.
-        pub fn from_str_name(value: &str) -> ::core::option::Option<Self> {
-            match value {
-                "NOT_IN_COMMITTEE" => Some(Self::NotInCommittee),
-                "ADDED_BUT_NOT_ACTIVE_IN_COMMITTEE" => Some(Self::AddedButNotActiveInCommittee),
-                "ADDED_BUT_WRONG_KEYS" => Some(Self::AddedButWrongKeys),
-                "ACTIVE_IN_COMMITTEE" => Some(Self::ActiveInCommittee),
-                _ => None,
-            }
-        }
     }
 }
 /// Hash of a block (encoded in hex). Is always 64 characters long.
 /// Example: "987d6c06256fbf874d6ba14f19baee4390a31c6ee58edd9cc4efef62e89d22d7"
-#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct BlockHash {
     #[prost(string, tag = "1")]
@@ -268,7 +233,6 @@ pub struct BlockHash {
 /// An account address. Uses a base58-check encoding with a version byte set to
 /// 1. Is always 50 characters long.
 /// Example: "3DJoe7aUwMwVmdFdRU2QsnJfsBbCmQu1QHvEg7YtWFZWmsoBXe"
-#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct AccountAddress {
     #[prost(string, tag = "1")]
@@ -276,14 +240,12 @@ pub struct AccountAddress {
 }
 /// Hash of a transaction (encoded in hex). Is always 64 characters long.
 /// Example: "987d6c06256fbf874d6ba14f19baee4390a31c6ee58edd9cc4efef62e89d22d7"
-#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct TransactionHash {
     #[prost(string, tag = "1")]
     pub transaction_hash: ::prost::alloc::string::String,
 }
 /// Request for getting the ancestors of a block.
-#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct BlockHashAndAmount {
     /// The block to get ancestors of.
@@ -295,7 +257,6 @@ pub struct BlockHashAndAmount {
 }
 /// Submit a transaction to the node. The transaction is subject to basic
 /// validation and is then relayed to all the peers.
-#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct SendTransactionRequest {
     /// The network id (currently not used in this request).
@@ -308,7 +269,6 @@ pub struct SendTransactionRequest {
     pub payload:    ::prost::alloc::vec::Vec<u8>,
 }
 /// Request for getting information about an account address.
-#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct GetAddressInfoRequest {
     /// Hash of the block (encoded in hex) at which the information should be
@@ -320,7 +280,6 @@ pub struct GetAddressInfoRequest {
     pub address:    ::prost::alloc::string::String,
 }
 /// Request for invoking a contract without a transaction.
-#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct InvokeContractRequest {
     /// Hash of the block (encoded in hex) at which to invoke the contract.
@@ -332,7 +291,6 @@ pub struct InvokeContractRequest {
     pub context:    ::prost::alloc::string::String,
 }
 /// Request for getting the source of a smart contract module.
-#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct GetModuleSourceRequest {
     /// The block to be used for the query.
@@ -343,7 +301,6 @@ pub struct GetModuleSourceRequest {
     pub module_ref: ::prost::alloc::string::String,
 }
 /// Request to enable dumping of network packages.
-#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct DumpRequest {
     /// Which file to dump the packages into.
@@ -354,7 +311,6 @@ pub struct DumpRequest {
     pub raw:  bool,
 }
 /// Request for getting (information about) the peers.
-#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct PeersRequest {
     /// Whether bootstrapper nodes should be included in the result.
@@ -362,7 +318,6 @@ pub struct PeersRequest {
     pub include_bootstrappers: bool,
 }
 /// Request for getting the status of a transaction in a given block.
-#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct GetTransactionStatusInBlockRequest {
     /// The transaction hash.
@@ -373,7 +328,6 @@ pub struct GetTransactionStatusInBlockRequest {
     pub block_hash:       ::prost::alloc::string::String,
 }
 /// Request for getting the status of a pool.
-#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct GetPoolStatusRequest {
     /// The block from which the query should be processed.
@@ -388,7 +342,6 @@ pub struct GetPoolStatusRequest {
     pub baker_id:           u64,
 }
 /// Request for gettings the blocks at a specific height.
-#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct BlockHeight {
     /// The block height.

--- a/src/v1/generated/concordium.rs
+++ b/src/v1/generated/concordium.rs
@@ -1,19 +1,23 @@
 /// An empty message.
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct Empty {}
 /// A numeric response.
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct NumberResponse {
     #[prost(uint64, tag = "1")]
     pub value: u64,
 }
 /// A response consisting of a boolean.
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct BoolResponse {
     #[prost(bool, tag = "1")]
     pub value: bool,
 }
 /// A response in string format.
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct StringResponse {
     #[prost(string, tag = "1")]
@@ -21,6 +25,7 @@ pub struct StringResponse {
 }
 /// A response that is encoded in JSON.
 /// JSON schemas are available at <https://developer.concordium.software/en/mainnet/net/references/grpc.html.>
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct JsonResponse {
     #[prost(string, tag = "1")]
@@ -28,12 +33,14 @@ pub struct JsonResponse {
 }
 /// A response in binary format.
 /// The encoding of the data is dependent on the endpoint.
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct BytesResponse {
     #[prost(bytes = "vec", tag = "1")]
     pub value: ::prost::alloc::vec::Vec<u8>,
 }
 /// A request that suggests the node to connect to the specified peer.
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct PeerConnectRequest {
     /// The IP of the peer.
@@ -44,6 +51,7 @@ pub struct PeerConnectRequest {
     pub port: ::core::option::Option<i32>,
 }
 /// A peer node.
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct PeerElement {
     /// The id of the node.
@@ -96,9 +104,20 @@ pub mod peer_element {
                 CatchupStatus::Catchingup => "CATCHINGUP",
             }
         }
+
+        /// Creates an enum from field names used in the ProtoBuf definition.
+        pub fn from_str_name(value: &str) -> ::core::option::Option<Self> {
+            match value {
+                "UPTODATE" => Some(Self::Uptodate),
+                "PENDING" => Some(Self::Pending),
+                "CATCHINGUP" => Some(Self::Catchingup),
+                _ => None,
+            }
+        }
     }
 }
 /// A response containing a list of peers.
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct PeerListResponse {
     /// The type of the queried node.
@@ -110,6 +129,7 @@ pub struct PeerListResponse {
     pub peers:     ::prost::alloc::vec::Vec<PeerElement>,
 }
 /// A response containing information about a peer.
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct PeerStatsResponse {
     /// A list of stats for the peers.
@@ -124,6 +144,7 @@ pub struct PeerStatsResponse {
 }
 /// Nested message and enum types in `PeerStatsResponse`.
 pub mod peer_stats_response {
+    #[allow(clippy::derive_partial_eq_without_eq)]
     #[derive(Clone, PartialEq, ::prost::Message)]
     pub struct PeerStats {
         /// The node id.
@@ -141,6 +162,7 @@ pub mod peer_stats_response {
     }
 }
 /// A request to change the network.
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct NetworkChangeRequest {
     /// The identifier for the network.
@@ -148,6 +170,7 @@ pub struct NetworkChangeRequest {
     pub network_id: ::core::option::Option<i32>,
 }
 /// A response containing information about the node.
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct NodeInfoResponse {
     /// The unique node identifier.
@@ -221,10 +244,22 @@ pub mod node_info_response {
                 IsInBakingCommittee::ActiveInCommittee => "ACTIVE_IN_COMMITTEE",
             }
         }
+
+        /// Creates an enum from field names used in the ProtoBuf definition.
+        pub fn from_str_name(value: &str) -> ::core::option::Option<Self> {
+            match value {
+                "NOT_IN_COMMITTEE" => Some(Self::NotInCommittee),
+                "ADDED_BUT_NOT_ACTIVE_IN_COMMITTEE" => Some(Self::AddedButNotActiveInCommittee),
+                "ADDED_BUT_WRONG_KEYS" => Some(Self::AddedButWrongKeys),
+                "ACTIVE_IN_COMMITTEE" => Some(Self::ActiveInCommittee),
+                _ => None,
+            }
+        }
     }
 }
 /// Hash of a block (encoded in hex). Is always 64 characters long.
 /// Example: "987d6c06256fbf874d6ba14f19baee4390a31c6ee58edd9cc4efef62e89d22d7"
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct BlockHash {
     #[prost(string, tag = "1")]
@@ -233,6 +268,7 @@ pub struct BlockHash {
 /// An account address. Uses a base58-check encoding with a version byte set to
 /// 1. Is always 50 characters long.
 /// Example: "3DJoe7aUwMwVmdFdRU2QsnJfsBbCmQu1QHvEg7YtWFZWmsoBXe"
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct AccountAddress {
     #[prost(string, tag = "1")]
@@ -240,12 +276,14 @@ pub struct AccountAddress {
 }
 /// Hash of a transaction (encoded in hex). Is always 64 characters long.
 /// Example: "987d6c06256fbf874d6ba14f19baee4390a31c6ee58edd9cc4efef62e89d22d7"
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct TransactionHash {
     #[prost(string, tag = "1")]
     pub transaction_hash: ::prost::alloc::string::String,
 }
 /// Request for getting the ancestors of a block.
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct BlockHashAndAmount {
     /// The block to get ancestors of.
@@ -257,6 +295,7 @@ pub struct BlockHashAndAmount {
 }
 /// Submit a transaction to the node. The transaction is subject to basic
 /// validation and is then relayed to all the peers.
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct SendTransactionRequest {
     /// The network id (currently not used in this request).
@@ -269,6 +308,7 @@ pub struct SendTransactionRequest {
     pub payload:    ::prost::alloc::vec::Vec<u8>,
 }
 /// Request for getting information about an account address.
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct GetAddressInfoRequest {
     /// Hash of the block (encoded in hex) at which the information should be
@@ -280,6 +320,7 @@ pub struct GetAddressInfoRequest {
     pub address:    ::prost::alloc::string::String,
 }
 /// Request for invoking a contract without a transaction.
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct InvokeContractRequest {
     /// Hash of the block (encoded in hex) at which to invoke the contract.
@@ -291,6 +332,7 @@ pub struct InvokeContractRequest {
     pub context:    ::prost::alloc::string::String,
 }
 /// Request for getting the source of a smart contract module.
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct GetModuleSourceRequest {
     /// The block to be used for the query.
@@ -301,6 +343,7 @@ pub struct GetModuleSourceRequest {
     pub module_ref: ::prost::alloc::string::String,
 }
 /// Request to enable dumping of network packages.
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct DumpRequest {
     /// Which file to dump the packages into.
@@ -311,6 +354,7 @@ pub struct DumpRequest {
     pub raw:  bool,
 }
 /// Request for getting (information about) the peers.
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct PeersRequest {
     /// Whether bootstrapper nodes should be included in the result.
@@ -318,6 +362,7 @@ pub struct PeersRequest {
     pub include_bootstrappers: bool,
 }
 /// Request for getting the status of a transaction in a given block.
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct GetTransactionStatusInBlockRequest {
     /// The transaction hash.
@@ -328,6 +373,7 @@ pub struct GetTransactionStatusInBlockRequest {
     pub block_hash:       ::prost::alloc::string::String,
 }
 /// Request for getting the status of a pool.
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct GetPoolStatusRequest {
     /// The block from which the query should be processed.
@@ -342,6 +388,7 @@ pub struct GetPoolStatusRequest {
     pub baker_id:           u64,
 }
 /// Request for gettings the blocks at a specific height.
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct BlockHeight {
     /// The block height.

--- a/src/v2/dry_run.rs
+++ b/src/v2/dry_run.rs
@@ -242,7 +242,7 @@ pub struct WithRemainingQuota<T> {
     pub quota_remaining: Energy,
 }
 
-/// The successful result of [DryRun::load_block_state].
+/// The successful result of [`DryRun::load_block_state()`].
 #[derive(Debug, Clone)]
 pub struct BlockStateLoaded {
     /// The timestamp of the block, taken to be the current timestamp when
@@ -399,7 +399,7 @@ impl From<&ContractContext> for DryRunInvokeInstance {
     }
 }
 
-/// The successful result of [DryRun::invoke_instance].
+/// The successful result of [`DryRun::invoke_instance()`].
 #[derive(Debug, Clone)]
 pub struct InvokeInstanceSuccess {
     /// The return value for a V1 contract call. Absent for a V0 contract call.
@@ -467,7 +467,7 @@ impl TryFrom<Option<Result<generated::DryRunResponse, tonic::Status>>>
     }
 }
 
-/// The successful result of [DryRun::set_timestamp].
+/// The successful result of [`DryRun::set_timestamp()`].
 #[derive(Clone, Debug)]
 pub struct TimestampSet {}
 
@@ -512,7 +512,7 @@ impl TryFrom<Option<Result<generated::DryRunResponse, tonic::Status>>>
     }
 }
 
-/// The successful result of [DryRun::mint_to_account].
+/// The successful result of [`DryRun::mint_to_account()`].
 #[derive(Clone, Debug)]
 pub struct MintedToAccount {}
 
@@ -619,7 +619,7 @@ impl From<DryRunTransaction> for generated::DryRunTransaction {
     }
 }
 
-/// The successful result of [DryRun::transaction].
+/// The successful result of [`DryRun::transaction()`].
 /// Note that a transaction can still be rejected (i.e. produce no effect beyond
 /// charging the sender) even if it is executed.
 #[derive(Clone, Debug)]
@@ -743,7 +743,7 @@ impl DryRun {
 
     /// Load the state from a specified block.
     /// This can result in an error if the dry-run session has already been
-    /// closed, either by [DryRun::close] or by the server closing the session.
+    /// closed, either by [`DryRun::close()`] or by the server closing the session.
     /// In this case, the response code indicates the cause.
     /// If successful, this returns a future that can be used to wait for the
     /// result of the operation. The following results are possible:
@@ -777,7 +777,7 @@ impl DryRun {
 
     /// Get the account information for a specified account in the current
     /// state. This can result in an error if the dry-run session has
-    /// already been closed, either by [DryRun::close] or by the server
+    /// already been closed, either by [`DryRun::close()`] or by the server
     /// closing the session. In this case, the response code indicates the
     /// cause. If successful, this returns a future that can be used to wait
     /// for the result of the operation. The following results are possible:
@@ -814,7 +814,7 @@ impl DryRun {
 
     /// Get the details of a specified smart contract instance in the current
     /// state. This operation can result in an error if the dry-run session has
-    /// already been closed, either by [DryRun::close] or by the server
+    /// already been closed, either by [`DryRun::close()`] or by the server
     /// closing the session. In this case, the response code indicates the
     /// cause. If successful, this returns a future that can be used to wait
     /// for the result of the operation. The following results are possible:
@@ -853,9 +853,9 @@ impl DryRun {
     /// Any changes this would make to the state will be rolled back so they are
     /// not observable by subsequent operations in the dry-run session. (To make
     /// updates that are observable within the dry-run session, use
-    /// [DryRun::run_transaction] instead.) This operation can result in an
+    /// [`DryRun::run_transaction()`] instead.) This operation can result in an
     /// error if the dry-run session has already been closed, either by
-    /// [DryRun::close] or by the server closing the session. In this case,
+    /// [`DryRun::close()`] or by the server closing the session. In this case,
     /// the response code indicates the cause. If successful, this returns a
     /// future that can be used to wait for the result of the operation. The
     /// following results are possible:
@@ -895,10 +895,10 @@ impl DryRun {
 
     /// Update the current timestamp for subsequent dry-run operations. The
     /// timestamp is automatically set to the timestamp of the block loaded
-    /// by [DryRun::load_block_state]. For smart contracts that are time
+    /// by [`DryRun::load_block_state()`]. For smart contracts that are time
     /// sensitive, overriding the timestamp can be useful. This operation can
     /// result in an error if the dry-run session has already been closed,
-    /// either by [DryRun::close] or by the server closing the session. In
+    /// either by [`DryRun::close()`] or by the server closing the session. In
     /// this case, the response code indicates the cause. If successful,
     /// this returns a future that can be used to wait for the result of the
     /// operation. The following results are possible:
@@ -936,7 +936,7 @@ impl DryRun {
 
     /// Mint a specified amount and award it to a specified account. This
     /// operation can result in an error if the dry-run session has already
-    /// been closed, either by [DryRun::close] or by the server closing the
+    /// been closed, either by [`DryRun::close()`] or by the server closing the
     /// session. In this case, the response code indicates the cause. If
     /// successful, this returns a future that can be used to wait for the
     /// result of the operation. The following results are possible:
@@ -982,7 +982,7 @@ impl DryRun {
 
     /// Dry-run a transaction, updating the state of the dry-run session
     /// accordingly. This operation can result in an error if the dry-run
-    /// session has already been closed, either by [DryRun::close] or by the
+    /// session has already been closed, either by [`DryRun::close()`] or by the
     /// server closing the session. In this case, the response code
     /// indicates the cause. If successful, this returns a future that can
     /// be used to wait for the result of the operation. The following

--- a/src/v2/dry_run.rs
+++ b/src/v2/dry_run.rs
@@ -1,0 +1,824 @@
+use concordium_base::{
+    base::{Energy, ProtocolVersion},
+    common::types::{CredentialIndex, KeyIndex, Timestamp},
+    contracts_common::{AccountAddress, Amount, ContractAddress},
+    hashes::BlockHash,
+    smart_contracts::ContractTraceElement,
+    transactions::{EncodedPayload, PayloadLike},
+};
+use queues::{IsQueue, Queue};
+use std::{mem, sync::Arc};
+
+use futures::{lock::Mutex, stream::FusedStream, *};
+
+use crate::{
+    endpoints,
+    types::{
+        smart_contracts::{ContractContext, InstanceInfo, ReturnValue},
+        AccountInfo, AccountTransactionDetails, RejectReason,
+    },
+    v2::{generated::DryRunStateQuery, Require},
+};
+
+use super::{
+    generated::{
+        self, account_transaction_payload, dry_run_error_response, dry_run_request,
+        DryRunInvokeInstance, DryRunMintToAccount, DryRunSignature, DryRunStateOperation,
+    },
+    AccountIdentifier, IntoBlockIdentifier,
+};
+
+/// A stream together with a queue of pending requests for items from the
+/// stream that have not yet been polled. This is used to allow multiple
+/// readers of the stream to be sequenced.
+struct InnerSharedReceiver<S>
+where
+    S: Stream, {
+    /// The underlying stream.
+    src:     S,
+    /// The queue of pending receivers.
+    pending: Queue<Arc<Mutex<Option<S::Item>>>>,
+}
+
+struct SharedReceiverItem<S>
+where
+    S: Stream, {
+    value:    Arc<Mutex<Option<S::Item>>>,
+    receiver: Arc<Mutex<InnerSharedReceiver<S>>>,
+}
+
+struct SharedReceiver<S>
+where
+    S: Stream, {
+    inner: Arc<Mutex<InnerSharedReceiver<S>>>,
+}
+
+impl<S: Stream> SharedReceiver<S> {
+    /// Construct a shared receiver from a stream.
+    fn new(stream: S) -> Self {
+        let inner = InnerSharedReceiver {
+            src:     stream,
+            pending: Queue::new(),
+        };
+        SharedReceiver {
+            inner: Arc::new(Mutex::new(inner)),
+        }
+    }
+
+    /// Get a [SharedReceiverItem] that can be used to get the next item from
+    /// the stream.
+    async fn next(&self) -> SharedReceiverItem<S> {
+        let new_item = Arc::new(Mutex::new(None));
+        self.inner
+            .lock()
+            .await
+            .pending
+            .add(new_item.clone())
+            .unwrap();
+        SharedReceiverItem {
+            value:    new_item,
+            receiver: self.inner.clone(),
+        }
+    }
+}
+
+impl<S: Stream + Unpin + FusedStream> SharedReceiverItem<S> {
+    async fn receive(self) -> Option<S::Item> {
+        let mut receiver = self.receiver.lock().await;
+        {
+            let out = {
+                let mut value = self.value.lock().await;
+                mem::replace(&mut *value, None)
+            };
+            if let Some(v) = out {
+                return Some(v);
+            }
+        }
+        {
+            loop {
+                let val = receiver.src.next().await;
+                let next_item = receiver.pending.remove().unwrap();
+                if Arc::ptr_eq(&next_item, &self.value) {
+                    return val;
+                } else {
+                    let mut other = next_item.lock().await;
+                    *other = val;
+                }
+            }
+        }
+    }
+}
+
+pub struct DryRun {
+    request_send:  channel::mpsc::Sender<generated::DryRunRequest>,
+    response_recv:
+        SharedReceiver<futures::stream::Fuse<tonic::Streaming<generated::DryRunResponse>>>,
+}
+
+#[derive(thiserror::Error, Debug)]
+pub enum ErrorResult {
+    #[error("block state not loaded")]
+    NoState(),
+    #[error("block not found")]
+    BlockNotFound(),
+    #[error("account not found")]
+    AccountNotFound(),
+    #[error("contract instance not found")]
+    InstanceNotFound(),
+    #[error("mint amount exceeds limit")]
+    AmountOverLimit { amount_limit: Amount },
+    #[error("account balance insufficient")]
+    BalanceInsufficient {
+        required_amount:  Amount,
+        available_amount: Amount,
+    },
+    #[error("energy insufficient")]
+    EnergyInsufficient { energy_required: Energy },
+    #[error("invoke instance failed")]
+    InvokeFailure {
+        return_value: Option<Vec<u8>>,
+        used_energy:  Energy,
+        reason:       RejectReason,
+    },
+}
+
+impl TryFrom<dry_run_error_response::Error> for ErrorResult {
+    type Error = tonic::Status;
+
+    fn try_from(value: dry_run_error_response::Error) -> Result<Self, Self::Error> {
+        use dry_run_error_response::Error;
+        let res = match value {
+            Error::NoState(_) => Self::NoState(),
+            Error::BlockNotFound(_) => Self::BlockNotFound(),
+            Error::AccountNotFound(_) => Self::AccountNotFound(),
+            Error::InstanceNotFound(_) => Self::InstanceNotFound(),
+            Error::AmountOverLimit(e) => Self::AmountOverLimit {
+                amount_limit: e.amount_limit.require()?.into(),
+            },
+            Error::BalanceInsufficient(e) => Self::BalanceInsufficient {
+                required_amount:  e.required_amount.require()?.into(),
+                available_amount: e.available_amount.require()?.into(),
+            },
+            Error::EnergyInsufficient(e) => Self::EnergyInsufficient {
+                energy_required: e.energy_required.require()?.into(),
+            },
+            Error::InvokeFailed(e) => Self::InvokeFailure {
+                return_value: e.return_value,
+                used_energy:  e.used_energy.require()?.into(),
+                reason:       e.reason.require()?.try_into()?,
+            },
+        };
+        Ok(res)
+    }
+}
+
+#[derive(thiserror::Error, Debug)]
+pub enum DryRunError {
+    #[error("{0}")]
+    QueryError(#[from] endpoints::QueryError),
+    #[error("dry-run operation failed: {result}")]
+    OperationFailed {
+        #[source]
+        result:          ErrorResult,
+        quota_remaining: Energy,
+    },
+}
+
+impl From<tonic::Status> for DryRunError {
+    fn from(s: tonic::Status) -> Self { Self::QueryError(s.into()) }
+}
+
+#[derive(Debug, Clone)]
+pub struct WithRemainingQuota<T> {
+    pub inner:           T,
+    pub quota_remaining: Energy,
+}
+
+#[derive(Debug, Clone)]
+pub struct BlockStateLoaded {
+    pub current_timestamp: Timestamp,
+    pub block_hash:        BlockHash,
+    pub protocol_version:  ProtocolVersion,
+}
+
+impl TryFrom<Option<Result<generated::DryRunResponse, tonic::Status>>>
+    for WithRemainingQuota<BlockStateLoaded>
+{
+    type Error = DryRunError;
+
+    fn try_from(
+        value: Option<Result<generated::DryRunResponse, tonic::Status>>,
+    ) -> Result<Self, Self::Error> {
+        let response =
+            value.ok_or_else(|| tonic::Status::cancelled("server closed dry run stream"))??;
+        let quota_remaining = response.quota_remaining.require()?.into();
+        use generated::dry_run_response::*;
+        match response.response.require()? {
+            Response::Error(e) => {
+                let result = e.error.require()?.try_into()?;
+                if !matches!(result, ErrorResult::BlockNotFound()) {
+                    Err(tonic::Status::unknown("unexpected error response type"))?
+                }
+                Err(DryRunError::OperationFailed {
+                    result,
+                    quota_remaining,
+                })
+            }
+            Response::Success(s) => {
+                let response = s.response.require()?;
+                use generated::dry_run_success_response::*;
+                match response {
+                    Response::BlockStateLoaded(loaded) => {
+                        let protocol_version =
+                            generated::ProtocolVersion::from_i32(loaded.protocol_version)
+                                .ok_or_else(|| tonic::Status::unknown("Unknown protocol version"))?
+                                .into();
+                        let loaded = BlockStateLoaded {
+                            current_timestamp: loaded.current_timestamp.require()?.into(),
+                            block_hash: loaded.block_hash.require()?.try_into()?,
+                            protocol_version,
+                        };
+                        Ok(WithRemainingQuota {
+                            inner: loaded,
+                            quota_remaining,
+                        })
+                    }
+                    _ => Err(tonic::Status::unknown("unexpected success response type"))?,
+                }
+            }
+        }
+    }
+}
+
+impl TryFrom<Option<Result<generated::DryRunResponse, tonic::Status>>>
+    for WithRemainingQuota<AccountInfo>
+{
+    type Error = DryRunError;
+
+    fn try_from(
+        value: Option<Result<generated::DryRunResponse, tonic::Status>>,
+    ) -> Result<Self, Self::Error> {
+        let response =
+            value.ok_or_else(|| tonic::Status::cancelled("server closed dry run stream"))??;
+        let quota_remaining = response.quota_remaining.require()?.into();
+        use generated::dry_run_response::*;
+        match response.response.require()? {
+            Response::Error(e) => {
+                let result = e.error.require()?.try_into()?;
+                if !matches!(
+                    result,
+                    ErrorResult::NoState() | ErrorResult::AccountNotFound()
+                ) {
+                    Err(tonic::Status::unknown("unexpected error response type"))?
+                }
+                Err(DryRunError::OperationFailed {
+                    result,
+                    quota_remaining,
+                })
+            }
+            Response::Success(s) => {
+                let response = s.response.require()?;
+                use generated::dry_run_success_response::*;
+                match response {
+                    Response::AccountInfo(info) => Ok(WithRemainingQuota {
+                        inner: info.try_into()?,
+                        quota_remaining,
+                    }),
+                    _ => Err(tonic::Status::unknown("unexpected success response type"))?,
+                }
+            }
+        }
+    }
+}
+
+impl TryFrom<Option<Result<generated::DryRunResponse, tonic::Status>>>
+    for WithRemainingQuota<InstanceInfo>
+{
+    type Error = DryRunError;
+
+    fn try_from(
+        value: Option<Result<generated::DryRunResponse, tonic::Status>>,
+    ) -> Result<Self, Self::Error> {
+        let response =
+            value.ok_or_else(|| tonic::Status::cancelled("server closed dry run stream"))??;
+        let quota_remaining = response.quota_remaining.require()?.into();
+        use generated::dry_run_response::*;
+        match response.response.require()? {
+            Response::Error(e) => {
+                let result = e.error.require()?.try_into()?;
+                if !matches!(
+                    result,
+                    ErrorResult::NoState() | ErrorResult::InstanceNotFound()
+                ) {
+                    Err(tonic::Status::unknown("unexpected error response type"))?
+                }
+                Err(DryRunError::OperationFailed {
+                    result,
+                    quota_remaining,
+                })
+            }
+            Response::Success(s) => {
+                let response = s.response.require()?;
+                use generated::dry_run_success_response::*;
+                match response {
+                    Response::InstanceInfo(info) => Ok(WithRemainingQuota {
+                        inner: info.try_into()?,
+                        quota_remaining,
+                    }),
+                    _ => Err(tonic::Status::unknown("unexpected success response type"))?,
+                }
+            }
+        }
+    }
+}
+
+impl From<&ContractContext> for DryRunInvokeInstance {
+    fn from(context: &ContractContext) -> Self {
+        DryRunInvokeInstance {
+            invoker:    context.invoker.as_ref().map(|a| a.into()),
+            instance:   Some((&context.contract).into()),
+            amount:     Some(context.amount.into()),
+            entrypoint: Some(context.method.as_receive_name().into()),
+            parameter:  Some(context.parameter.as_ref().into()),
+            energy:     Some(context.energy.into()),
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct InvokeContractSuccess {
+    pub return_value: Option<ReturnValue>,
+    pub events:       Vec<ContractTraceElement>,
+    pub used_energy:  Energy,
+}
+
+impl TryFrom<Option<Result<generated::DryRunResponse, tonic::Status>>>
+    for WithRemainingQuota<InvokeContractSuccess>
+{
+    type Error = DryRunError;
+
+    fn try_from(
+        value: Option<Result<generated::DryRunResponse, tonic::Status>>,
+    ) -> Result<Self, Self::Error> {
+        let response =
+            value.ok_or_else(|| tonic::Status::cancelled("server closed dry run stream"))??;
+        let quota_remaining = response.quota_remaining.require()?.into();
+        use generated::dry_run_response::*;
+        match response.response.require()? {
+            Response::Error(e) => {
+                let result = e.error.require()?.try_into()?;
+                if !matches!(
+                    result,
+                    ErrorResult::NoState()
+                        | ErrorResult::InvokeFailure {
+                            return_value: _,
+                            used_energy:  _,
+                            reason:       _,
+                        }
+                ) {
+                    Err(tonic::Status::unknown("unexpected error response type"))?
+                }
+                Err(DryRunError::OperationFailed {
+                    result,
+                    quota_remaining,
+                })
+            }
+            Response::Success(s) => {
+                let response = s.response.require()?;
+                use generated::dry_run_success_response::*;
+                match response {
+                    Response::InvokeSucceeded(result) => {
+                        let inner = InvokeContractSuccess {
+                            return_value: result.return_value.map(|a| ReturnValue { value: a }),
+                            events:       result
+                                .effects
+                                .into_iter()
+                                .map(TryFrom::try_from)
+                                .collect::<Result<_, tonic::Status>>()?,
+                            used_energy:  result.used_energy.require()?.into(),
+                        };
+                        Ok(WithRemainingQuota {
+                            inner,
+                            quota_remaining,
+                        })
+                    }
+                    _ => Err(tonic::Status::unknown("unexpected success response type"))?,
+                }
+            }
+        }
+    }
+}
+
+#[derive(Clone, Debug)]
+pub struct TimestampSet {}
+
+impl TryFrom<Option<Result<generated::DryRunResponse, tonic::Status>>>
+    for WithRemainingQuota<TimestampSet>
+{
+    type Error = DryRunError;
+
+    fn try_from(
+        value: Option<Result<generated::DryRunResponse, tonic::Status>>,
+    ) -> Result<Self, Self::Error> {
+        let response =
+            value.ok_or_else(|| tonic::Status::cancelled("server closed dry run stream"))??;
+        let quota_remaining = response.quota_remaining.require()?.into();
+        use generated::dry_run_response::*;
+        match response.response.require()? {
+            Response::Error(e) => {
+                let result = e.error.require()?.try_into()?;
+                if !matches!(result, ErrorResult::NoState()) {
+                    Err(tonic::Status::unknown("unexpected error response type"))?
+                }
+                Err(DryRunError::OperationFailed {
+                    result,
+                    quota_remaining,
+                })
+            }
+            Response::Success(s) => {
+                let response = s.response.require()?;
+                use generated::dry_run_success_response::*;
+                match response {
+                    Response::TimestampSet(_) => {
+                        let inner = TimestampSet {};
+                        Ok(WithRemainingQuota {
+                            inner,
+                            quota_remaining,
+                        })
+                    }
+                    _ => Err(tonic::Status::unknown("unexpected success response type"))?,
+                }
+            }
+        }
+    }
+}
+
+#[derive(Clone, Debug)]
+pub struct MintedToAccount {}
+
+impl TryFrom<Option<Result<generated::DryRunResponse, tonic::Status>>>
+    for WithRemainingQuota<MintedToAccount>
+{
+    type Error = DryRunError;
+
+    fn try_from(
+        value: Option<Result<generated::DryRunResponse, tonic::Status>>,
+    ) -> Result<Self, Self::Error> {
+        let response =
+            value.ok_or_else(|| tonic::Status::cancelled("server closed dry run stream"))??;
+        let quota_remaining = response.quota_remaining.require()?.into();
+        use generated::dry_run_response::*;
+        match response.response.require()? {
+            Response::Error(e) => {
+                let result = e.error.require()?.try_into()?;
+                if !matches!(
+                    result,
+                    ErrorResult::NoState() | ErrorResult::AmountOverLimit { amount_limit: _ }
+                ) {
+                    Err(tonic::Status::unknown("unexpected error response type"))?
+                }
+                Err(DryRunError::OperationFailed {
+                    result,
+                    quota_remaining,
+                })
+            }
+            Response::Success(s) => {
+                let response = s.response.require()?;
+                use generated::dry_run_success_response::*;
+                match response {
+                    Response::MintedToAccount(_) => {
+                        let inner = MintedToAccount {};
+                        Ok(WithRemainingQuota {
+                            inner,
+                            quota_remaining,
+                        })
+                    }
+                    _ => Err(tonic::Status::unknown("unexpected success response type"))?,
+                }
+            }
+        }
+    }
+}
+
+#[derive(Clone, Debug)]
+pub struct DryRunTransaction {
+    /// The account originating the transaction.
+    pub sender:        AccountAddress,
+    /// The limit on the energy that may be used by the transaction.
+    pub energy_amount: Energy,
+    /// The transaction payload to execute.
+    pub payload:       EncodedPayload,
+    /// The credential-keys that are treated as signing the transaction.
+    /// If this is the empty vector, it is treated as the single key (0,0)
+    /// signing.
+    pub signatures:    Vec<(CredentialIndex, KeyIndex)>,
+}
+
+impl DryRunTransaction {
+    /// Create a [DryRunTransaction] given the sender address, energy limit and
+    /// payload. The empty list is used for the signatures, meaning that it
+    /// will be treated as though key 0 of credential 0 is the sole
+    /// signature on the transaction. For most purposes, this is sufficient.
+    pub fn new(sender: AccountAddress, energy_amount: Energy, payload: &impl PayloadLike) -> Self {
+        DryRunTransaction {
+            sender,
+            energy_amount,
+            payload: payload.encode(),
+            signatures: vec![],
+        }
+    }
+}
+
+impl From<DryRunTransaction> for generated::DryRunTransaction {
+    fn from(transaction: DryRunTransaction) -> Self {
+        let payload = account_transaction_payload::Payload::RawPayload(transaction.payload.into());
+        generated::DryRunTransaction {
+            sender:        Some(transaction.sender.into()),
+            energy_amount: Some(transaction.energy_amount.into()),
+            payload:       Some(generated::AccountTransactionPayload {
+                payload: Some(payload),
+            }),
+            signatures:    transaction
+                .signatures
+                .into_iter()
+                .map(|(cred, key)| DryRunSignature {
+                    credential: cred.index as u32,
+                    key:        key.0 as u32,
+                })
+                .collect(),
+        }
+    }
+}
+
+#[derive(Clone, Debug)]
+pub struct TransactionExecuted {
+    pub energy_cost:  Energy,
+    pub details:      AccountTransactionDetails,
+    pub return_value: Option<Vec<u8>>,
+}
+
+impl TryFrom<Option<Result<generated::DryRunResponse, tonic::Status>>>
+    for WithRemainingQuota<TransactionExecuted>
+{
+    type Error = DryRunError;
+
+    fn try_from(
+        value: Option<Result<generated::DryRunResponse, tonic::Status>>,
+    ) -> Result<Self, Self::Error> {
+        let response =
+            value.ok_or_else(|| tonic::Status::cancelled("server closed dry run stream"))??;
+        let quota_remaining = response.quota_remaining.require()?.into();
+        use generated::dry_run_response::*;
+        match response.response.require()? {
+            Response::Error(e) => {
+                let result = e.error.require()?.try_into()?;
+                if !matches!(
+                    result,
+                    ErrorResult::NoState()
+                        | ErrorResult::AccountNotFound()
+                        | ErrorResult::BalanceInsufficient {
+                            required_amount:  _,
+                            available_amount: _,
+                        }
+                        | ErrorResult::EnergyInsufficient { energy_required: _ }
+                ) {
+                    Err(tonic::Status::unknown("unexpected error response type"))?
+                }
+                Err(DryRunError::OperationFailed {
+                    result,
+                    quota_remaining,
+                })
+            }
+            Response::Success(s) => {
+                let response = s.response.require()?;
+                use generated::dry_run_success_response::*;
+                match response {
+                    Response::TransactionExecuted(res) => {
+                        let inner = TransactionExecuted {
+                            energy_cost:  res.energy_cost.require()?.into(),
+                            details:      res.details.require()?.try_into()?,
+                            return_value: res.return_value,
+                        };
+                        Ok(WithRemainingQuota {
+                            inner,
+                            quota_remaining,
+                        })
+                    }
+                    _ => Err(tonic::Status::unknown("unexpected success response type"))?,
+                }
+            }
+        }
+    }
+}
+
+type DryRunResult<T> = Result<WithRemainingQuota<T>, DryRunError>;
+
+impl DryRun {
+    pub(crate) async fn new(
+        client: &mut generated::queries_client::QueriesClient<tonic::transport::Channel>,
+    ) -> endpoints::QueryResult<Self> {
+        let (request_send, request_recv) = channel::mpsc::channel(10);
+        let response = client.dry_run(request_recv).await?;
+        let response_stream = response.into_inner();
+        let response_recv = SharedReceiver::new(futures::stream::StreamExt::fuse(response_stream));
+        Ok(DryRun {
+            request_send,
+            response_recv,
+        })
+    }
+
+    pub async fn load_block_state(
+        &mut self,
+        bi: impl IntoBlockIdentifier,
+    ) -> endpoints::QueryResult<impl Future<Output = DryRunResult<BlockStateLoaded>>> {
+        let request = generated::DryRunRequest {
+            request: Some(dry_run_request::Request::LoadBlockState(
+                (&bi.into_block_identifier()).into(),
+            )),
+        };
+        self.request_send
+            .send(request)
+            .await
+            // If an error occurs, it will be because the stream has been closed, which
+            // means that no more requests can be sent.
+            .map_err(|_| tonic::Status::cancelled("dry run already completed"))?;
+        let result_future = self
+            .response_recv
+            .next()
+            .await
+            .receive()
+            .map(|z| z.try_into());
+
+        Ok(result_future)
+    }
+
+    pub async fn get_account_info(
+        &mut self,
+        acc: &AccountIdentifier,
+    ) -> endpoints::QueryResult<impl Future<Output = DryRunResult<AccountInfo>>> {
+        let request = generated::DryRunRequest {
+            request: Some(dry_run_request::Request::StateQuery(DryRunStateQuery {
+                query: Some(generated::dry_run_state_query::Query::GetAccountInfo(
+                    acc.into(),
+                )),
+            })),
+        };
+        self.request_send.send(request)
+        .await
+        // If an error occurs, it will be because the stream has been closed, which
+        // means that no more requests can be sent.
+        .map_err(|_| tonic::Status::cancelled("dry run already completed"))?;
+        let result_future = self
+            .response_recv
+            .next()
+            .await
+            .receive()
+            .map(|z| z.try_into());
+
+        Ok(result_future)
+    }
+
+    pub async fn get_instance_info(
+        &mut self,
+        address: &ContractAddress,
+    ) -> endpoints::QueryResult<impl Future<Output = DryRunResult<InstanceInfo>>> {
+        let request = generated::DryRunRequest {
+            request: Some(dry_run_request::Request::StateQuery(DryRunStateQuery {
+                query: Some(generated::dry_run_state_query::Query::GetInstanceInfo(
+                    address.into(),
+                )),
+            })),
+        };
+        self.request_send.send(request)
+        .await
+        // If an error occurs, it will be because the stream has been closed, which
+        // means that no more requests can be sent.
+        .map_err(|_| tonic::Status::cancelled("dry run already completed"))?;
+        let result_future = self
+            .response_recv
+            .next()
+            .await
+            .receive()
+            .map(|z| z.try_into());
+
+        Ok(result_future)
+    }
+
+    pub async fn invoke_instance(
+        &mut self,
+        context: &ContractContext,
+    ) -> endpoints::QueryResult<impl Future<Output = DryRunResult<InvokeContractSuccess>>> {
+        let request = generated::DryRunRequest {
+            request: Some(dry_run_request::Request::StateQuery(DryRunStateQuery {
+                query: Some(generated::dry_run_state_query::Query::InvokeInstance(
+                    context.into(),
+                )),
+            })),
+        };
+        self.request_send.send(request)
+        .await
+        // If an error occurs, it will be because the stream has been closed, which
+        // means that no more requests can be sent.
+        .map_err(|_| tonic::Status::cancelled("dry run already completed"))?;
+        let result_future = self
+            .response_recv
+            .next()
+            .await
+            .receive()
+            .map(|z| z.try_into());
+
+        Ok(result_future)
+    }
+
+    pub async fn set_timestamp(
+        &mut self,
+        timestamp: Timestamp,
+    ) -> endpoints::QueryResult<impl Future<Output = DryRunResult<TimestampSet>>> {
+        let request = generated::DryRunRequest {
+            request: Some(dry_run_request::Request::StateOperation(
+                DryRunStateOperation {
+                    operation: Some(generated::dry_run_state_operation::Operation::SetTimestamp(
+                        timestamp.into(),
+                    )),
+                },
+            )),
+        };
+        self.request_send.send(request)
+        .await
+        // If an error occurs, it will be because the stream has been closed, which
+        // means that no more requests can be sent.
+        .map_err(|_| tonic::Status::cancelled("dry run already completed"))?;
+        let result_future = self
+            .response_recv
+            .next()
+            .await
+            .receive()
+            .map(|z| z.try_into());
+
+        Ok(result_future)
+    }
+
+    pub async fn mint_to_account(
+        &mut self,
+        account_address: &AccountAddress,
+        mint_amount: Amount,
+    ) -> endpoints::QueryResult<impl Future<Output = DryRunResult<MintedToAccount>>> {
+        let request = generated::DryRunRequest {
+            request: Some(dry_run_request::Request::StateOperation(
+                DryRunStateOperation {
+                    operation: Some(
+                        generated::dry_run_state_operation::Operation::MintToAccount(
+                            DryRunMintToAccount {
+                                account: Some(account_address.into()),
+                                amount:  Some(mint_amount.into()),
+                            },
+                        ),
+                    ),
+                },
+            )),
+        };
+        self.request_send.send(request)
+        .await
+        // If an error occurs, it will be because the stream has been closed, which
+        // means that no more requests can be sent.
+        .map_err(|_| tonic::Status::cancelled("dry run already completed"))?;
+        let result_future = self
+            .response_recv
+            .next()
+            .await
+            .receive()
+            .map(|z| z.try_into());
+
+        Ok(result_future)
+    }
+
+    pub async fn run_transaction(
+        &mut self,
+        transaction: DryRunTransaction,
+    ) -> endpoints::QueryResult<impl Future<Output = DryRunResult<TransactionExecuted>>> {
+        let request = generated::DryRunRequest {
+            request: Some(dry_run_request::Request::StateOperation(
+                DryRunStateOperation {
+                    operation: Some(
+                        generated::dry_run_state_operation::Operation::RunTransaction(
+                            transaction.into(),
+                        ),
+                    ),
+                },
+            )),
+        };
+        self.request_send.send(request)
+        .await
+        // If an error occurs, it will be because the stream has been closed, which
+        // means that no more requests can be sent.
+        .map_err(|_| tonic::Status::cancelled("dry run already completed"))?;
+        let result_future = self
+            .response_recv
+            .next()
+            .await
+            .receive()
+            .map(|z| z.try_into());
+
+        Ok(result_future)
+    }
+}

--- a/src/v2/generated/concordium.v2.rs
+++ b/src/v2/generated/concordium.v2.rs
@@ -1,25 +1,30 @@
 /// A message that contains no information.
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct Empty {}
 /// Hash of a block. This is always 32 bytes long.
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct BlockHash {
     #[prost(bytes = "vec", tag = "1")]
     pub value: ::prost::alloc::vec::Vec<u8>,
 }
 /// A SHA256 hash. This is always 32 bytes long.
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct Sha256Hash {
     #[prost(bytes = "vec", tag = "1")]
     pub value: ::prost::alloc::vec::Vec<u8>,
 }
 /// Hash of a transaction. This is always 32 bytes long.
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct TransactionHash {
     #[prost(bytes = "vec", tag = "1")]
     pub value: ::prost::alloc::vec::Vec<u8>,
 }
 /// Hash of the state after some block. This is always 32 bytes long.
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct StateHash {
     #[prost(bytes = "vec", tag = "1")]
@@ -28,6 +33,7 @@ pub struct StateHash {
 /// The absolute height of a block. This is the number of ancestors of a block
 /// since the genesis block. In particular, the chain genesis block has absolute
 /// height 0.
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct AbsoluteBlockHeight {
     #[prost(uint64, tag = "1")]
@@ -36,12 +42,14 @@ pub struct AbsoluteBlockHeight {
 /// The height of a block relative to the last genesis. This differs from the
 /// absolute block height in that it counts height from the last protocol
 /// update.
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct BlockHeight {
     #[prost(uint64, tag = "1")]
     pub value: u64,
 }
 /// The ID of a baker, which is the index of its account.
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct BakerId {
     #[prost(uint64, tag = "1")]
@@ -49,18 +57,21 @@ pub struct BakerId {
 }
 /// Index of the account in the account table. These are assigned sequentially
 /// in the order of creation of accounts. The first account has index 0.
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct AccountIndex {
     #[prost(uint64, tag = "1")]
     pub value: u64,
 }
 /// A smart contract module reference. This is always 32 bytes long.
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct ModuleRef {
     #[prost(bytes = "vec", tag = "1")]
     pub value: ::prost::alloc::vec::Vec<u8>,
 }
 /// Source bytes of a versioned smart contract module.
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct VersionedModuleSource {
     #[prost(oneof = "versioned_module_source::Module", tags = "1, 2")]
@@ -69,17 +80,20 @@ pub struct VersionedModuleSource {
 /// Nested message and enum types in `VersionedModuleSource`.
 pub mod versioned_module_source {
     /// Source bytes of a smart contract v0 module.
+    #[allow(clippy::derive_partial_eq_without_eq)]
     #[derive(Clone, PartialEq, ::prost::Message)]
     pub struct ModuleSourceV0 {
         #[prost(bytes = "vec", tag = "1")]
         pub value: ::prost::alloc::vec::Vec<u8>,
     }
     /// Source bytes of a smart contract v1 module.
+    #[allow(clippy::derive_partial_eq_without_eq)]
     #[derive(Clone, PartialEq, ::prost::Message)]
     pub struct ModuleSourceV1 {
         #[prost(bytes = "vec", tag = "1")]
         pub value: ::prost::alloc::vec::Vec<u8>,
     }
+    #[allow(clippy::derive_partial_eq_without_eq)]
     #[derive(Clone, PartialEq, ::prost::Oneof)]
     pub enum Module {
         #[prost(message, tag = "1")]
@@ -89,12 +103,14 @@ pub mod versioned_module_source {
     }
 }
 /// Unix timestamp in milliseconds.
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct Timestamp {
     #[prost(uint64, tag = "1")]
     pub value: u64,
 }
 /// An individual release of a locked balance.
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct Release {
     /// Effective time of the release in milliseconds since unix epoch.
@@ -109,6 +125,7 @@ pub struct Release {
 }
 /// A new individual release. Part of a single transfer with schedule
 /// transaction.
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct NewRelease {
     /// Effective time of the release in milliseconds since unix epoch.
@@ -120,6 +137,7 @@ pub struct NewRelease {
 }
 /// State of the account's release schedule. This is the balance of the account
 /// that is owned by the account, but cannot be used until the release point.
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct ReleaseSchedule {
     /// Total amount locked in the release schedule.
@@ -134,11 +152,13 @@ pub struct ReleaseSchedule {
 /// represents the high 32 bits. The chunks are serialized in order and
 /// represented as a byte array.
 /// Always 192 bytes.
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct EncryptedAmount {
     #[prost(bytes = "vec", tag = "1")]
     pub value: ::prost::alloc::vec::Vec<u8>,
 }
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct EncryptedBalance {
     /// Encrypted amount that is a result of this account's actions.
@@ -174,6 +194,7 @@ pub struct EncryptedBalance {
     pub incoming_amounts:  ::prost::alloc::vec::Vec<EncryptedAmount>,
 }
 /// Entity to which the account delegates a portion of its stake.
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct DelegationTarget {
     #[prost(oneof = "delegation_target::Target", tags = "1, 2")]
@@ -181,6 +202,7 @@ pub struct DelegationTarget {
 }
 /// Nested message and enum types in `DelegationTarget`.
 pub mod delegation_target {
+    #[allow(clippy::derive_partial_eq_without_eq)]
     #[derive(Clone, PartialEq, ::prost::Oneof)]
     pub enum Target {
         /// Delegate passively, i.e., to no specific baker.
@@ -192,6 +214,7 @@ pub mod delegation_target {
     }
 }
 /// Baker's public key used to check whether they won the lottery or not.
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct BakerElectionVerifyKey {
     #[prost(bytes = "vec", tag = "1")]
@@ -199,6 +222,7 @@ pub struct BakerElectionVerifyKey {
 }
 /// Baker's public key used to check that they are indeed the ones who
 /// produced the block.
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct BakerSignatureVerifyKey {
     #[prost(bytes = "vec", tag = "1")]
@@ -207,12 +231,14 @@ pub struct BakerSignatureVerifyKey {
 /// Baker's public key used to check signatures on finalization records.
 /// This is only used if the baker has sufficient stake to participate in
 /// finalization.
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct BakerAggregationVerifyKey {
     #[prost(bytes = "vec", tag = "1")]
     pub value: ::prost::alloc::vec::Vec<u8>,
 }
 /// Information about a baker.
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct BakerInfo {
     /// Identity of the baker. This is actually the account index of
@@ -233,6 +259,7 @@ pub struct BakerInfo {
     pub aggregation_key: ::core::option::Option<BakerAggregationVerifyKey>,
 }
 /// Pending change to the stake either of a baker or delegator.
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct StakePendingChange {
     #[prost(oneof = "stake_pending_change::Change", tags = "1, 2")]
@@ -240,6 +267,7 @@ pub struct StakePendingChange {
 }
 /// Nested message and enum types in `StakePendingChange`.
 pub mod stake_pending_change {
+    #[allow(clippy::derive_partial_eq_without_eq)]
     #[derive(Clone, PartialEq, ::prost::Message)]
     pub struct Reduce {
         #[prost(message, optional, tag = "1")]
@@ -248,6 +276,7 @@ pub mod stake_pending_change {
         #[prost(message, optional, tag = "2")]
         pub effective_time: ::core::option::Option<super::Timestamp>,
     }
+    #[allow(clippy::derive_partial_eq_without_eq)]
     #[derive(Clone, PartialEq, ::prost::Oneof)]
     pub enum Change {
         #[prost(message, tag = "1")]
@@ -259,6 +288,7 @@ pub mod stake_pending_change {
     }
 }
 /// A fraction of an amount with a precision of `1/100_000`.
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct AmountFraction {
     /// Must not exceed 100000.
@@ -266,6 +296,7 @@ pub struct AmountFraction {
     pub parts_per_hundred_thousand: u32,
 }
 /// Distribution of the rewards for the particular pool.
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct CommissionRates {
     /// Fraction of finalization rewards charged by the pool owner.
@@ -280,6 +311,7 @@ pub struct CommissionRates {
 }
 /// Additional information about a baking pool.
 /// This information is added with the introduction of delegation.
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct BakerPoolInfo {
     /// Whether the pool allows delegators.
@@ -294,6 +326,7 @@ pub struct BakerPoolInfo {
 }
 /// Information about the account stake, if the account is either a baker or a
 /// delegator.
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct AccountStakingInfo {
     #[prost(oneof = "account_staking_info::StakingInfo", tags = "1, 2")]
@@ -301,6 +334,7 @@ pub struct AccountStakingInfo {
 }
 /// Nested message and enum types in `AccountStakingInfo`.
 pub mod account_staking_info {
+    #[allow(clippy::derive_partial_eq_without_eq)]
     #[derive(Clone, PartialEq, ::prost::Message)]
     pub struct Baker {
         /// Amount staked at present.
@@ -321,6 +355,7 @@ pub mod account_staking_info {
         #[prost(message, optional, tag = "5")]
         pub pool_info:        ::core::option::Option<super::BakerPoolInfo>,
     }
+    #[allow(clippy::derive_partial_eq_without_eq)]
     #[derive(Clone, PartialEq, ::prost::Message)]
     pub struct Delegator {
         /// The amount that the account delegates.
@@ -336,6 +371,7 @@ pub mod account_staking_info {
         #[prost(message, optional, tag = "4")]
         pub pending_change:   ::core::option::Option<super::StakePendingChange>,
     }
+    #[allow(clippy::derive_partial_eq_without_eq)]
     #[derive(Clone, PartialEq, ::prost::Oneof)]
     pub enum StakingInfo {
         /// The account is a baker.
@@ -348,6 +384,7 @@ pub mod account_staking_info {
 }
 /// A sequence number that determines the ordering of transactions from the
 /// account. The minimum sequence number is 1.
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct SequenceNumber {
     /// The sequence number.
@@ -357,6 +394,7 @@ pub struct SequenceNumber {
 /// A sequence number that determines the ordering of update transactions.
 /// Equivalent to `SequenceNumber` for account transactions.
 /// Update sequence numbers are per update type and the minimum value is 1.
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct UpdateSequenceNumber {
     /// The sequence number.
@@ -364,42 +402,49 @@ pub struct UpdateSequenceNumber {
     pub value: u64,
 }
 /// An amount of microCCD.
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct Amount {
     #[prost(uint64, tag = "1")]
     pub value: u64,
 }
 /// Index of a credential on an account.
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct CredentialIndex {
     #[prost(uint32, tag = "1")]
     pub value: u32,
 }
 /// The number of signatures required to sign.
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct SignatureThreshold {
     #[prost(uint32, tag = "1")]
     pub value: u32,
 }
 /// The number of credentials required to sign an account transaction.
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct AccountThreshold {
     #[prost(uint32, tag = "1")]
     pub value: u32,
 }
 /// An account encryption key. Always 96 bytes.
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct EncryptionKey {
     #[prost(bytes = "vec", tag = "1")]
     pub value: ::prost::alloc::vec::Vec<u8>,
 }
 /// An address of an account. Always 32 bytes.
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct AccountAddress {
     #[prost(bytes = "vec", tag = "1")]
     pub value: ::prost::alloc::vec::Vec<u8>,
 }
 /// An address of either a contract or an account.
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct Address {
     #[prost(oneof = "address::Type", tags = "1, 2")]
@@ -407,6 +452,7 @@ pub struct Address {
 }
 /// Nested message and enum types in `Address`.
 pub mod address {
+    #[allow(clippy::derive_partial_eq_without_eq)]
     #[derive(Clone, PartialEq, ::prost::Oneof)]
     pub enum Type {
         #[prost(message, tag = "1")]
@@ -416,6 +462,7 @@ pub mod address {
     }
 }
 /// A public key used to verify transaction signatures from an account.
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct AccountVerifyKey {
     #[prost(oneof = "account_verify_key::Key", tags = "1")]
@@ -423,6 +470,7 @@ pub struct AccountVerifyKey {
 }
 /// Nested message and enum types in `AccountVerifyKey`.
 pub mod account_verify_key {
+    #[allow(clippy::derive_partial_eq_without_eq)]
     #[derive(Clone, PartialEq, ::prost::Oneof)]
     pub enum Key {
         #[prost(bytes, tag = "1")]
@@ -430,6 +478,7 @@ pub mod account_verify_key {
     }
 }
 /// Public keys of a single credential.
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct CredentialPublicKeys {
     #[prost(map = "uint32, message", tag = "1")]
@@ -439,6 +488,7 @@ pub struct CredentialPublicKeys {
 }
 /// A registration ID of a credential, derived from the secret PRF key and a
 /// nonce. This is always 48 bytes long.
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct CredentialRegistrationId {
     #[prost(bytes = "vec", tag = "1")]
@@ -446,12 +496,14 @@ pub struct CredentialRegistrationId {
 }
 /// An index of the identity provider that identifies them uniquely in the
 /// context of a specific chain.
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct IdentityProviderIdentity {
     #[prost(uint32, tag = "1")]
     pub value: u32,
 }
 /// Representation of the pair of a year and month.
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct YearMonth {
     #[prost(uint32, tag = "1")]
@@ -460,6 +512,7 @@ pub struct YearMonth {
     pub month: u32,
 }
 /// Policy on a credential.
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct Policy {
     /// The year and month when the identity object from which the credential is
@@ -477,6 +530,7 @@ pub struct Policy {
     pub attributes: ::std::collections::HashMap<u32, ::prost::alloc::vec::Vec<u8>>,
 }
 /// Values contained in an initial credential.
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct InitialCredentialValues {
     /// Public keys of the credential.
@@ -495,6 +549,7 @@ pub struct InitialCredentialValues {
 }
 /// Data relating to a single anonymity revoker sent by the account holder to
 /// the chain.
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct ChainArData {
     /// Share of the encryption of IdCredPub.
@@ -503,6 +558,7 @@ pub struct ChainArData {
 }
 /// The number of anonymity revokers needed to revoke anonymity of a credential
 /// holder.
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct ArThreshold {
     #[prost(uint32, tag = "1")]
@@ -510,12 +566,14 @@ pub struct ArThreshold {
 }
 /// A single commitment in the G1 group of the BLS curve. This is always 48
 /// bytes in length.
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct Commitment {
     #[prost(bytes = "vec", tag = "1")]
     pub value: ::prost::alloc::vec::Vec<u8>,
 }
 /// Commitments that are part of a normal credential.
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct CredentialCommitments {
     /// Commitment to the PRF key.
@@ -540,6 +598,7 @@ pub struct CredentialCommitments {
     pub id_cred_sec_sharing_coeff: ::prost::alloc::vec::Vec<Commitment>,
 }
 /// Values contained in a normal (non-initial) credential.
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct NormalCredentialValues {
     /// Public keys of the credential.
@@ -568,6 +627,7 @@ pub struct NormalCredentialValues {
     pub commitments:  ::core::option::Option<CredentialCommitments>,
 }
 /// Credential that is part of an account.
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct AccountCredential {
     #[prost(oneof = "account_credential::CredentialValues", tags = "1, 2")]
@@ -575,6 +635,7 @@ pub struct AccountCredential {
 }
 /// Nested message and enum types in `AccountCredential`.
 pub mod account_credential {
+    #[allow(clippy::derive_partial_eq_without_eq)]
     #[derive(Clone, PartialEq, ::prost::Oneof)]
     pub enum CredentialValues {
         #[prost(message, tag = "1")]
@@ -584,6 +645,7 @@ pub mod account_credential {
     }
 }
 /// Information about the account at a particular point in time.
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct AccountInfo {
     /// Next sequence number to be used for transactions signed from this
@@ -630,6 +692,7 @@ pub struct AccountInfo {
     pub address:           ::core::option::Option<AccountAddress>,
 }
 /// Input to queries which take a block as a parameter.
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct BlockHashInput {
     #[prost(oneof = "block_hash_input::BlockHashInput", tags = "1, 2, 3, 4, 5")]
@@ -638,6 +701,7 @@ pub struct BlockHashInput {
 /// Nested message and enum types in `BlockHashInput`.
 pub mod block_hash_input {
     /// Request using a relative block height.
+    #[allow(clippy::derive_partial_eq_without_eq)]
     #[derive(Clone, PartialEq, ::prost::Message)]
     pub struct RelativeHeight {
         /// Genesis index to start from.
@@ -652,6 +716,7 @@ pub mod block_hash_input {
         #[prost(bool, tag = "3")]
         pub restrict:      bool,
     }
+    #[allow(clippy::derive_partial_eq_without_eq)]
     #[derive(Clone, PartialEq, ::prost::Oneof)]
     pub enum BlockHashInput {
         /// Query for the best block.
@@ -674,6 +739,7 @@ pub mod block_hash_input {
     }
 }
 /// Input to queries which take an epoch as a parameter.
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct EpochRequest {
     #[prost(oneof = "epoch_request::EpochRequestInput", tags = "1, 2")]
@@ -682,6 +748,7 @@ pub struct EpochRequest {
 /// Nested message and enum types in `EpochRequest`.
 pub mod epoch_request {
     /// Request an epoch by number at a given genesis index.
+    #[allow(clippy::derive_partial_eq_without_eq)]
     #[derive(Clone, PartialEq, ::prost::Message)]
     pub struct RelativeEpoch {
         /// The genesis index to query at. The query is restricted to this
@@ -693,6 +760,7 @@ pub mod epoch_request {
         #[prost(message, optional, tag = "2")]
         pub epoch:         ::core::option::Option<super::Epoch>,
     }
+    #[allow(clippy::derive_partial_eq_without_eq)]
     #[derive(Clone, PartialEq, ::prost::Oneof)]
     pub enum EpochRequestInput {
         /// Query by genesis index and epoch number.
@@ -704,6 +772,7 @@ pub mod epoch_request {
     }
 }
 /// Input to queries which take an account as a parameter.
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct AccountIdentifierInput {
     #[prost(
@@ -715,6 +784,7 @@ pub struct AccountIdentifierInput {
 }
 /// Nested message and enum types in `AccountIdentifierInput`.
 pub mod account_identifier_input {
+    #[allow(clippy::derive_partial_eq_without_eq)]
     #[derive(Clone, PartialEq, ::prost::Oneof)]
     pub enum AccountIdentifierInput {
         /// Identify the account by the address of the account.
@@ -730,6 +800,7 @@ pub mod account_identifier_input {
     }
 }
 /// Request for account information.
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct AccountInfoRequest {
     /// Block in which to query the account information.
@@ -740,6 +811,7 @@ pub struct AccountInfoRequest {
     pub account_identifier: ::core::option::Option<AccountIdentifierInput>,
 }
 /// Information about a finalized block that is part of the streaming response.
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct FinalizedBlockInfo {
     /// Hash of the block.
@@ -750,6 +822,7 @@ pub struct FinalizedBlockInfo {
     pub height: ::core::option::Option<AbsoluteBlockHeight>,
 }
 /// Request the ancestors for the given block.
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct AncestorsRequest {
     /// The block to get ancestors of.
@@ -760,6 +833,7 @@ pub struct AncestorsRequest {
     pub amount:     u64,
 }
 /// Request for getting the source of a smart contract module.
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct ModuleSourceRequest {
     /// The block to be used for the query.
@@ -770,6 +844,7 @@ pub struct ModuleSourceRequest {
     pub module_ref: ::core::option::Option<ModuleRef>,
 }
 /// Address of a smart contract instance.
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct ContractAddress {
     /// The index of the smart contract.
@@ -781,6 +856,7 @@ pub struct ContractAddress {
     pub subindex: u64,
 }
 /// Request for getting information about a smart contract instance.
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct InstanceInfoRequest {
     /// The block to be used for the query.
@@ -791,6 +867,7 @@ pub struct InstanceInfoRequest {
     pub address:    ::core::option::Option<ContractAddress>,
 }
 /// Information about a smart contract instance.
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct InstanceInfo {
     /// The information depends on the smart contract version used by the
@@ -801,6 +878,7 @@ pub struct InstanceInfo {
 /// Nested message and enum types in `InstanceInfo`.
 pub mod instance_info {
     /// Version 0 smart contract instance information.
+    #[allow(clippy::derive_partial_eq_without_eq)]
     #[derive(Clone, PartialEq, ::prost::Message)]
     pub struct V0 {
         /// The state of the instance.
@@ -823,6 +901,7 @@ pub mod instance_info {
         pub source_module: ::core::option::Option<super::ModuleRef>,
     }
     /// Version 1 smart contract instance information.
+    #[allow(clippy::derive_partial_eq_without_eq)]
     #[derive(Clone, PartialEq, ::prost::Message)]
     pub struct V1 {
         /// The account address which deployed the instance.
@@ -843,6 +922,7 @@ pub mod instance_info {
     }
     /// The information depends on the smart contract version used by the
     /// instance.
+    #[allow(clippy::derive_partial_eq_without_eq)]
     #[derive(Clone, PartialEq, ::prost::Oneof)]
     pub enum Version {
         #[prost(message, tag = "1")]
@@ -852,6 +932,7 @@ pub mod instance_info {
     }
 }
 /// A smart contract instance key-value pair.
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct InstanceStateKvPair {
     #[prost(bytes = "vec", tag = "1")]
@@ -860,6 +941,7 @@ pub struct InstanceStateKvPair {
     pub value: ::prost::alloc::vec::Vec<u8>,
 }
 /// Request for a specific key of a smart contract instance state.
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct InstanceStateLookupRequest {
     /// The block to be used for the query.
@@ -875,6 +957,7 @@ pub struct InstanceStateLookupRequest {
 }
 /// Value at the requested key of a smart contract instance state. For V0
 /// contracts this will always be the entire state of the contract.
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct InstanceStateValueAtKey {
     #[prost(bytes = "vec", tag = "1")]
@@ -883,6 +966,7 @@ pub struct InstanceStateValueAtKey {
 /// The receive name of a smart contract function. Expected format:
 /// `<contract_name>.<func_name>`. It must only consist of atmost 100 ASCII
 /// alphanumeric or punctuation characters, and must contain a '.'.
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct ReceiveName {
     #[prost(string, tag = "1")]
@@ -892,24 +976,28 @@ pub struct ReceiveName {
 /// `init_<contract_name>`. It must only consist of atmost 100 ASCII
 /// alphanumeric or punctuation characters, must not contain a '.' and must
 /// start with 'init_'.
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct InitName {
     #[prost(string, tag = "1")]
     pub value: ::prost::alloc::string::String,
 }
 /// Parameter to a smart contract initialization or invocation.
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct Parameter {
     #[prost(bytes = "vec", tag = "1")]
     pub value: ::prost::alloc::vec::Vec<u8>,
 }
 /// A smart contract v0 state.
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct ContractStateV0 {
     #[prost(bytes = "vec", tag = "1")]
     pub value: ::prost::alloc::vec::Vec<u8>,
 }
 /// Status of a block item known to the node.
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct BlockItemStatus {
     #[prost(oneof = "block_item_status::Status", tags = "1, 2, 3")]
@@ -917,16 +1005,19 @@ pub struct BlockItemStatus {
 }
 /// Nested message and enum types in `BlockItemStatus`.
 pub mod block_item_status {
+    #[allow(clippy::derive_partial_eq_without_eq)]
     #[derive(Clone, PartialEq, ::prost::Message)]
     pub struct Committed {
         #[prost(message, repeated, tag = "1")]
         pub outcomes: ::prost::alloc::vec::Vec<super::BlockItemSummaryInBlock>,
     }
+    #[allow(clippy::derive_partial_eq_without_eq)]
     #[derive(Clone, PartialEq, ::prost::Message)]
     pub struct Finalized {
         #[prost(message, optional, tag = "1")]
         pub outcome: ::core::option::Option<super::BlockItemSummaryInBlock>,
     }
+    #[allow(clippy::derive_partial_eq_without_eq)]
     #[derive(Clone, PartialEq, ::prost::Oneof)]
     pub enum Status {
         /// Block item is received, but not yet in any blocks.
@@ -944,6 +1035,7 @@ pub mod block_item_status {
     }
 }
 /// A block item summary together with a block hash. Used in BlockItemStatus.
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct BlockItemSummaryInBlock {
     /// The block hash.
@@ -955,18 +1047,21 @@ pub struct BlockItemSummaryInBlock {
 }
 /// Energy is used to count exact execution cost.
 /// This cost is then converted to CCD amounts.
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct Energy {
     #[prost(uint64, tag = "1")]
     pub value: u64,
 }
 /// A number representing a slot for baking a block.
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct Slot {
     #[prost(uint64, tag = "1")]
     pub value: u64,
 }
 /// The response for getNextAccountSequenceNumber.
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct NextAccountSequenceNumber {
     /// The best guess for the available account sequence number.
@@ -978,6 +1073,7 @@ pub struct NextAccountSequenceNumber {
     pub all_final:       bool,
 }
 /// A duration of milliseconds.
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct Duration {
     #[prost(uint64, tag = "1")]
@@ -986,6 +1082,7 @@ pub struct Duration {
 /// A reason for why a transaction was rejected. Rejected means included in a
 /// block, but the desired action was not achieved. The only effect of a
 /// rejected transaction is payment.
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct RejectReason {
     #[prost(
@@ -998,6 +1095,7 @@ pub struct RejectReason {
 }
 /// Nested message and enum types in `RejectReason`.
 pub mod reject_reason {
+    #[allow(clippy::derive_partial_eq_without_eq)]
     #[derive(Clone, PartialEq, ::prost::Message)]
     pub struct InvalidInitMethod {
         #[prost(message, optional, tag = "1")]
@@ -1005,6 +1103,7 @@ pub mod reject_reason {
         #[prost(message, optional, tag = "2")]
         pub init_name:  ::core::option::Option<super::InitName>,
     }
+    #[allow(clippy::derive_partial_eq_without_eq)]
     #[derive(Clone, PartialEq, ::prost::Message)]
     pub struct InvalidReceiveMethod {
         #[prost(message, optional, tag = "1")]
@@ -1012,6 +1111,7 @@ pub mod reject_reason {
         #[prost(message, optional, tag = "2")]
         pub receive_name: ::core::option::Option<super::ReceiveName>,
     }
+    #[allow(clippy::derive_partial_eq_without_eq)]
     #[derive(Clone, PartialEq, ::prost::Message)]
     pub struct AmountTooLarge {
         #[prost(message, optional, tag = "1")]
@@ -1019,11 +1119,13 @@ pub mod reject_reason {
         #[prost(message, optional, tag = "2")]
         pub amount:  ::core::option::Option<super::Amount>,
     }
+    #[allow(clippy::derive_partial_eq_without_eq)]
     #[derive(Clone, PartialEq, ::prost::Message)]
     pub struct RejectedInit {
         #[prost(int32, tag = "1")]
         pub reject_reason: i32,
     }
+    #[allow(clippy::derive_partial_eq_without_eq)]
     #[derive(Clone, PartialEq, ::prost::Message)]
     pub struct RejectedReceive {
         #[prost(int32, tag = "1")]
@@ -1035,16 +1137,19 @@ pub mod reject_reason {
         #[prost(message, optional, tag = "4")]
         pub parameter:        ::core::option::Option<super::Parameter>,
     }
+    #[allow(clippy::derive_partial_eq_without_eq)]
     #[derive(Clone, PartialEq, ::prost::Message)]
     pub struct DuplicateCredIds {
         #[prost(message, repeated, tag = "1")]
         pub ids: ::prost::alloc::vec::Vec<super::CredentialRegistrationId>,
     }
+    #[allow(clippy::derive_partial_eq_without_eq)]
     #[derive(Clone, PartialEq, ::prost::Message)]
     pub struct NonExistentCredIds {
         #[prost(message, repeated, tag = "1")]
         pub ids: ::prost::alloc::vec::Vec<super::CredentialRegistrationId>,
     }
+    #[allow(clippy::derive_partial_eq_without_eq)]
     #[derive(Clone, PartialEq, ::prost::Oneof)]
     pub enum Reason {
         /// Raised while validating a Wasm module that is not well formed.
@@ -1236,6 +1341,7 @@ pub mod reject_reason {
     }
 }
 /// Data generated as part of initializing a single contract instance.
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct ContractInitializedEvent {
     /// Contract version.
@@ -1259,6 +1365,7 @@ pub struct ContractInitializedEvent {
     pub events:           ::prost::alloc::vec::Vec<ContractEvent>,
 }
 /// An event generated by a smart contract.
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct ContractEvent {
     #[prost(bytes = "vec", tag = "1")]
@@ -1267,6 +1374,7 @@ pub struct ContractEvent {
 /// Data generated as part of updating a single contract instance.
 /// In general a single Update transaction will
 /// generate one or more of these events, together with possibly some transfers.
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct InstanceUpdatedEvent {
     /// Contract version.
@@ -1295,6 +1403,7 @@ pub struct InstanceUpdatedEvent {
 }
 /// Effects produced by successful smart contract invocations.
 /// A single invocation will produce a sequence of these effects.
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct ContractTraceElement {
     #[prost(oneof = "contract_trace_element::Element", tags = "1, 2, 3, 4, 5")]
@@ -1303,6 +1412,7 @@ pub struct ContractTraceElement {
 /// Nested message and enum types in `ContractTraceElement`.
 pub mod contract_trace_element {
     /// A contract transferred an amount to an account.
+    #[allow(clippy::derive_partial_eq_without_eq)]
     #[derive(Clone, PartialEq, ::prost::Message)]
     pub struct Transferred {
         /// Sender contract.
@@ -1318,6 +1428,7 @@ pub mod contract_trace_element {
     /// A contract was interrupted.
     /// This occurs when a contract invokes another contract or makes a transfer
     /// to an account.
+    #[allow(clippy::derive_partial_eq_without_eq)]
     #[derive(Clone, PartialEq, ::prost::Message)]
     pub struct Interrupted {
         /// The contract interrupted.
@@ -1328,6 +1439,7 @@ pub mod contract_trace_element {
         pub events:  ::prost::alloc::vec::Vec<super::ContractEvent>,
     }
     /// A previously interrupted contract was resumed.
+    #[allow(clippy::derive_partial_eq_without_eq)]
     #[derive(Clone, PartialEq, ::prost::Message)]
     pub struct Resumed {
         /// The contract resumed.
@@ -1339,6 +1451,7 @@ pub mod contract_trace_element {
         pub success: bool,
     }
     /// A previously interrupted contract was resumed.
+    #[allow(clippy::derive_partial_eq_without_eq)]
     #[derive(Clone, PartialEq, ::prost::Message)]
     pub struct Upgraded {
         /// The that was upgraded.
@@ -1351,6 +1464,7 @@ pub mod contract_trace_element {
         #[prost(message, optional, tag = "3")]
         pub to:      ::core::option::Option<super::ModuleRef>,
     }
+    #[allow(clippy::derive_partial_eq_without_eq)]
     #[derive(Clone, PartialEq, ::prost::Oneof)]
     pub enum Element {
         /// A contract instance was updated.
@@ -1373,6 +1487,7 @@ pub mod contract_trace_element {
     }
 }
 /// Result of a successful change of baker keys.
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct BakerKeysEvent {
     /// ID of the baker whose keys were changed.
@@ -1393,11 +1508,13 @@ pub struct BakerKeysEvent {
     pub aggregation_key: ::core::option::Option<BakerAggregationVerifyKey>,
 }
 /// A memo which can be included as part of a transfer. Max size is 256 bytes.
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct Memo {
     #[prost(bytes = "vec", tag = "1")]
     pub value: ::prost::alloc::vec::Vec<u8>,
 }
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct BakerStakeUpdatedData {
     /// Affected baker.
@@ -1413,6 +1530,7 @@ pub struct BakerStakeUpdatedData {
 }
 /// Event generated when one or more encrypted amounts are consumed from the
 /// account.
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct EncryptedAmountRemovedEvent {
     /// The affected account.
@@ -1429,6 +1547,7 @@ pub struct EncryptedAmountRemovedEvent {
     pub up_to_index:  u64,
 }
 /// Event generated when an account receives a new encrypted amount.
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct NewEncryptedAmountEvent {
     /// The account onto which the amount was added.
@@ -1441,6 +1560,7 @@ pub struct NewEncryptedAmountEvent {
     #[prost(message, optional, tag = "3")]
     pub encrypted_amount: ::core::option::Option<EncryptedAmount>,
 }
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct EncryptedSelfAmountAddedEvent {
     /// The affected account.
@@ -1454,12 +1574,14 @@ pub struct EncryptedSelfAmountAddedEvent {
     pub amount:     ::core::option::Option<Amount>,
 }
 /// Data registered on the chain with a register data transaction.
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct RegisteredData {
     #[prost(bytes = "vec", tag = "1")]
     pub value: ::prost::alloc::vec::Vec<u8>,
 }
 /// Events that may result from the ConfigureBaker transaction.
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct BakerEvent {
     #[prost(
@@ -1471,6 +1593,7 @@ pub struct BakerEvent {
 /// Nested message and enum types in `BakerEvent`.
 pub mod baker_event {
     /// A baker was added.
+    #[allow(clippy::derive_partial_eq_without_eq)]
     #[derive(Clone, PartialEq, ::prost::Message)]
     pub struct BakerAdded {
         /// The keys with which the baker registered.
@@ -1486,6 +1609,7 @@ pub mod baker_event {
         pub restake_earnings: bool,
     }
     /// Baker stake increased.
+    #[allow(clippy::derive_partial_eq_without_eq)]
     #[derive(Clone, PartialEq, ::prost::Message)]
     pub struct BakerStakeIncreased {
         /// Baker's id.
@@ -1495,6 +1619,7 @@ pub mod baker_event {
         #[prost(message, optional, tag = "2")]
         pub new_stake: ::core::option::Option<super::Amount>,
     }
+    #[allow(clippy::derive_partial_eq_without_eq)]
     #[derive(Clone, PartialEq, ::prost::Message)]
     pub struct BakerStakeDecreased {
         /// Baker's id.
@@ -1504,6 +1629,7 @@ pub mod baker_event {
         #[prost(message, optional, tag = "2")]
         pub new_stake: ::core::option::Option<super::Amount>,
     }
+    #[allow(clippy::derive_partial_eq_without_eq)]
     #[derive(Clone, PartialEq, ::prost::Message)]
     pub struct BakerRestakeEarningsUpdated {
         /// Baker's id.
@@ -1514,6 +1640,7 @@ pub mod baker_event {
         pub restake_earnings: bool,
     }
     /// Updated open status for a baker pool.
+    #[allow(clippy::derive_partial_eq_without_eq)]
     #[derive(Clone, PartialEq, ::prost::Message)]
     pub struct BakerSetOpenStatus {
         /// Baker's id.
@@ -1524,6 +1651,7 @@ pub mod baker_event {
         pub open_status: i32,
     }
     /// Updated metadata url for a baker pool.
+    #[allow(clippy::derive_partial_eq_without_eq)]
     #[derive(Clone, PartialEq, ::prost::Message)]
     pub struct BakerSetMetadataUrl {
         /// Baker's id.
@@ -1534,6 +1662,7 @@ pub mod baker_event {
         pub url:      ::prost::alloc::string::String,
     }
     /// Updated transaction fee commission for a baker pool.
+    #[allow(clippy::derive_partial_eq_without_eq)]
     #[derive(Clone, PartialEq, ::prost::Message)]
     pub struct BakerSetTransactionFeeCommission {
         /// Baker's id.
@@ -1544,6 +1673,7 @@ pub mod baker_event {
         pub transaction_fee_commission: ::core::option::Option<super::AmountFraction>,
     }
     /// Updated baking reward commission for baker pool
+    #[allow(clippy::derive_partial_eq_without_eq)]
     #[derive(Clone, PartialEq, ::prost::Message)]
     pub struct BakerSetBakingRewardCommission {
         /// Baker's id
@@ -1554,6 +1684,7 @@ pub mod baker_event {
         pub baking_reward_commission: ::core::option::Option<super::AmountFraction>,
     }
     /// Updated finalization reward commission for baker pool
+    #[allow(clippy::derive_partial_eq_without_eq)]
     #[derive(Clone, PartialEq, ::prost::Message)]
     pub struct BakerSetFinalizationRewardCommission {
         /// Baker's id
@@ -1563,6 +1694,7 @@ pub mod baker_event {
         #[prost(message, optional, tag = "2")]
         pub finalization_reward_commission: ::core::option::Option<super::AmountFraction>,
     }
+    #[allow(clippy::derive_partial_eq_without_eq)]
     #[derive(Clone, PartialEq, ::prost::Oneof)]
     pub enum Event {
         /// A baker was added.
@@ -1601,11 +1733,13 @@ pub mod baker_event {
     }
 }
 /// The identifier for a delegator.
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct DelegatorId {
     #[prost(message, optional, tag = "1")]
     pub id: ::core::option::Option<AccountIndex>,
 }
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct DelegationEvent {
     #[prost(oneof = "delegation_event::Event", tags = "1, 2, 3, 4, 5, 6")]
@@ -1613,6 +1747,7 @@ pub struct DelegationEvent {
 }
 /// Nested message and enum types in `DelegationEvent`.
 pub mod delegation_event {
+    #[allow(clippy::derive_partial_eq_without_eq)]
     #[derive(Clone, PartialEq, ::prost::Message)]
     pub struct DelegationStakeIncreased {
         /// Delegator's id
@@ -1622,6 +1757,7 @@ pub mod delegation_event {
         #[prost(message, optional, tag = "2")]
         pub new_stake:    ::core::option::Option<super::Amount>,
     }
+    #[allow(clippy::derive_partial_eq_without_eq)]
     #[derive(Clone, PartialEq, ::prost::Message)]
     pub struct DelegationStakeDecreased {
         /// Delegator's id
@@ -1631,6 +1767,7 @@ pub mod delegation_event {
         #[prost(message, optional, tag = "2")]
         pub new_stake:    ::core::option::Option<super::Amount>,
     }
+    #[allow(clippy::derive_partial_eq_without_eq)]
     #[derive(Clone, PartialEq, ::prost::Message)]
     pub struct DelegationSetRestakeEarnings {
         /// Delegator's id
@@ -1640,6 +1777,7 @@ pub mod delegation_event {
         #[prost(bool, tag = "2")]
         pub restake_earnings: bool,
     }
+    #[allow(clippy::derive_partial_eq_without_eq)]
     #[derive(Clone, PartialEq, ::prost::Message)]
     pub struct DelegationSetDelegationTarget {
         /// Delegator's id
@@ -1649,6 +1787,7 @@ pub mod delegation_event {
         #[prost(message, optional, tag = "2")]
         pub delegation_target: ::core::option::Option<super::DelegationTarget>,
     }
+    #[allow(clippy::derive_partial_eq_without_eq)]
     #[derive(Clone, PartialEq, ::prost::Oneof)]
     pub enum Event {
         /// The delegator's stake increased.
@@ -1673,6 +1812,7 @@ pub mod delegation_event {
 }
 /// Effects of an account transaction. All variants except `None`
 /// correspond to a unique transaction that was successful.
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct AccountTransactionEffects {
     #[prost(
@@ -1685,6 +1825,7 @@ pub struct AccountTransactionEffects {
 pub mod account_transaction_effects {
     /// No effects other than payment from this transaction.
     /// The rejection reason indicates why the transaction failed.
+    #[allow(clippy::derive_partial_eq_without_eq)]
     #[derive(Clone, PartialEq, ::prost::Message)]
     pub struct None {
         /// Transaction type of a failed transaction, if known.
@@ -1697,6 +1838,7 @@ pub mod account_transaction_effects {
     }
     /// A contract update transaction was issued and produced the given trace.
     /// This is the result of Update transaction.
+    #[allow(clippy::derive_partial_eq_without_eq)]
     #[derive(Clone, PartialEq, ::prost::Message)]
     pub struct ContractUpdateIssued {
         #[prost(message, repeated, tag = "1")]
@@ -1704,6 +1846,7 @@ pub mod account_transaction_effects {
     }
     /// A simple account to account transfer occurred. This is the result of a
     /// successful Transfer transaction.
+    #[allow(clippy::derive_partial_eq_without_eq)]
     #[derive(Clone, PartialEq, ::prost::Message)]
     pub struct AccountTransfer {
         /// Amount that was transferred.
@@ -1718,6 +1861,7 @@ pub mod account_transaction_effects {
     }
     /// An account was deregistered as a baker. This is the result of a
     /// successful UpdateBakerStake transaction.
+    #[allow(clippy::derive_partial_eq_without_eq)]
     #[derive(Clone, PartialEq, ::prost::Message)]
     pub struct BakerStakeUpdated {
         /// If the stake was updated (that is, it changed and did not stay the
@@ -1727,6 +1871,7 @@ pub mod account_transaction_effects {
     }
     /// An encrypted amount was transferred. This is the result of a successful
     /// EncryptedAmountTransfer transaction.
+    #[allow(clippy::derive_partial_eq_without_eq)]
     #[derive(Clone, PartialEq, ::prost::Message)]
     pub struct EncryptedAmountTransferred {
         #[prost(message, optional, tag = "1")]
@@ -1739,6 +1884,7 @@ pub mod account_transaction_effects {
     /// An account transferred part of its encrypted balance to its public
     /// balance. This is the result of a successful TransferToPublic
     /// transaction.
+    #[allow(clippy::derive_partial_eq_without_eq)]
     #[derive(Clone, PartialEq, ::prost::Message)]
     pub struct TransferredToPublic {
         #[prost(message, optional, tag = "1")]
@@ -1748,6 +1894,7 @@ pub mod account_transaction_effects {
     }
     /// A transfer with schedule was performed. This is the result of a
     /// successful TransferWithSchedule transaction.
+    #[allow(clippy::derive_partial_eq_without_eq)]
     #[derive(Clone, PartialEq, ::prost::Message)]
     pub struct TransferredWithSchedule {
         /// Receiver account.
@@ -1762,6 +1909,7 @@ pub mod account_transaction_effects {
     }
     /// Account's credentials were updated. This is the result of a
     /// successful UpdateCredentials transaction.
+    #[allow(clippy::derive_partial_eq_without_eq)]
     #[derive(Clone, PartialEq, ::prost::Message)]
     pub struct CredentialsUpdated {
         /// The credential ids that were added.
@@ -1776,6 +1924,7 @@ pub mod account_transaction_effects {
     }
     /// A baker was configured. The details of what happened are contained in
     /// the list of BakerEvents.
+    #[allow(clippy::derive_partial_eq_without_eq)]
     #[derive(Clone, PartialEq, ::prost::Message)]
     pub struct BakerConfigured {
         #[prost(message, repeated, tag = "1")]
@@ -1783,11 +1932,13 @@ pub mod account_transaction_effects {
     }
     /// An account configured delegation. The details of what happened are
     /// contained in the list of DelegationEvents.
+    #[allow(clippy::derive_partial_eq_without_eq)]
     #[derive(Clone, PartialEq, ::prost::Message)]
     pub struct DelegationConfigured {
         #[prost(message, repeated, tag = "1")]
         pub events: ::prost::alloc::vec::Vec<super::DelegationEvent>,
     }
+    #[allow(clippy::derive_partial_eq_without_eq)]
     #[derive(Clone, PartialEq, ::prost::Oneof)]
     pub enum Effect {
         /// No effects other than payment from this transaction.
@@ -1855,6 +2006,7 @@ pub mod account_transaction_effects {
     }
 }
 /// Election difficulty parameter.
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct ElectionDifficulty {
     #[prost(message, optional, tag = "1")]
@@ -1862,6 +2014,7 @@ pub struct ElectionDifficulty {
 }
 /// Parameters that determine timeouts in the consensus protocol used from
 /// protocol version 6.
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct TimeoutParameters {
     /// The base value for triggering a timeout
@@ -1875,6 +2028,7 @@ pub struct TimeoutParameters {
     pub timeout_decrease: ::core::option::Option<Ratio>,
 }
 /// Finalization committee parameters used from protocol version 6
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct FinalizationCommitteeParameters {
     /// The minimum size of a finalization committee before
@@ -1891,6 +2045,7 @@ pub struct FinalizationCommitteeParameters {
     pub finalizer_relative_stake_threshold: ::core::option::Option<AmountFraction>,
 }
 /// Parameters for the consensus protocol used from protocol version 6.
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct ConsensusParametersV1 {
     /// Parameters controlling round timeouts.
@@ -1904,12 +2059,14 @@ pub struct ConsensusParametersV1 {
     pub block_energy_limit: ::core::option::Option<Energy>,
 }
 /// Represents an exchange rate.
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct ExchangeRate {
     #[prost(message, optional, tag = "1")]
     pub value: ::core::option::Option<Ratio>,
 }
 /// Represents a ratio, i.e., 'numerator / denominator'.
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct Ratio {
     /// The numerator.
@@ -1920,6 +2077,7 @@ pub struct Ratio {
     pub denominator: u64,
 }
 /// A public key used for chain updates.
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct UpdatePublicKey {
     #[prost(bytes = "vec", tag = "1")]
@@ -1927,6 +2085,7 @@ pub struct UpdatePublicKey {
 }
 /// The threshold for how many UpdatePublicKeys are need to make a certain chain
 /// update.
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct UpdateKeysThreshold {
     /// Is ensured to be within between 1 and 2^16.
@@ -1934,12 +2093,14 @@ pub struct UpdateKeysThreshold {
     pub value: u32,
 }
 /// Index of a key in an authorizations update payload.
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct UpdateKeysIndex {
     #[prost(uint32, tag = "1")]
     pub value: u32,
 }
 /// Represents root or level 1 keys.
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct HigherLevelKeys {
     /// The keys.
@@ -1953,6 +2114,7 @@ pub struct HigherLevelKeys {
 /// HigherLevelKeys that are allowed to make chain update of a specific type.
 /// The threshold defines the minimum number of allowed keys needed to make the
 /// actual update.
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct AccessStructure {
     /// Unique indexes into the set of keys in AuthorizationV0.
@@ -1965,6 +2127,7 @@ pub struct AccessStructure {
 /// The set of keys authorized for chain updates, together with access
 /// structures determining which keys are authorized for which update types.
 /// This is the payload of an update to authorization.
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct AuthorizationsV0 {
     /// The set of keys authorized for chain updates.
@@ -2012,6 +2175,7 @@ pub struct AuthorizationsV0 {
 /// The set of keys authorized for chain updates, together with access
 /// structures determining which keys are authorized for which update types.
 /// This is the payload of an update to authorization.
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct AuthorizationsV1 {
     #[prost(message, optional, tag = "1")]
@@ -2026,6 +2190,7 @@ pub struct AuthorizationsV1 {
 }
 /// Description either of an anonymity revoker or identity provider.
 /// Metadata that should be visible on the chain.
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct Description {
     /// The name.
@@ -2041,6 +2206,7 @@ pub struct Description {
 }
 /// Information on a single anonymity revoker help by the identity provider.
 /// Typically an identity provider will hold more than one.
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct ArInfo {
     /// Unique identifier of the anonymity revoker.
@@ -2057,12 +2223,14 @@ pub struct ArInfo {
 pub mod ar_info {
     /// Identity of the anonymity revoker on the chain. This defines their
     /// evaluateion point for secret sharing, and thus it cannot be 0.
+    #[allow(clippy::derive_partial_eq_without_eq)]
     #[derive(Clone, PartialEq, ::prost::Message)]
     pub struct ArIdentity {
         #[prost(uint32, tag = "1")]
         pub value: u32,
     }
     /// Public key of an anonymity revoker.
+    #[allow(clippy::derive_partial_eq_without_eq)]
     #[derive(Clone, PartialEq, ::prost::Message)]
     pub struct ArPublicKey {
         #[prost(bytes = "vec", tag = "1")]
@@ -2072,12 +2240,14 @@ pub mod ar_info {
 /// A succinct identifier of an identity provider on the chain.
 /// In credential deployments, and other interactions with the chain this is
 /// used to identify which identity provider is meant.
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct IpIdentity {
     #[prost(uint32, tag = "1")]
     pub value: u32,
 }
 /// Public information about an identity provider.
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct IpInfo {
     /// Unique identifier of the identity provider.
@@ -2096,12 +2266,14 @@ pub struct IpInfo {
 /// Nested message and enum types in `IpInfo`.
 pub mod ip_info {
     /// Pointcheval-Sanders public key of the identity provider.
+    #[allow(clippy::derive_partial_eq_without_eq)]
     #[derive(Clone, PartialEq, ::prost::Message)]
     pub struct IpVerifyKey {
         #[prost(bytes = "vec", tag = "1")]
         pub value: ::prost::alloc::vec::Vec<u8>,
     }
     /// Ed25519 public key of the identity provider.
+    #[allow(clippy::derive_partial_eq_without_eq)]
     #[derive(Clone, PartialEq, ::prost::Message)]
     pub struct IpCdiVerifyKey {
         #[prost(bytes = "vec", tag = "1")]
@@ -2109,12 +2281,14 @@ pub mod ip_info {
     }
 }
 /// A duration in seconds.
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct DurationSeconds {
     #[prost(uint64, tag = "1")]
     pub value: u64,
 }
 /// Inclusive range of amount fractions.
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct InclusiveRangeAmountFraction {
     #[prost(message, optional, tag = "1")]
@@ -2123,6 +2297,7 @@ pub struct InclusiveRangeAmountFraction {
     pub max: ::core::option::Option<AmountFraction>,
 }
 /// Ranges of allowed commission values that pools may choose from.
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct CommissionRanges {
     /// The range of allowed finalization commissions.
@@ -2137,24 +2312,28 @@ pub struct CommissionRanges {
 }
 /// A bound on the relative share of the total staked capital that a baker can
 /// have as its stake. This is required to be greater than 0.
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct CapitalBound {
     #[prost(message, optional, tag = "1")]
     pub value: ::core::option::Option<AmountFraction>,
 }
 /// A leverage factor.
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct LeverageFactor {
     #[prost(message, optional, tag = "1")]
     pub value: ::core::option::Option<Ratio>,
 }
 /// A chain epoch.
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct Epoch {
     #[prost(uint64, tag = "1")]
     pub value: u64,
 }
 /// A round.
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct Round {
     #[prost(uint64, tag = "1")]
@@ -2162,6 +2341,7 @@ pub struct Round {
 }
 /// Length of a reward period in epochs.
 /// Must always be a strictly positive number.
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct RewardPeriodLength {
     #[prost(message, optional, tag = "1")]
@@ -2169,6 +2349,7 @@ pub struct RewardPeriodLength {
 }
 /// A minting rate of CCD.
 /// The value is `mantissa * 10^(-exponent)`.
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct MintRate {
     #[prost(uint32, tag = "1")]
@@ -2177,6 +2358,7 @@ pub struct MintRate {
     #[prost(uint32, tag = "2")]
     pub exponent: u32,
 }
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct CooldownParametersCpv1 {
     /// Number of seconds that pool owners must cooldown
@@ -2189,6 +2371,7 @@ pub struct CooldownParametersCpv1 {
     pub delegator_cooldown:  ::core::option::Option<DurationSeconds>,
 }
 /// Parameters related to staking pools.
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct PoolParametersCpv1 {
     /// Fraction of finalization rewards charged by the passive delegation.
@@ -2218,6 +2401,7 @@ pub struct PoolParametersCpv1 {
 /// The time parameters are introduced as of protocol version 4, and consist of
 /// the reward period length and the mint rate per payday. These are coupled as
 /// a change to either affects the overall rate of minting.
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct TimeParametersCpv1 {
     #[prost(message, optional, tag = "1")]
@@ -2226,6 +2410,7 @@ pub struct TimeParametersCpv1 {
     pub mint_per_payday:      ::core::option::Option<MintRate>,
 }
 /// Mint distribution payload as it looks in protocol version 4 and onward.
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct MintDistributionCpv1 {
     #[prost(message, optional, tag = "1")]
@@ -2233,6 +2418,7 @@ pub struct MintDistributionCpv1 {
     #[prost(message, optional, tag = "2")]
     pub finalization_reward: ::core::option::Option<AmountFraction>,
 }
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct ProtocolUpdate {
     /// A brief message about the update.
@@ -2252,6 +2438,7 @@ pub struct ProtocolUpdate {
 /// finalizers, and the foundation account. It must be the case that
 /// baking_reward + finalization_reward <= 1. The remaining amount is the
 /// platform development charge.
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct MintDistributionCpv0 {
     /// Mint rate per slot.
@@ -2265,6 +2452,7 @@ pub struct MintDistributionCpv0 {
     pub finalization_reward: ::core::option::Option<AmountFraction>,
 }
 /// Parameters determining the distribution of transaction fees.
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct TransactionFeeDistribution {
     /// The fraction allocated to the baker.
@@ -2275,6 +2463,7 @@ pub struct TransactionFeeDistribution {
     pub gas_account: ::core::option::Option<AmountFraction>,
 }
 /// Distribution of gas rewards for chain parameters version 0 and 1.
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct GasRewards {
     /// The fraction paid to the baker.
@@ -2292,6 +2481,7 @@ pub struct GasRewards {
     pub chain_update:       ::core::option::Option<AmountFraction>,
 }
 /// Distribution of gas rewards for chain parameters version 2.
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct GasRewardsCpv2 {
     /// The fraction paid to the baker.
@@ -2307,6 +2497,7 @@ pub struct GasRewardsCpv2 {
 }
 /// Minimum stake needed to become a baker. This only applies to protocol
 /// version 1-3.
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct BakerStakeThreshold {
     /// Minimum threshold required for registering as a baker.
@@ -2316,6 +2507,7 @@ pub struct BakerStakeThreshold {
 /// Root updates are the highest kind of key updates. They can update every
 /// other set of keys, even themselves. They can only be performed by Root level
 /// keys.
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct RootUpdate {
     #[prost(oneof = "root_update::UpdateType", tags = "1, 2, 3, 4")]
@@ -2323,6 +2515,7 @@ pub struct RootUpdate {
 }
 /// Nested message and enum types in `RootUpdate`.
 pub mod root_update {
+    #[allow(clippy::derive_partial_eq_without_eq)]
     #[derive(Clone, PartialEq, ::prost::Oneof)]
     pub enum UpdateType {
         /// The root keys were updated.
@@ -2343,6 +2536,7 @@ pub mod root_update {
 /// Level 1 updates are the intermediate update kind.
 /// They can update themselves or level 2 keys. They can only be performed by
 /// level 1 keys.
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct Level1Update {
     #[prost(oneof = "level1_update::UpdateType", tags = "1, 2, 3")]
@@ -2350,6 +2544,7 @@ pub struct Level1Update {
 }
 /// Nested message and enum types in `Level1Update`.
 pub mod level1_update {
+    #[allow(clippy::derive_partial_eq_without_eq)]
     #[derive(Clone, PartialEq, ::prost::Oneof)]
     pub enum UpdateType {
         /// The level 1 keys were updated.
@@ -2365,6 +2560,7 @@ pub mod level1_update {
     }
 }
 /// The payload of a chain update.
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct UpdatePayload {
     #[prost(
@@ -2375,6 +2571,7 @@ pub struct UpdatePayload {
 }
 /// Nested message and enum types in `UpdatePayload`.
 pub mod update_payload {
+    #[allow(clippy::derive_partial_eq_without_eq)]
     #[derive(Clone, PartialEq, ::prost::Oneof)]
     pub enum Payload {
         /// The protocol version was updated.
@@ -2447,6 +2644,7 @@ pub mod update_payload {
     }
 }
 /// Details about an account transaction.
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct AccountTransactionDetails {
     /// The cost of the transaction. Paid by the sender.
@@ -2462,6 +2660,7 @@ pub struct AccountTransactionDetails {
 /// Details of an account creation. These transactions are free, and we only
 /// ever get a response for them if the account is created, hence no failure
 /// cases.
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct AccountCreationDetails {
     /// Whether this is an initial or normal account.
@@ -2475,6 +2674,7 @@ pub struct AccountCreationDetails {
     pub reg_id:          ::core::option::Option<CredentialRegistrationId>,
 }
 /// Transaction time specified as seconds since unix epoch.
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct TransactionTime {
     #[prost(uint64, tag = "1")]
@@ -2483,6 +2683,7 @@ pub struct TransactionTime {
 /// Details of an update instruction. These are free, and we only ever get a
 /// response for them if the update is successfully enqueued, hence no failure
 /// cases.
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct UpdateDetails {
     /// The time at which the update will be effective.
@@ -2494,6 +2695,7 @@ pub struct UpdateDetails {
 }
 /// Summary of the outcome of a block item in structured form.
 /// The summary determines which transaction type it was.
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct BlockItemSummary {
     /// Index of the transaction in the block where it is included.
@@ -2511,12 +2713,14 @@ pub struct BlockItemSummary {
 }
 /// Nested message and enum types in `BlockItemSummary`.
 pub mod block_item_summary {
+    #[allow(clippy::derive_partial_eq_without_eq)]
     #[derive(Clone, PartialEq, ::prost::Message)]
     pub struct TransactionIndex {
         #[prost(uint64, tag = "1")]
         pub value: u64,
     }
     /// Details that are specific to different transaction types.
+    #[allow(clippy::derive_partial_eq_without_eq)]
     #[derive(Clone, PartialEq, ::prost::Oneof)]
     pub enum Details {
         /// Details about an account transaction.
@@ -2534,12 +2738,14 @@ pub mod block_item_summary {
 /// protocol update instruction might not change the protocol version
 /// specified in the previous field, but it always increments the genesis
 /// index.
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct GenesisIndex {
     #[prost(uint32, tag = "1")]
     pub value: u32,
 }
 /// The response for GetConsensusInfo.
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct ConsensusInfo {
     /// Hash of the current best block.
@@ -2662,6 +2868,7 @@ pub struct ConsensusInfo {
     pub trigger_block_time:          ::core::option::Option<Timestamp>,
 }
 /// Information about an arrived block that is part of the streaming response.
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct ArrivedBlockInfo {
     /// Hash of the block.
@@ -2672,6 +2879,7 @@ pub struct ArrivedBlockInfo {
     pub height: ::core::option::Option<AbsoluteBlockHeight>,
 }
 /// The response for GetCryptographicParameters.
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct CryptographicParameters {
     /// A free-form string used to distinguish between different chains even if
@@ -2692,6 +2900,7 @@ pub struct CryptographicParameters {
     pub on_chain_commitment_key: ::prost::alloc::vec::Vec<u8>,
 }
 /// The response for GetBlockInfo.
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct BlockInfo {
     /// Hash of the block.
@@ -2759,6 +2968,7 @@ pub struct BlockInfo {
     pub epoch:                    ::core::option::Option<Epoch>,
 }
 /// Request for GetPoolInfo.
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct PoolInfoRequest {
     /// Block in which to query the pool information.
@@ -2769,6 +2979,7 @@ pub struct PoolInfoRequest {
     pub baker:      ::core::option::Option<BakerId>,
 }
 /// A pending change to a baker pool.
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct PoolPendingChange {
     #[prost(oneof = "pool_pending_change::Change", tags = "1, 2")]
@@ -2777,6 +2988,7 @@ pub struct PoolPendingChange {
 /// Nested message and enum types in `PoolPendingChange`.
 pub mod pool_pending_change {
     /// A reduction in baker equity capital is pending.
+    #[allow(clippy::derive_partial_eq_without_eq)]
     #[derive(Clone, PartialEq, ::prost::Message)]
     pub struct Reduce {
         /// New baker equity capital.
@@ -2787,12 +2999,14 @@ pub mod pool_pending_change {
         pub effective_time:         ::core::option::Option<super::Timestamp>,
     }
     /// Removal of the pool is pending.
+    #[allow(clippy::derive_partial_eq_without_eq)]
     #[derive(Clone, PartialEq, ::prost::Message)]
     pub struct Remove {
         /// Timestamp when the change takes effect.
         #[prost(message, optional, tag = "1")]
         pub effective_time: ::core::option::Option<super::Timestamp>,
     }
+    #[allow(clippy::derive_partial_eq_without_eq)]
     #[derive(Clone, PartialEq, ::prost::Oneof)]
     pub enum Change {
         #[prost(message, tag = "1")]
@@ -2802,6 +3016,7 @@ pub mod pool_pending_change {
     }
 }
 /// Information about a baker pool in the current reward period.
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct PoolCurrentPaydayInfo {
     /// The number of blocks baked in the current reward period.
@@ -2833,6 +3048,7 @@ pub struct PoolCurrentPaydayInfo {
 }
 /// Type for the response of GetPoolInfo.
 /// Contains information about a given pool at the end of a given block.
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct PoolInfoResponse {
     /// The 'BakerId' of the pool owner.
@@ -2867,6 +3083,7 @@ pub struct PoolInfoResponse {
 }
 /// Type for the response of GetPassiveDelegationInfo.
 /// Contains information about passive delegators at the end of a given block.
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct PassiveDelegationInfo {
     /// The total capital delegated passively.
@@ -2888,6 +3105,7 @@ pub struct PassiveDelegationInfo {
     pub all_pool_total_capital: ::core::option::Option<Amount>,
 }
 /// Request for GetBlocksAtHeight.
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct BlocksAtHeightRequest {
     #[prost(oneof = "blocks_at_height_request::BlocksAtHeight", tags = "1, 2")]
@@ -2896,6 +3114,7 @@ pub struct BlocksAtHeightRequest {
 /// Nested message and enum types in `BlocksAtHeightRequest`.
 pub mod blocks_at_height_request {
     /// Request using an absolute block height.
+    #[allow(clippy::derive_partial_eq_without_eq)]
     #[derive(Clone, PartialEq, ::prost::Message)]
     pub struct Absolute {
         /// The absolute block height.
@@ -2903,6 +3122,7 @@ pub mod blocks_at_height_request {
         pub height: ::core::option::Option<super::AbsoluteBlockHeight>,
     }
     /// Request using a relative block height.
+    #[allow(clippy::derive_partial_eq_without_eq)]
     #[derive(Clone, PartialEq, ::prost::Message)]
     pub struct Relative {
         /// Genesis index to start from.
@@ -2917,6 +3137,7 @@ pub mod blocks_at_height_request {
         #[prost(bool, tag = "3")]
         pub restrict:      bool,
     }
+    #[allow(clippy::derive_partial_eq_without_eq)]
     #[derive(Clone, PartialEq, ::prost::Oneof)]
     pub enum BlocksAtHeight {
         #[prost(message, tag = "1")]
@@ -2926,6 +3147,7 @@ pub mod blocks_at_height_request {
     }
 }
 /// Response for GetBlocksAtHeight.
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct BlocksAtHeightResponse {
     /// Live blocks at the given height.
@@ -2934,6 +3156,7 @@ pub struct BlocksAtHeightResponse {
 }
 /// Type for the response of GetTokenomicsInfo.
 /// Contains information related to tokenomics at the end of a given block.
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct TokenomicsInfo {
     #[prost(oneof = "tokenomics_info::Tokenomics", tags = "1, 2")]
@@ -2942,6 +3165,7 @@ pub struct TokenomicsInfo {
 /// Nested message and enum types in `TokenomicsInfo`.
 pub mod tokenomics_info {
     /// Version 0 tokenomics.
+    #[allow(clippy::derive_partial_eq_without_eq)]
     #[derive(Clone, PartialEq, ::prost::Message)]
     pub struct V0 {
         /// The total CCD in existence.
@@ -2964,6 +3188,7 @@ pub mod tokenomics_info {
         pub protocol_version:            i32,
     }
     /// Version 1 tokenomics.
+    #[allow(clippy::derive_partial_eq_without_eq)]
     #[derive(Clone, PartialEq, ::prost::Message)]
     pub struct V1 {
         /// The total CCD in existence.
@@ -2999,6 +3224,7 @@ pub mod tokenomics_info {
         #[prost(enumeration = "super::ProtocolVersion", tag = "10")]
         pub protocol_version:               i32,
     }
+    #[allow(clippy::derive_partial_eq_without_eq)]
     #[derive(Clone, PartialEq, ::prost::Oneof)]
     pub enum Tokenomics {
         #[prost(message, tag = "1")]
@@ -3008,6 +3234,7 @@ pub mod tokenomics_info {
     }
 }
 /// Request for InvokeInstance.
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct InvokeInstanceRequest {
     /// Block to invoke the contract. The invocation will be at the end of the
@@ -3040,6 +3267,7 @@ pub struct InvokeInstanceRequest {
     pub energy:     ::core::option::Option<Energy>,
 }
 /// Response type for InvokeInstance.
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct InvokeInstanceResponse {
     #[prost(oneof = "invoke_instance_response::Result", tags = "1, 2")]
@@ -3048,6 +3276,7 @@ pub struct InvokeInstanceResponse {
 /// Nested message and enum types in `InvokeInstanceResponse`.
 pub mod invoke_instance_response {
     /// Contract execution failed.
+    #[allow(clippy::derive_partial_eq_without_eq)]
     #[derive(Clone, PartialEq, ::prost::Message)]
     pub struct Failure {
         /// If invoking a V0 contract this is not provided, otherwise it is
@@ -3065,6 +3294,7 @@ pub mod invoke_instance_response {
         pub reason:       ::core::option::Option<super::RejectReason>,
     }
     /// Contract execution succeeded.
+    #[allow(clippy::derive_partial_eq_without_eq)]
     #[derive(Clone, PartialEq, ::prost::Message)]
     pub struct Success {
         /// If invoking a V0 contract this is absent. Otherwise it is the return
@@ -3078,6 +3308,7 @@ pub mod invoke_instance_response {
         #[prost(message, repeated, tag = "3")]
         pub effects:      ::prost::alloc::vec::Vec<super::ContractTraceElement>,
     }
+    #[allow(clippy::derive_partial_eq_without_eq)]
     #[derive(Clone, PartialEq, ::prost::Oneof)]
     pub enum Result {
         #[prost(message, tag = "1")]
@@ -3087,6 +3318,7 @@ pub mod invoke_instance_response {
     }
 }
 /// Request for GetPoolDelegators and GetPoolDelegatorsRewardPeriod.
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct GetPoolDelegatorsRequest {
     /// Block in which to query the delegators.
@@ -3097,6 +3329,7 @@ pub struct GetPoolDelegatorsRequest {
     pub baker:      ::core::option::Option<BakerId>,
 }
 /// Stream item for GetPoolDelegators and GetPassiveDelegators.
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct DelegatorInfo {
     /// The delegator account address.
@@ -3111,6 +3344,7 @@ pub struct DelegatorInfo {
 }
 /// Stream item for GetPoolDelegatorsRewardPeriod and
 /// GetPassiveDelegatorsRewardPeriod.
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct DelegatorRewardPeriodInfo {
     /// The delegator account address.
@@ -3121,6 +3355,7 @@ pub struct DelegatorRewardPeriodInfo {
     pub stake:   ::core::option::Option<Amount>,
 }
 /// Response type for GetBranches.
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct Branch {
     /// The hash of the block.
@@ -3133,6 +3368,7 @@ pub struct Branch {
 /// The leadership election nonce is an unpredictable value updated once an
 /// epoch to make sure that bakers cannot predict too far in the future when
 /// they will win the right to bake blocks.
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct LeadershipElectionNonce {
     #[prost(bytes = "vec", tag = "1")]
@@ -3140,6 +3376,7 @@ pub struct LeadershipElectionNonce {
 }
 /// Response type for GetElectionInfo.
 /// Contains information related to baker election for a perticular block.
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct ElectionInfo {
     /// Baking lottery election difficulty. Present only in protocol versions
@@ -3155,6 +3392,7 @@ pub struct ElectionInfo {
 }
 /// Nested message and enum types in `ElectionInfo`.
 pub mod election_info {
+    #[allow(clippy::derive_partial_eq_without_eq)]
     #[derive(Clone, PartialEq, ::prost::Message)]
     pub struct Baker {
         /// The ID of the baker.
@@ -3172,6 +3410,7 @@ pub mod election_info {
 /// A protocol generated event that is not directly caused by a transaction.
 /// This includes minting new CCD, rewarding different bakers and delegators,
 /// etc.
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct BlockSpecialEvent {
     #[prost(oneof = "block_special_event::Event", tags = "1, 2, 3, 4, 5, 6, 7, 8")]
@@ -3180,6 +3419,7 @@ pub struct BlockSpecialEvent {
 /// Nested message and enum types in `BlockSpecialEvent`.
 pub mod block_special_event {
     /// A representation of a mapping from an account address to an amount.
+    #[allow(clippy::derive_partial_eq_without_eq)]
     #[derive(Clone, PartialEq, ::prost::Message)]
     pub struct AccountAmounts {
         #[prost(message, repeated, tag = "1")]
@@ -3188,6 +3428,7 @@ pub mod block_special_event {
     /// Nested message and enum types in `AccountAmounts`.
     pub mod account_amounts {
         /// The entry for the map.
+        #[allow(clippy::derive_partial_eq_without_eq)]
         #[derive(Clone, PartialEq, ::prost::Message)]
         pub struct Entry {
             /// The key type
@@ -3200,6 +3441,7 @@ pub mod block_special_event {
     }
     /// Payment to each baker of a previous epoch, in proportion to the number
     /// of blocks they contributed.
+    #[allow(clippy::derive_partial_eq_without_eq)]
     #[derive(Clone, PartialEq, ::prost::Message)]
     pub struct BakingRewards {
         /// The amount awarded to each baker.
@@ -3210,6 +3452,7 @@ pub mod block_special_event {
         pub remainder:     ::core::option::Option<super::Amount>,
     }
     /// Minting of new CCD.
+    #[allow(clippy::derive_partial_eq_without_eq)]
     #[derive(Clone, PartialEq, ::prost::Message)]
     pub struct Mint {
         /// The amount allocated to the banking reward account.
@@ -3227,6 +3470,7 @@ pub mod block_special_event {
     }
     /// Payment to each finalizer on inclusion of a finalization record in a
     /// block.
+    #[allow(clippy::derive_partial_eq_without_eq)]
     #[derive(Clone, PartialEq, ::prost::Message)]
     pub struct FinalizationRewards {
         /// The amount awarded to each finalizer.
@@ -3241,6 +3485,7 @@ pub mod block_special_event {
     ///
     /// ```transaction_fees + old_gas_account = new_gas_account + baker_reward +
     /// foundation_charge```
+    #[allow(clippy::derive_partial_eq_without_eq)]
     #[derive(Clone, PartialEq, ::prost::Message)]
     pub struct BlockReward {
         /// The total fees paid for transactions in the block.
@@ -3266,6 +3511,7 @@ pub mod block_special_event {
         pub foundation_account: ::core::option::Option<super::AccountAddress>,
     }
     /// Foundation tax.
+    #[allow(clippy::derive_partial_eq_without_eq)]
     #[derive(Clone, PartialEq, ::prost::Message)]
     pub struct PaydayFoundationReward {
         /// The account that got rewarded.
@@ -3276,6 +3522,7 @@ pub mod block_special_event {
         pub development_charge: ::core::option::Option<super::Amount>,
     }
     /// Reward payment to the given account.
+    #[allow(clippy::derive_partial_eq_without_eq)]
     #[derive(Clone, PartialEq, ::prost::Message)]
     pub struct PaydayAccountReward {
         /// The account that got rewarded.
@@ -3292,6 +3539,7 @@ pub mod block_special_event {
         pub finalization_reward: ::core::option::Option<super::Amount>,
     }
     /// Amounts accrued to accounts for each baked block.
+    #[allow(clippy::derive_partial_eq_without_eq)]
     #[derive(Clone, PartialEq, ::prost::Message)]
     pub struct BlockAccrueReward {
         /// The total fees paid for transactions in the block.
@@ -3317,6 +3565,7 @@ pub mod block_special_event {
         pub baker:             ::core::option::Option<super::BakerId>,
     }
     /// Payment distributed to a pool or passive delegators.
+    #[allow(clippy::derive_partial_eq_without_eq)]
     #[derive(Clone, PartialEq, ::prost::Message)]
     pub struct PaydayPoolReward {
         /// The pool owner (passive delegators when not present).
@@ -3332,6 +3581,7 @@ pub mod block_special_event {
         #[prost(message, optional, tag = "4")]
         pub finalization_reward: ::core::option::Option<super::Amount>,
     }
+    #[allow(clippy::derive_partial_eq_without_eq)]
     #[derive(Clone, PartialEq, ::prost::Oneof)]
     pub enum Event {
         #[prost(message, tag = "1")]
@@ -3353,6 +3603,7 @@ pub mod block_special_event {
     }
 }
 /// A pending update.
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct PendingUpdate {
     /// The effective time of the update.
@@ -3369,6 +3620,7 @@ pub struct PendingUpdate {
 /// Nested message and enum types in `PendingUpdate`.
 pub mod pending_update {
     /// The effect of the update.
+    #[allow(clippy::derive_partial_eq_without_eq)]
     #[derive(Clone, PartialEq, ::prost::Oneof)]
     pub enum Effect {
         /// Updates to the root keys.
@@ -3453,6 +3705,7 @@ pub mod pending_update {
     }
 }
 /// The response for `GetNextUpdateSequenceNumbers`.
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct NextUpdateSequenceNumbers {
     /// Updates to the root keys.
@@ -3521,6 +3774,7 @@ pub struct NextUpdateSequenceNumbers {
 }
 /// A request to send a new block item to the chain.
 /// An IP address
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct IpAddress {
     #[prost(string, tag = "1")]
@@ -3529,6 +3783,7 @@ pub struct IpAddress {
 /// A port
 /// Valid port numbers are expected thus
 /// the value is expected to be in the range (0..u16::MAX).
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct Port {
     #[prost(uint32, tag = "1")]
@@ -3536,6 +3791,7 @@ pub struct Port {
 }
 /// A socket address consisting of
 /// an IP + port.
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct IpSocketAddress {
     #[prost(message, optional, tag = "1")]
@@ -3549,12 +3805,14 @@ pub struct IpSocketAddress {
 /// The underlying value is simply a u64.
 /// Note. There is no authenticity of the peer id and
 /// as such it is only used for logging purposes.
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct PeerId {
     #[prost(string, tag = "1")]
     pub value: ::prost::alloc::string::String,
 }
 /// A banned peer
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct BannedPeer {
     /// The IP address of the banned peer.
@@ -3563,6 +3821,7 @@ pub struct BannedPeer {
 }
 /// The banned peers given by
 /// their IP addresses.
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct BannedPeers {
     #[prost(message, repeated, tag = "1")]
@@ -3571,12 +3830,14 @@ pub struct BannedPeers {
 /// A peer to ban specified by its IP.
 /// Note. This will ban all peers located behind the
 /// specified IP even though they are using different ports.
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct PeerToBan {
     #[prost(message, optional, tag = "1")]
     pub ip_address: ::core::option::Option<IpAddress>,
 }
 /// Request to enable dumping of network packages.
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct DumpRequest {
     /// Which file to dump the packages into.
@@ -3588,6 +3849,7 @@ pub struct DumpRequest {
     pub raw:  bool,
 }
 /// Peers and their associated network related statistics
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct PeersInfo {
     #[prost(message, repeated, tag = "1")]
@@ -3596,6 +3858,7 @@ pub struct PeersInfo {
 /// Nested message and enum types in `PeersInfo`.
 pub mod peers_info {
     /// A peer that the node is connected to.
+    #[allow(clippy::derive_partial_eq_without_eq)]
     #[derive(Clone, PartialEq, ::prost::Message)]
     pub struct Peer {
         /// The identifier of the peer that it
@@ -3615,6 +3878,7 @@ pub mod peers_info {
     /// Nested message and enum types in `Peer`.
     pub mod peer {
         /// Network statistics for the peer
+        #[allow(clippy::derive_partial_eq_without_eq)]
         #[derive(Clone, PartialEq, ::prost::Message)]
         pub struct NetworkStats {
             /// The number of messages sent to the peer.
@@ -3672,8 +3936,20 @@ pub mod peers_info {
                     CatchupStatus::Catchingup => "CATCHINGUP",
                 }
             }
+
+            /// Creates an enum from field names used in the ProtoBuf
+            /// definition.
+            pub fn from_str_name(value: &str) -> ::core::option::Option<Self> {
+                match value {
+                    "UPTODATE" => Some(Self::Uptodate),
+                    "PENDING" => Some(Self::Pending),
+                    "CATCHINGUP" => Some(Self::Catchingup),
+                    _ => None,
+                }
+            }
         }
         /// consensus related information of the peer.
+        #[allow(clippy::derive_partial_eq_without_eq)]
         #[derive(Clone, PartialEq, ::prost::Oneof)]
         pub enum ConsensusInfo {
             /// The peer is of type `Bootstrapper` is not participating in
@@ -3690,6 +3966,7 @@ pub mod peers_info {
 /// Node info response
 /// Contains various information of the
 /// enquired node.
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct NodeInfo {
     /// The version of the node.
@@ -3712,6 +3989,7 @@ pub struct NodeInfo {
 /// Nested message and enum types in `NodeInfo`.
 pub mod node_info {
     /// Network related information of the node.
+    #[allow(clippy::derive_partial_eq_without_eq)]
     #[derive(Clone, PartialEq, ::prost::Message)]
     pub struct NetworkInfo {
         /// The node id.
@@ -3731,6 +4009,7 @@ pub mod node_info {
         pub avg_bps_out:         u64,
     }
     /// Consensus info for a node configured with baker keys.
+    #[allow(clippy::derive_partial_eq_without_eq)]
     #[derive(Clone, PartialEq, ::prost::Message)]
     pub struct BakerConsensusInfo {
         #[prost(message, optional, tag = "1")]
@@ -3744,11 +4023,13 @@ pub mod node_info {
         /// Tagging message type for a node that
         /// is configured with baker keys and active in
         /// the current baking committee
+        #[allow(clippy::derive_partial_eq_without_eq)]
         #[derive(Clone, PartialEq, ::prost::Message)]
         pub struct ActiveBakerCommitteeInfo {}
         /// Tagging message type for a node that
         /// is configured with baker keys and active in
         /// the current finalizer committee (and also baking committee).
+        #[allow(clippy::derive_partial_eq_without_eq)]
         #[derive(Clone, PartialEq, ::prost::Message)]
         pub struct ActiveFinalizerCommitteeInfo {}
         /// The committee information of a node configured with
@@ -3786,8 +4067,20 @@ pub mod node_info {
                     PassiveCommitteeInfo::AddedButWrongKeys => "ADDED_BUT_WRONG_KEYS",
                 }
             }
+
+            /// Creates an enum from field names used in the ProtoBuf
+            /// definition.
+            pub fn from_str_name(value: &str) -> ::core::option::Option<Self> {
+                match value {
+                    "NOT_IN_COMMITTEE" => Some(Self::NotInCommittee),
+                    "ADDED_BUT_NOT_ACTIVE_IN_COMMITTEE" => Some(Self::AddedButNotActiveInCommittee),
+                    "ADDED_BUT_WRONG_KEYS" => Some(Self::AddedButWrongKeys),
+                    _ => None,
+                }
+            }
         }
         /// Status of the baker configured node.
+        #[allow(clippy::derive_partial_eq_without_eq)]
         #[derive(Clone, PartialEq, ::prost::Oneof)]
         pub enum Status {
             /// The node is currently not baking.
@@ -3804,6 +4097,7 @@ pub mod node_info {
         }
     }
     /// The node is a regular node.
+    #[allow(clippy::derive_partial_eq_without_eq)]
     #[derive(Clone, PartialEq, ::prost::Message)]
     pub struct Node {
         #[prost(oneof = "node::ConsensusStatus", tags = "1, 2, 3")]
@@ -3811,6 +4105,7 @@ pub mod node_info {
     }
     /// Nested message and enum types in `Node`.
     pub mod node {
+        #[allow(clippy::derive_partial_eq_without_eq)]
         #[derive(Clone, PartialEq, ::prost::Oneof)]
         pub enum ConsensusStatus {
             /// The node is not running consensus.
@@ -3833,6 +4128,7 @@ pub mod node_info {
         }
     }
     /// Details of the node.
+    #[allow(clippy::derive_partial_eq_without_eq)]
     #[derive(Clone, PartialEq, ::prost::Oneof)]
     pub enum Details {
         /// The node is a bootstrapper and is not running consensus.
@@ -3844,6 +4140,7 @@ pub mod node_info {
         Node(Node),
     }
 }
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct SendBlockItemRequest {
     #[prost(oneof = "send_block_item_request::BlockItem", tags = "1, 2, 3")]
@@ -3851,6 +4148,7 @@ pub struct SendBlockItemRequest {
 }
 /// Nested message and enum types in `SendBlockItemRequest`.
 pub mod send_block_item_request {
+    #[allow(clippy::derive_partial_eq_without_eq)]
     #[derive(Clone, PartialEq, ::prost::Oneof)]
     pub enum BlockItem {
         /// Account transactions are messages which are signed and paid for by
@@ -3872,6 +4170,7 @@ pub mod send_block_item_request {
 /// Credential deployments create new accounts. They are not paid for
 /// directly by the sender. Instead, bakers are rewarded by the protocol for
 /// including them.
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct CredentialDeployment {
     #[prost(message, optional, tag = "1")]
@@ -3883,6 +4182,7 @@ pub struct CredentialDeployment {
 /// Nested message and enum types in `CredentialDeployment`.
 pub mod credential_deployment {
     /// The credential to be added.
+    #[allow(clippy::derive_partial_eq_without_eq)]
     #[derive(Clone, PartialEq, ::prost::Oneof)]
     pub enum Payload {
         /// A raw payload, which is just the encoded payload.
@@ -3893,6 +4193,7 @@ pub mod credential_deployment {
 }
 /// A single signature. Used when sending block items to a node with
 /// `SendBlockItem`.
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct Signature {
     #[prost(bytes = "vec", tag = "1")]
@@ -3900,6 +4201,7 @@ pub struct Signature {
 }
 /// Wrapper for a map from indexes to signatures.
 /// Needed because protobuf doesn't allow nested maps directly.
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct SignatureMap {
     #[prost(map = "uint32, message", tag = "1")]
@@ -3908,11 +4210,13 @@ pub struct SignatureMap {
 /// Wrapper for a map from indexes to signatures.
 /// Needed because protobuf doesn't allow nested maps directly.
 /// The keys in the SignatureMap must not exceed 2^8.
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct AccountSignatureMap {
     #[prost(map = "uint32, message", tag = "1")]
     pub signatures: ::std::collections::HashMap<u32, Signature>,
 }
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct AccountTransactionSignature {
     /// A map from `CredentialIndex` to `SignatureMap`s.
@@ -3924,6 +4228,7 @@ pub struct AccountTransactionSignature {
 /// Header of an account transaction that contains basic data to check whether
 /// the sender and the transaction are valid. The header is shared by all
 /// transaction types.
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct AccountTransactionHeader {
     /// Sender of the transaction.
@@ -3940,6 +4245,7 @@ pub struct AccountTransactionHeader {
     pub expiry:          ::core::option::Option<TransactionTime>,
 }
 /// Data required to initialize a new contract instance.
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct InitContractPayload {
     /// Amount of CCD to send to the instance.
@@ -3957,6 +4263,7 @@ pub struct InitContractPayload {
     pub parameter:  ::core::option::Option<Parameter>,
 }
 /// Data required to update a contract instance.
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct UpdateContractPayload {
     /// Amount of CCD to send to the instance.
@@ -3974,6 +4281,7 @@ pub struct UpdateContractPayload {
     pub parameter:    ::core::option::Option<Parameter>,
 }
 /// Payload of a transfer between two accounts.
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct TransferPayload {
     /// Amount of CCD to send.
@@ -3984,6 +4292,7 @@ pub struct TransferPayload {
     pub receiver: ::core::option::Option<AccountAddress>,
 }
 /// Payload of a transfer between two accounts with a memo.
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct TransferWithMemoPayload {
     /// Amount of CCD to send.
@@ -3997,6 +4306,7 @@ pub struct TransferWithMemoPayload {
     pub memo:     ::core::option::Option<Memo>,
 }
 /// The payload for an account transaction.
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct AccountTransactionPayload {
     #[prost(
@@ -4007,6 +4317,7 @@ pub struct AccountTransactionPayload {
 }
 /// Nested message and enum types in `AccountTransactionPayload`.
 pub mod account_transaction_payload {
+    #[allow(clippy::derive_partial_eq_without_eq)]
     #[derive(Clone, PartialEq, ::prost::Oneof)]
     pub enum Payload {
         /// A pre-serialized payload in the binary serialization format defined
@@ -4030,6 +4341,7 @@ pub mod account_transaction_payload {
 }
 /// An unsigned account transaction. This is used with the
 /// `GetTransactionSignHash` endpoint to obtain the message to sign.
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct PreAccountTransaction {
     #[prost(message, optional, tag = "1")]
@@ -4039,6 +4351,7 @@ pub struct PreAccountTransaction {
 }
 /// Account transactions are messages which are signed and paid for by the
 /// sender account.
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct AccountTransaction {
     #[prost(message, optional, tag = "1")]
@@ -4048,6 +4361,7 @@ pub struct AccountTransaction {
     #[prost(message, optional, tag = "3")]
     pub payload:   ::core::option::Option<AccountTransactionPayload>,
 }
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct UpdateInstructionSignature {
     /// A map from `UpdateKeysIndex` to `Signature`.
@@ -4056,6 +4370,7 @@ pub struct UpdateInstructionSignature {
     #[prost(map = "uint32, message", tag = "1")]
     pub signatures: ::std::collections::HashMap<u32, Signature>,
 }
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct UpdateInstructionHeader {
     #[prost(message, optional, tag = "1")]
@@ -4066,6 +4381,7 @@ pub struct UpdateInstructionHeader {
     pub timeout:         ::core::option::Option<TransactionTime>,
 }
 /// The payload for an UpdateInstruction.
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct UpdateInstructionPayload {
     #[prost(oneof = "update_instruction_payload::Payload", tags = "3")]
@@ -4073,6 +4389,7 @@ pub struct UpdateInstructionPayload {
 }
 /// Nested message and enum types in `UpdateInstructionPayload`.
 pub mod update_instruction_payload {
+    #[allow(clippy::derive_partial_eq_without_eq)]
     #[derive(Clone, PartialEq, ::prost::Oneof)]
     pub enum Payload {
         /// A raw payload encoded according to the format defined by the
@@ -4081,6 +4398,7 @@ pub mod update_instruction_payload {
         RawPayload(::prost::alloc::vec::Vec<u8>),
     }
 }
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct UpdateInstruction {
     /// A map from `UpdateKeysIndex` to `Signature`. Keys must not exceed 2^16.
@@ -4093,6 +4411,7 @@ pub struct UpdateInstruction {
 }
 /// Signature on an account transaction is defined to be the signature on the
 /// hash of the `PreAccountTransaction`.
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct AccountTransactionSignHash {
     #[prost(bytes = "vec", tag = "1")]
@@ -4100,12 +4419,14 @@ pub struct AccountTransactionSignHash {
 }
 /// The number of credential deployments allowed in a block. This in effect
 /// determines the number of accounts that can be created in a block.
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct CredentialsPerBlockLimit {
     #[prost(uint32, tag = "1")]
     pub value: u32,
 }
 /// Updatable chain parameters that apply to protocol versions 1-3.
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct ChainParametersV0 {
     /// Election difficulty for consensus lottery.
@@ -4150,6 +4471,7 @@ pub struct ChainParametersV0 {
     pub level2_keys:                  ::core::option::Option<AuthorizationsV0>,
 }
 /// Updatable chain parameters that apply to protocol versions 4-5.
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct ChainParametersV1 {
     /// Election difficulty for consensus lottery.
@@ -4199,6 +4521,7 @@ pub struct ChainParametersV1 {
     pub level2_keys:                  ::core::option::Option<AuthorizationsV1>,
 }
 /// Updatable chain parameters that apply to protocol versions 6.
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct ChainParametersV2 {
     /// Consensus parameters.
@@ -4251,6 +4574,7 @@ pub struct ChainParametersV2 {
     pub finalization_committee_parameters: ::core::option::Option<FinalizationCommitteeParameters>,
 }
 /// Chain parameters.
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct ChainParameters {
     #[prost(oneof = "chain_parameters::Parameters", tags = "1, 2, 3")]
@@ -4258,6 +4582,7 @@ pub struct ChainParameters {
 }
 /// Nested message and enum types in `ChainParameters`.
 pub mod chain_parameters {
+    #[allow(clippy::derive_partial_eq_without_eq)]
     #[derive(Clone, PartialEq, ::prost::Oneof)]
     pub enum Parameters {
         /// Chain parameters that apply when the block is a protocol version 1-3
@@ -4275,6 +4600,7 @@ pub mod chain_parameters {
     }
 }
 /// Details about a finalizer for the finalization round.
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct FinalizationSummaryParty {
     /// Baker ID. Every finalizer is in particular a baker.
@@ -4291,12 +4617,14 @@ pub struct FinalizationSummaryParty {
 }
 /// Index of the finalization round. This increases on each successfully
 /// completed finalization.
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct FinalizationIndex {
     #[prost(uint64, tag = "1")]
     pub value: u64,
 }
 /// Details about a finalization record included in a block.
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct FinalizationSummary {
     /// Block that was finalized by the finalization record.
@@ -4314,6 +4642,7 @@ pub struct FinalizationSummary {
     pub finalizers: ::prost::alloc::vec::Vec<FinalizationSummaryParty>,
 }
 /// Finalization summary that may or may not be part of the block.
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct BlockFinalizationSummary {
     #[prost(oneof = "block_finalization_summary::Summary", tags = "1, 2")]
@@ -4321,6 +4650,7 @@ pub struct BlockFinalizationSummary {
 }
 /// Nested message and enum types in `BlockFinalizationSummary`.
 pub mod block_finalization_summary {
+    #[allow(clippy::derive_partial_eq_without_eq)]
     #[derive(Clone, PartialEq, ::prost::Oneof)]
     pub enum Summary {
         /// There is no finalization data in the block.
@@ -4331,6 +4661,7 @@ pub mod block_finalization_summary {
         Record(super::FinalizationSummary),
     }
 }
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct BlockItem {
     /// The hash of the block item that identifies it to the chain.
@@ -4341,6 +4672,7 @@ pub struct BlockItem {
 }
 /// Nested message and enum types in `BlockItem`.
 pub mod block_item {
+    #[allow(clippy::derive_partial_eq_without_eq)]
     #[derive(Clone, PartialEq, ::prost::Oneof)]
     pub enum BlockItem {
         /// Account transactions are messages which are signed and paid for by
@@ -4361,6 +4693,7 @@ pub mod block_item {
 }
 /// Information about a particular baker with respect to
 /// the current reward period.
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct BakerRewardPeriodInfo {
     /// The baker id and public keys for the baker.
@@ -4386,6 +4719,7 @@ pub struct BakerRewardPeriodInfo {
     pub is_finalizer:      bool,
 }
 /// The signature of a 'QuorumCertificate'.
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct QuorumSignature {
     /// The bytes representing the raw aggregate signature.
@@ -4397,6 +4731,7 @@ pub struct QuorumSignature {
 /// finalization comittee issues in order to certify a block.
 /// A block must be certified before it will be part of the
 /// authorative part of the chain.
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct QuorumCertificate {
     /// The hash of the block that the quorum certificate refers to.
@@ -4421,6 +4756,7 @@ pub struct QuorumCertificate {
 /// The finalizer round is a map from a 'Round'
 /// to the list of finalizers (identified by their 'BakerId') that signed
 /// off the round.
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct FinalizerRound {
     /// The round that was signed off.
@@ -4432,6 +4768,7 @@ pub struct FinalizerRound {
     pub finalizers: ::prost::alloc::vec::Vec<BakerId>,
 }
 /// The signature of a 'TimeoutCertificate'.
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct TimeoutSignature {
     /// The bytes representing the raw aggregate signature.
@@ -4443,6 +4780,7 @@ pub struct TimeoutSignature {
 /// finalization committee issues when a round times out,
 /// thus making it possible for the protocol to proceed to the
 /// next round.
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct TimeoutCertificate {
     /// The round that timed out.
@@ -4468,6 +4806,7 @@ pub struct TimeoutCertificate {
 /// A proof that establishes that the successor block of
 /// a 'EpochFinalizationEntry' is the immediate successor of
 /// the finalized block.
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct SuccessorProof {
     /// The proof represented as raw bytes.
@@ -4479,6 +4818,7 @@ pub struct SuccessorProof {
 /// makes the protocol able to advance to a new epoch.
 /// I.e. the 'EpochFinalizationEntry' is present if and only if
 /// the block is the first block of a new 'Epoch'.
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct EpochFinalizationEntry {
     /// The quorum certificate for the finalized block.
@@ -4495,6 +4835,7 @@ pub struct EpochFinalizationEntry {
 }
 /// Certificates for a block for protocols supporting
 /// ConcordiumBFT.
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct BlockCertificates {
     /// The quorum certificate. Is present if and only if the block is
@@ -4512,6 +4853,7 @@ pub struct BlockCertificates {
 }
 /// Details of which baker won the lottery in a given round in consensus version
 /// 1.
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct WinningBaker {
     /// The round number.
@@ -4525,7 +4867,10 @@ pub struct WinningBaker {
     #[prost(bool, tag = "3")]
     pub present: bool,
 }
-/// An operation to dry run.
+/// An operation to dry run.  The first operation in a dry-run sequence should
+/// be `load_block_state`: any other operation will be met with `NoState` until
+/// a state is successfully loaded.
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct DryRunRequest {
     #[prost(oneof = "dry_run_request::Request", tags = "1, 2, 3")]
@@ -4533,6 +4878,7 @@ pub struct DryRunRequest {
 }
 /// Nested message and enum types in `DryRunRequest`.
 pub mod dry_run_request {
+    #[allow(clippy::derive_partial_eq_without_eq)]
     #[derive(Clone, PartialEq, ::prost::Oneof)]
     pub enum Request {
         /// Load the state of the specified block to use for subsequent
@@ -4552,6 +4898,7 @@ pub mod dry_run_request {
     }
 }
 /// Run a query as part of a dry run. Queries do not update the block state.
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct DryRunStateQuery {
     #[prost(oneof = "dry_run_state_query::Query", tags = "1, 2, 3")]
@@ -4559,6 +4906,7 @@ pub struct DryRunStateQuery {
 }
 /// Nested message and enum types in `DryRunStateQuery`.
 pub mod dry_run_state_query {
+    #[allow(clippy::derive_partial_eq_without_eq)]
     #[derive(Clone, PartialEq, ::prost::Oneof)]
     pub enum Query {
         /// Look up information on a particular account.
@@ -4582,6 +4930,7 @@ pub mod dry_run_state_query {
     }
 }
 /// Invoke an entrypoint on a smart contract instance.
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct DryRunInvokeInstance {
     /// Invoker of the contract. If this is not supplied then the contract will
@@ -4609,6 +4958,7 @@ pub struct DryRunInvokeInstance {
     pub energy:     ::core::option::Option<Energy>,
 }
 /// An operation that can update the state as part of a dry run.
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct DryRunStateOperation {
     #[prost(oneof = "dry_run_state_operation::Operation", tags = "1, 2, 3")]
@@ -4616,6 +4966,7 @@ pub struct DryRunStateOperation {
 }
 /// Nested message and enum types in `DryRunStateOperation`.
 pub mod dry_run_state_operation {
+    #[allow(clippy::derive_partial_eq_without_eq)]
     #[derive(Clone, PartialEq, ::prost::Oneof)]
     pub enum Operation {
         /// Sets the current block time to the given timestamp for the purposes
@@ -4640,6 +4991,7 @@ pub mod dry_run_state_operation {
 }
 /// Mint a specified amount and credit it to the specified account as part of a
 /// dry run.
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct DryRunMintToAccount {
     /// The account to mint to.
@@ -4650,6 +5002,7 @@ pub struct DryRunMintToAccount {
     pub amount:  ::core::option::Option<Amount>,
 }
 /// Dry run an account transaction
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct DryRunTransaction {
     /// The account to use as the sender of the transaction.
@@ -4665,7 +5018,7 @@ pub struct DryRunTransaction {
     /// transaction. If none is given, then the transaction is treated as
     /// having one signature for credential 0, key 0. Therefore, this is
     /// only required when the transaction is from a multi-signature
-    /// account. There two reason why you might want to specify signatures:
+    /// account. There are two reasons why you might want to specify signatures:
     ///    * The cost of the transaction depends on the number of signatures, so
     ///      if you want to get the correct cost for a multi-signature
     ///      transaction, then specifying the signatures supports this.
@@ -4681,6 +5034,7 @@ pub struct DryRunTransaction {
 /// A dry run signature is a pair of a credential index and key index,
 /// identifying the credential and key that is presumed to have signed the
 /// transaction. No actual cryptographic signature is included.
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct DryRunSignature {
     /// Credential index. Must not exceed 255.
@@ -4691,6 +5045,7 @@ pub struct DryRunSignature {
     pub key:        u32,
 }
 /// A response to a `DryRunRequest`.
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct DryRunResponse {
     /// The remaining available energy quota after the dry run operation.
@@ -4701,6 +5056,7 @@ pub struct DryRunResponse {
 }
 /// Nested message and enum types in `DryRunResponse`.
 pub mod dry_run_response {
+    #[allow(clippy::derive_partial_eq_without_eq)]
     #[derive(Clone, PartialEq, ::prost::Oneof)]
     pub enum Response {
         /// The request produced an error. The request otherwise has no effect
@@ -4712,110 +5068,129 @@ pub mod dry_run_response {
         Success(super::DryRunSuccessResponse),
     }
 }
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct DryRunErrorResponse {
     #[prost(
         oneof = "dry_run_error_response::Error",
-        tags = "1, 2, 3, 4, 5, 6, 8, 10"
+        tags = "1, 2, 3, 4, 5, 6, 8, 9"
     )]
     pub error: ::core::option::Option<dry_run_error_response::Error>,
 }
 /// Nested message and enum types in `DryRunErrorResponse`.
 pub mod dry_run_error_response {
+    /// The current block state is undefined. It should be initialized with
+    /// a 'load_block_state' request before any other operations.
+    #[allow(clippy::derive_partial_eq_without_eq)]
+    #[derive(Clone, PartialEq, ::prost::Message)]
+    pub struct NoState {}
+    /// The requested block was not found, so its state could not be loaded.
+    #[allow(clippy::derive_partial_eq_without_eq)]
+    #[derive(Clone, PartialEq, ::prost::Message)]
+    pub struct BlockNotFound {}
+    /// The specified account was not found.
+    #[allow(clippy::derive_partial_eq_without_eq)]
+    #[derive(Clone, PartialEq, ::prost::Message)]
+    pub struct AccountNotFound {}
+    /// The specified instance was not found.
+    #[allow(clippy::derive_partial_eq_without_eq)]
+    #[derive(Clone, PartialEq, ::prost::Message)]
+    pub struct InstanceNotFound {}
+    /// The amount that was requested to be minted would overflow the total
+    /// supply.
+    #[allow(clippy::derive_partial_eq_without_eq)]
+    #[derive(Clone, PartialEq, ::prost::Message)]
+    pub struct AmountOverLimit {
+        /// The maximum amount that can be minted without overflowing the
+        /// supply.
+        #[prost(message, optional, tag = "1")]
+        pub amount_limit: ::core::option::Option<super::Amount>,
+    }
+    /// The sender account for the transaction has insufficient balance to pay
+    /// the preliminary fees for the transaction to be included in a block.
+    #[allow(clippy::derive_partial_eq_without_eq)]
+    #[derive(Clone, PartialEq, ::prost::Message)]
+    pub struct BalanceInsufficient {
+        /// The minimum balance required to perform the operation.
+        #[prost(message, optional, tag = "1")]
+        pub required_amount:  ::core::option::Option<super::Amount>,
+        /// The currently-available balance on the account to pay for the
+        /// operation.
+        #[prost(message, optional, tag = "2")]
+        pub available_amount: ::core::option::Option<super::Amount>,
+    }
+    /// The energy made available for the transaction is insufficient to cover
+    /// the basic processing required to include a transaction in a block.
+    #[allow(clippy::derive_partial_eq_without_eq)]
+    #[derive(Clone, PartialEq, ::prost::Message)]
+    pub struct EnergyInsufficient {
+        /// The minimum energy required for the transaction to be included in
+        /// the chain. Note that, even if the energy supplied for the
+        /// transaction is enough to prevent a `EnergyInsufficient`, the
+        /// transaction can still be rejected for having insufficient
+        /// energy. In that case, a `TransactionExecuted` response will be
+        /// produced, but indicate the transaction was rejected.
+        #[prost(message, optional, tag = "1")]
+        pub energy_required: ::core::option::Option<super::Energy>,
+    }
+    /// Invoking the smart contract instance failed.
+    #[allow(clippy::derive_partial_eq_without_eq)]
+    #[derive(Clone, PartialEq, ::prost::Message)]
+    pub struct InvokeFailure {
+        /// If invoking a V0 contract this is not provided, otherwise it is
+        /// potentially return value produced by the call unless the call failed
+        /// with out of energy or runtime error. If the V1 contract
+        /// terminated with a logic error then the return value is
+        /// present.
+        #[prost(bytes = "vec", optional, tag = "1")]
+        pub return_value: ::core::option::Option<::prost::alloc::vec::Vec<u8>>,
+        /// Energy used by the execution.
+        #[prost(message, optional, tag = "2")]
+        pub used_energy:  ::core::option::Option<super::Energy>,
+        /// Contract execution failed for the given reason.
+        #[prost(message, optional, tag = "3")]
+        pub reason:       ::core::option::Option<super::RejectReason>,
+    }
+    #[allow(clippy::derive_partial_eq_without_eq)]
     #[derive(Clone, PartialEq, ::prost::Oneof)]
     pub enum Error {
         /// The current block state is undefined. It should be initialized with
         /// a 'load_block_state' request before any other operations.
         #[prost(message, tag = "1")]
-        NoState(super::DryRunErrorNoState),
+        NoState(NoState),
         /// The requested block was not found, so its state could not be loaded.
         /// Response to 'load_block_state'.
         #[prost(message, tag = "2")]
-        BlockNotFound(super::DryRunErrorBlockNotFound),
+        BlockNotFound(BlockNotFound),
         /// The specified account was not found.
         /// Response to 'get_account_info', 'mint_to_account' and
         /// 'run_transaction'.
         #[prost(message, tag = "3")]
-        AccountNotFound(super::DryRunErrorAccountNotFound),
+        AccountNotFound(AccountNotFound),
         /// The specified instance was not found.
         /// Response to 'get_instance_info'.
         #[prost(message, tag = "4")]
-        InstanceNotFound(super::DryRunErrorInstanceNotFound),
+        InstanceNotFound(InstanceNotFound),
         /// The amount to mint would overflow the total CCD supply.
         /// Response to 'mint_to_account'.
         #[prost(message, tag = "5")]
-        AmountOverLimit(super::DryRunErrorAmountOverLimit),
+        AmountOverLimit(AmountOverLimit),
         /// The balance of the sender account is not sufficient to pay for the
         /// operation. Response to 'run_transaction'.
         #[prost(message, tag = "6")]
-        BalanceInsufficient(super::DryRunErrorBalanceInsufficient),
+        BalanceInsufficient(BalanceInsufficient),
         /// The energy supplied for the transaction was not sufficient to
         /// perform the basic checks. Response to 'run_transaction'.
         #[prost(message, tag = "8")]
-        EnergyInsufficient(super::DryRunErrorEnergyInsufficient),
+        EnergyInsufficient(EnergyInsufficient),
         /// The contract invocation failed.
         /// Response to 'invoke_instance'.
-        #[prost(message, tag = "10")]
-        InvokeFailed(super::DryRunErrorInvokeFailure),
+        #[prost(message, tag = "9")]
+        InvokeFailed(InvokeFailure),
     }
 }
-/// The current block state is undefined. It should be initialized with
-/// a 'load_block_state' request before any other operations.
-#[derive(Clone, PartialEq, ::prost::Message)]
-pub struct DryRunErrorNoState {}
-/// The requested block was not found, so its state could not be loaded.
-#[derive(Clone, PartialEq, ::prost::Message)]
-pub struct DryRunErrorBlockNotFound {}
-/// The specified account was not found.
-#[derive(Clone, PartialEq, ::prost::Message)]
-pub struct DryRunErrorAccountNotFound {}
-/// The specified instance was not found.
-#[derive(Clone, PartialEq, ::prost::Message)]
-pub struct DryRunErrorInstanceNotFound {}
-/// The amount that was requested to be minted would overflow the total supply.
-#[derive(Clone, PartialEq, ::prost::Message)]
-pub struct DryRunErrorAmountOverLimit {
-    /// The maximum amount that can be minted without overflowing the supply.
-    #[prost(message, optional, tag = "1")]
-    pub amount_limit: ::core::option::Option<Amount>,
-}
-/// The sender account for the transaction has insufficient balance to pay the
-/// preliminary fees for the transaction to be included in a block.
-#[derive(Clone, PartialEq, ::prost::Message)]
-pub struct DryRunErrorBalanceInsufficient {
-    /// The minimum balance required to perform the operation.
-    #[prost(message, optional, tag = "1")]
-    pub required_amount:  ::core::option::Option<Amount>,
-    /// The currently-available balance on the account to pay for the operation.
-    #[prost(message, optional, tag = "2")]
-    pub available_amount: ::core::option::Option<Amount>,
-}
-/// The energy made available for the transaction is insufficient to cover the
-/// basic processing required to include a transaction in a block.
-#[derive(Clone, PartialEq, ::prost::Message)]
-pub struct DryRunErrorEnergyInsufficient {
-    /// The minimum energy required for the transaction to be included in the
-    /// chain. Note that this does not guarantee that
-    #[prost(message, optional, tag = "1")]
-    pub energy_required: ::core::option::Option<Energy>,
-}
-/// Invoking the smart contract instance failed.
-#[derive(Clone, PartialEq, ::prost::Message)]
-pub struct DryRunErrorInvokeFailure {
-    /// If invoking a V0 contract this is not provided, otherwise it is
-    /// potentially return value produced by the call unless the call failed
-    /// with out of energy or runtime error. If the V1 contract terminated
-    /// with a logic error then the return value is present.
-    #[prost(bytes = "vec", optional, tag = "1")]
-    pub return_value: ::core::option::Option<::prost::alloc::vec::Vec<u8>>,
-    /// Energy used by the execution.
-    #[prost(message, optional, tag = "2")]
-    pub used_energy:  ::core::option::Option<Energy>,
-    /// Contract execution failed for the given reason.
-    #[prost(message, optional, tag = "3")]
-    pub reason:       ::core::option::Option<RejectReason>,
-}
 /// The dry run operation completed successfully.
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct DryRunSuccessResponse {
     #[prost(
@@ -4826,12 +5201,66 @@ pub struct DryRunSuccessResponse {
 }
 /// Nested message and enum types in `DryRunSuccessResponse`.
 pub mod dry_run_success_response {
+    /// The block state at the specified block was successfully loaded.
+    #[allow(clippy::derive_partial_eq_without_eq)]
+    #[derive(Clone, PartialEq, ::prost::Message)]
+    pub struct BlockStateLoaded {
+        /// The timestamp of the block, taken to be the current timestamp.
+        #[prost(message, optional, tag = "1")]
+        pub current_timestamp: ::core::option::Option<super::Timestamp>,
+        /// The hash of the block that was loaded.
+        #[prost(message, optional, tag = "2")]
+        pub block_hash:        ::core::option::Option<super::BlockHash>,
+        /// The protocol version at the specified block. The behavior of
+        /// operations can vary across protocol versions.
+        #[prost(enumeration = "super::ProtocolVersion", tag = "3")]
+        pub protocol_version:  i32,
+    }
+    /// The current apparent timestamp was updated to the specified value.
+    #[allow(clippy::derive_partial_eq_without_eq)]
+    #[derive(Clone, PartialEq, ::prost::Message)]
+    pub struct TimestampSet {}
+    /// The specified amount was minted to the specified account.
+    #[allow(clippy::derive_partial_eq_without_eq)]
+    #[derive(Clone, PartialEq, ::prost::Message)]
+    pub struct MintedToAccount {}
+    /// The transaction was executed.
+    #[allow(clippy::derive_partial_eq_without_eq)]
+    #[derive(Clone, PartialEq, ::prost::Message)]
+    pub struct TransactionExecuted {
+        /// The amount of energy actually expended in executing the transaction.
+        #[prost(message, optional, tag = "1")]
+        pub energy_cost:  ::core::option::Option<super::Energy>,
+        /// The details of the outcome of the transaction.
+        #[prost(message, optional, tag = "2")]
+        pub details:      ::core::option::Option<super::AccountTransactionDetails>,
+        /// If this is an invocation of a V1 contract that produced a return
+        /// value, this is that value. Otherwise it is absent.
+        #[prost(bytes = "vec", optional, tag = "3")]
+        pub return_value: ::core::option::Option<::prost::alloc::vec::Vec<u8>>,
+    }
+    /// The smart contract instance was invoked successfully.
+    #[allow(clippy::derive_partial_eq_without_eq)]
+    #[derive(Clone, PartialEq, ::prost::Message)]
+    pub struct InvokeSuccess {
+        /// If invoking a V0 contract this is absent. Otherwise it is the return
+        /// value produced by the contract.
+        #[prost(bytes = "vec", optional, tag = "1")]
+        pub return_value: ::core::option::Option<::prost::alloc::vec::Vec<u8>>,
+        /// Energy used by the execution.
+        #[prost(message, optional, tag = "2")]
+        pub used_energy:  ::core::option::Option<super::Energy>,
+        /// Effects produced by contract execution.
+        #[prost(message, repeated, tag = "3")]
+        pub effects:      ::prost::alloc::vec::Vec<super::ContractTraceElement>,
+    }
+    #[allow(clippy::derive_partial_eq_without_eq)]
     #[derive(Clone, PartialEq, ::prost::Oneof)]
     pub enum Response {
         /// The state from the specified block was successfully loaded.
         /// Response to 'load_block_state'.
         #[prost(message, tag = "1")]
-        BlockStateLoaded(super::DryRunBlockStateLoaded),
+        BlockStateLoaded(BlockStateLoaded),
         /// Details of the requested account.
         /// Response to 'get_account_info'.
         #[prost(message, tag = "2")]
@@ -4842,69 +5271,21 @@ pub mod dry_run_success_response {
         InstanceInfo(super::InstanceInfo),
         /// The smart contract instance was invoked successfully.
         #[prost(message, tag = "4")]
-        InvokeSucceeded(super::DryRunInvokeSuccess),
+        InvokeSucceeded(InvokeSuccess),
         /// The current timestamp was set successfully.
         /// Response to 'set_timestamp'.
         #[prost(message, tag = "5")]
-        TimestampSet(super::DryRunTimestampSet),
+        TimestampSet(TimestampSet),
         /// The specified amount was minted and credited to the account.
         /// Response to 'mint_to_account'.
         #[prost(message, tag = "6")]
-        MintedToAccount(super::DryRunMintedToAccount),
+        MintedToAccount(MintedToAccount),
         /// The specified transaction was executed. Note that the transaction
         /// could still have been rejected.
         /// Response to 'run_transaction'.
         #[prost(message, tag = "7")]
-        TransactionExecuted(super::DryRunTransactionExecuted),
+        TransactionExecuted(TransactionExecuted),
     }
-}
-/// The block state at the specified block was successfully loaded.
-#[derive(Clone, PartialEq, ::prost::Message)]
-pub struct DryRunBlockStateLoaded {
-    /// The timestamp of the block, taken to be the current timestamp.
-    #[prost(message, optional, tag = "1")]
-    pub current_timestamp: ::core::option::Option<Timestamp>,
-    /// The hash of the block that was loaded.
-    #[prost(message, optional, tag = "2")]
-    pub block_hash:        ::core::option::Option<BlockHash>,
-    /// The protocol version at the specified block. The behavior of operations
-    /// can vary across protocol versions.
-    #[prost(enumeration = "ProtocolVersion", tag = "3")]
-    pub protocol_version:  i32,
-}
-/// The current apparent timestamp was updated to the specified value.
-#[derive(Clone, PartialEq, ::prost::Message)]
-pub struct DryRunTimestampSet {}
-/// The specified amount was minted to the specified account.
-#[derive(Clone, PartialEq, ::prost::Message)]
-pub struct DryRunMintedToAccount {}
-/// The transaction was executed.
-#[derive(Clone, PartialEq, ::prost::Message)]
-pub struct DryRunTransactionExecuted {
-    /// The amount of energy actually expended in executing the transaction.
-    #[prost(message, optional, tag = "1")]
-    pub energy_cost:  ::core::option::Option<Energy>,
-    /// The details of the outcome of the transaction.
-    #[prost(message, optional, tag = "2")]
-    pub details:      ::core::option::Option<AccountTransactionDetails>,
-    /// If this is an invocation of a V1 contract that produced a return value,
-    /// this is that value. Otherwise it is absent.
-    #[prost(bytes = "vec", optional, tag = "3")]
-    pub return_value: ::core::option::Option<::prost::alloc::vec::Vec<u8>>,
-}
-/// The smart contract instance was invoked successfully.
-#[derive(Clone, PartialEq, ::prost::Message)]
-pub struct DryRunInvokeSuccess {
-    /// If invoking a V0 contract this is absent. Otherwise it is the return
-    /// value produced by the contract.
-    #[prost(bytes = "vec", optional, tag = "1")]
-    pub return_value: ::core::option::Option<::prost::alloc::vec::Vec<u8>>,
-    /// Energy used by the execution.
-    #[prost(message, optional, tag = "2")]
-    pub used_energy:  ::core::option::Option<Energy>,
-    /// Effects produced by contract execution.
-    #[prost(message, repeated, tag = "3")]
-    pub effects:      ::prost::alloc::vec::Vec<ContractTraceElement>,
 }
 /// Information about how open the pool is to new delegators.
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, ::prost::Enumeration)]
@@ -4927,6 +5308,16 @@ impl OpenStatus {
             OpenStatus::ClosedForAll => "OPEN_STATUS_CLOSED_FOR_ALL",
         }
     }
+
+    /// Creates an enum from field names used in the ProtoBuf definition.
+    pub fn from_str_name(value: &str) -> ::core::option::Option<Self> {
+        match value {
+            "OPEN_STATUS_OPEN_FOR_ALL" => Some(Self::OpenForAll),
+            "OPEN_STATUS_CLOSED_FOR_NEW" => Some(Self::ClosedForNew),
+            "OPEN_STATUS_CLOSED_FOR_ALL" => Some(Self::ClosedForAll),
+            _ => None,
+        }
+    }
 }
 /// Version of smart contract.
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, ::prost::Enumeration)]
@@ -4945,6 +5336,15 @@ impl ContractVersion {
         match self {
             ContractVersion::V0 => "V0",
             ContractVersion::V1 => "V1",
+        }
+    }
+
+    /// Creates an enum from field names used in the ProtoBuf definition.
+    pub fn from_str_name(value: &str) -> ::core::option::Option<Self> {
+        match value {
+            "V0" => Some(Self::V0),
+            "V1" => Some(Self::V1),
+            _ => None,
         }
     }
 }
@@ -4967,6 +5367,15 @@ impl CredentialType {
         match self {
             CredentialType::Initial => "CREDENTIAL_TYPE_INITIAL",
             CredentialType::Normal => "CREDENTIAL_TYPE_NORMAL",
+        }
+    }
+
+    /// Creates an enum from field names used in the ProtoBuf definition.
+    pub fn from_str_name(value: &str) -> ::core::option::Option<Self> {
+        match value {
+            "CREDENTIAL_TYPE_INITIAL" => Some(Self::Initial),
+            "CREDENTIAL_TYPE_NORMAL" => Some(Self::Normal),
+            _ => None,
         }
     }
 }
@@ -5025,6 +5434,35 @@ impl UpdateType {
             UpdateType::UpdateFinalizationCommitteeParameters => {
                 "UPDATE_FINALIZATION_COMMITTEE_PARAMETERS"
             }
+        }
+    }
+
+    /// Creates an enum from field names used in the ProtoBuf definition.
+    pub fn from_str_name(value: &str) -> ::core::option::Option<Self> {
+        match value {
+            "UPDATE_PROTOCOL" => Some(Self::UpdateProtocol),
+            "UPDATE_ELECTION_DIFFICULTY" => Some(Self::UpdateElectionDifficulty),
+            "UPDATE_EURO_PER_ENERGY" => Some(Self::UpdateEuroPerEnergy),
+            "UPDATE_MICRO_CCD_PER_EURO" => Some(Self::UpdateMicroCcdPerEuro),
+            "UPDATE_FOUNDATION_ACCOUNT" => Some(Self::UpdateFoundationAccount),
+            "UPDATE_MINT_DISTRIBUTION" => Some(Self::UpdateMintDistribution),
+            "UPDATE_TRANSACTION_FEE_DISTRIBUTION" => Some(Self::UpdateTransactionFeeDistribution),
+            "UPDATE_GAS_REWARDS" => Some(Self::UpdateGasRewards),
+            "UPDATE_POOL_PARAMETERS" => Some(Self::UpdatePoolParameters),
+            "ADD_ANONYMITY_REVOKER" => Some(Self::AddAnonymityRevoker),
+            "ADD_IDENTITY_PROVIDER" => Some(Self::AddIdentityProvider),
+            "UPDATE_ROOT_KEYS" => Some(Self::UpdateRootKeys),
+            "UPDATE_LEVEL1_KEYS" => Some(Self::UpdateLevel1Keys),
+            "UPDATE_LEVEL2_KEYS" => Some(Self::UpdateLevel2Keys),
+            "UPDATE_COOLDOWN_PARAMETERS" => Some(Self::UpdateCooldownParameters),
+            "UPDATE_TIME_PARAMETERS" => Some(Self::UpdateTimeParameters),
+            "UPDATE_TIMEOUT_PARAMETERS" => Some(Self::UpdateTimeoutParameters),
+            "UPDATE_MIN_BLOCK_TIME" => Some(Self::UpdateMinBlockTime),
+            "UPDATE_BLOCK_ENERGY_LIMIT" => Some(Self::UpdateBlockEnergyLimit),
+            "UPDATE_FINALIZATION_COMMITTEE_PARAMETERS" => {
+                Some(Self::UpdateFinalizationCommitteeParameters)
+            }
+            _ => None,
         }
     }
 }
@@ -5087,6 +5525,34 @@ impl TransactionType {
             TransactionType::ConfigureDelegation => "CONFIGURE_DELEGATION",
         }
     }
+
+    /// Creates an enum from field names used in the ProtoBuf definition.
+    pub fn from_str_name(value: &str) -> ::core::option::Option<Self> {
+        match value {
+            "DEPLOY_MODULE" => Some(Self::DeployModule),
+            "INIT_CONTRACT" => Some(Self::InitContract),
+            "UPDATE" => Some(Self::Update),
+            "TRANSFER" => Some(Self::Transfer),
+            "ADD_BAKER" => Some(Self::AddBaker),
+            "REMOVE_BAKER" => Some(Self::RemoveBaker),
+            "UPDATE_BAKER_STAKE" => Some(Self::UpdateBakerStake),
+            "UPDATE_BAKER_RESTAKE_EARNINGS" => Some(Self::UpdateBakerRestakeEarnings),
+            "UPDATE_BAKER_KEYS" => Some(Self::UpdateBakerKeys),
+            "UPDATE_CREDENTIAL_KEYS" => Some(Self::UpdateCredentialKeys),
+            "ENCRYPTED_AMOUNT_TRANSFER" => Some(Self::EncryptedAmountTransfer),
+            "TRANSFER_TO_ENCRYPTED" => Some(Self::TransferToEncrypted),
+            "TRANSFER_TO_PUBLIC" => Some(Self::TransferToPublic),
+            "TRANSFER_WITH_SCHEDULE" => Some(Self::TransferWithSchedule),
+            "UPDATE_CREDENTIALS" => Some(Self::UpdateCredentials),
+            "REGISTER_DATA" => Some(Self::RegisterData),
+            "TRANSFER_WITH_MEMO" => Some(Self::TransferWithMemo),
+            "ENCRYPTED_AMOUNT_TRANSFER_WITH_MEMO" => Some(Self::EncryptedAmountTransferWithMemo),
+            "TRANSFER_WITH_SCHEDULE_AND_MEMO" => Some(Self::TransferWithScheduleAndMemo),
+            "CONFIGURE_BAKER" => Some(Self::ConfigureBaker),
+            "CONFIGURE_DELEGATION" => Some(Self::ConfigureDelegation),
+            _ => None,
+        }
+    }
 }
 /// The different versions of the protocol.
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, ::prost::Enumeration)]
@@ -5113,6 +5579,19 @@ impl ProtocolVersion {
             ProtocolVersion::ProtocolVersion4 => "PROTOCOL_VERSION_4",
             ProtocolVersion::ProtocolVersion5 => "PROTOCOL_VERSION_5",
             ProtocolVersion::ProtocolVersion6 => "PROTOCOL_VERSION_6",
+        }
+    }
+
+    /// Creates an enum from field names used in the ProtoBuf definition.
+    pub fn from_str_name(value: &str) -> ::core::option::Option<Self> {
+        match value {
+            "PROTOCOL_VERSION_1" => Some(Self::ProtocolVersion1),
+            "PROTOCOL_VERSION_2" => Some(Self::ProtocolVersion2),
+            "PROTOCOL_VERSION_3" => Some(Self::ProtocolVersion3),
+            "PROTOCOL_VERSION_4" => Some(Self::ProtocolVersion4),
+            "PROTOCOL_VERSION_5" => Some(Self::ProtocolVersion5),
+            "PROTOCOL_VERSION_6" => Some(Self::ProtocolVersion6),
+            _ => None,
         }
     }
 }
@@ -6095,8 +6574,8 @@ pub mod queries_client {
             self.inner.unary(request.into_request(), path, codec).await
         }
 
-        //// Get a list of the peers that the node is connected to
-        //// and assoicated network related information for each peer.
+        /// / Get a list of the peers that the node is connected to
+        /// / and assoicated network related information for each peer.
         pub async fn get_peers_info(
             &mut self,
             request: impl tonic::IntoRequest<super::Empty>,
@@ -6302,7 +6781,7 @@ pub mod queries_client {
         ///  * `NOT_FOUND` if the query specifies an unknown block.
         ///  * `UNAVAILABLE` if the query is for an epoch that is not finalized
         ///    in the current genesis
-        ////    index, or is for a future genesis index.
+        /// /    index, or is for a future genesis index.
         ///  * `INVALID_ARGUMENT` if the query is for an epoch that is not
         ///    finalized for a past genesis index.
         ///  * `INVALID_ARGUMENT` if the query is for a genesis index at
@@ -6385,7 +6864,7 @@ pub mod queries_client {
         ///  * `RESOURCE_EXHAUSTED` if the energy quota is exceeded.
         ///  * `DEADLINE_EXCEEDED` if the session does not complete before the
         ///    server-imposed timeout.
-        ///  * `UNAVAILABLE` if the server is not currently accepting new
+        ///  * `RESOURCE_EXHAUSTED` if the server is not currently accepting new
         ///    `DryRun` sessions. (The server may impose a limit on the number
         ///    of concurrent sessions.)
         ///  * `INTERNAL` if an interal server error occurs. This should not

--- a/src/v2/generated/concordium.v2.rs
+++ b/src/v2/generated/concordium.v2.rs
@@ -1,30 +1,25 @@
 /// A message that contains no information.
-#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct Empty {}
 /// Hash of a block. This is always 32 bytes long.
-#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct BlockHash {
     #[prost(bytes = "vec", tag = "1")]
     pub value: ::prost::alloc::vec::Vec<u8>,
 }
 /// A SHA256 hash. This is always 32 bytes long.
-#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct Sha256Hash {
     #[prost(bytes = "vec", tag = "1")]
     pub value: ::prost::alloc::vec::Vec<u8>,
 }
 /// Hash of a transaction. This is always 32 bytes long.
-#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct TransactionHash {
     #[prost(bytes = "vec", tag = "1")]
     pub value: ::prost::alloc::vec::Vec<u8>,
 }
 /// Hash of the state after some block. This is always 32 bytes long.
-#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct StateHash {
     #[prost(bytes = "vec", tag = "1")]
@@ -33,7 +28,6 @@ pub struct StateHash {
 /// The absolute height of a block. This is the number of ancestors of a block
 /// since the genesis block. In particular, the chain genesis block has absolute
 /// height 0.
-#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct AbsoluteBlockHeight {
     #[prost(uint64, tag = "1")]
@@ -42,14 +36,12 @@ pub struct AbsoluteBlockHeight {
 /// The height of a block relative to the last genesis. This differs from the
 /// absolute block height in that it counts height from the last protocol
 /// update.
-#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct BlockHeight {
     #[prost(uint64, tag = "1")]
     pub value: u64,
 }
 /// The ID of a baker, which is the index of its account.
-#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct BakerId {
     #[prost(uint64, tag = "1")]
@@ -57,21 +49,18 @@ pub struct BakerId {
 }
 /// Index of the account in the account table. These are assigned sequentially
 /// in the order of creation of accounts. The first account has index 0.
-#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct AccountIndex {
     #[prost(uint64, tag = "1")]
     pub value: u64,
 }
 /// A smart contract module reference. This is always 32 bytes long.
-#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct ModuleRef {
     #[prost(bytes = "vec", tag = "1")]
     pub value: ::prost::alloc::vec::Vec<u8>,
 }
 /// Source bytes of a versioned smart contract module.
-#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct VersionedModuleSource {
     #[prost(oneof = "versioned_module_source::Module", tags = "1, 2")]
@@ -80,20 +69,17 @@ pub struct VersionedModuleSource {
 /// Nested message and enum types in `VersionedModuleSource`.
 pub mod versioned_module_source {
     /// Source bytes of a smart contract v0 module.
-    #[allow(clippy::derive_partial_eq_without_eq)]
     #[derive(Clone, PartialEq, ::prost::Message)]
     pub struct ModuleSourceV0 {
         #[prost(bytes = "vec", tag = "1")]
         pub value: ::prost::alloc::vec::Vec<u8>,
     }
     /// Source bytes of a smart contract v1 module.
-    #[allow(clippy::derive_partial_eq_without_eq)]
     #[derive(Clone, PartialEq, ::prost::Message)]
     pub struct ModuleSourceV1 {
         #[prost(bytes = "vec", tag = "1")]
         pub value: ::prost::alloc::vec::Vec<u8>,
     }
-    #[allow(clippy::derive_partial_eq_without_eq)]
     #[derive(Clone, PartialEq, ::prost::Oneof)]
     pub enum Module {
         #[prost(message, tag = "1")]
@@ -103,14 +89,12 @@ pub mod versioned_module_source {
     }
 }
 /// Unix timestamp in milliseconds.
-#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct Timestamp {
     #[prost(uint64, tag = "1")]
     pub value: u64,
 }
 /// An individual release of a locked balance.
-#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct Release {
     /// Effective time of the release in milliseconds since unix epoch.
@@ -125,7 +109,6 @@ pub struct Release {
 }
 /// A new individual release. Part of a single transfer with schedule
 /// transaction.
-#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct NewRelease {
     /// Effective time of the release in milliseconds since unix epoch.
@@ -137,7 +120,6 @@ pub struct NewRelease {
 }
 /// State of the account's release schedule. This is the balance of the account
 /// that is owned by the account, but cannot be used until the release point.
-#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct ReleaseSchedule {
     /// Total amount locked in the release schedule.
@@ -152,13 +134,11 @@ pub struct ReleaseSchedule {
 /// represents the high 32 bits. The chunks are serialized in order and
 /// represented as a byte array.
 /// Always 192 bytes.
-#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct EncryptedAmount {
     #[prost(bytes = "vec", tag = "1")]
     pub value: ::prost::alloc::vec::Vec<u8>,
 }
-#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct EncryptedBalance {
     /// Encrypted amount that is a result of this account's actions.
@@ -194,7 +174,6 @@ pub struct EncryptedBalance {
     pub incoming_amounts:  ::prost::alloc::vec::Vec<EncryptedAmount>,
 }
 /// Entity to which the account delegates a portion of its stake.
-#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct DelegationTarget {
     #[prost(oneof = "delegation_target::Target", tags = "1, 2")]
@@ -202,7 +181,6 @@ pub struct DelegationTarget {
 }
 /// Nested message and enum types in `DelegationTarget`.
 pub mod delegation_target {
-    #[allow(clippy::derive_partial_eq_without_eq)]
     #[derive(Clone, PartialEq, ::prost::Oneof)]
     pub enum Target {
         /// Delegate passively, i.e., to no specific baker.
@@ -214,7 +192,6 @@ pub mod delegation_target {
     }
 }
 /// Baker's public key used to check whether they won the lottery or not.
-#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct BakerElectionVerifyKey {
     #[prost(bytes = "vec", tag = "1")]
@@ -222,7 +199,6 @@ pub struct BakerElectionVerifyKey {
 }
 /// Baker's public key used to check that they are indeed the ones who
 /// produced the block.
-#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct BakerSignatureVerifyKey {
     #[prost(bytes = "vec", tag = "1")]
@@ -231,14 +207,12 @@ pub struct BakerSignatureVerifyKey {
 /// Baker's public key used to check signatures on finalization records.
 /// This is only used if the baker has sufficient stake to participate in
 /// finalization.
-#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct BakerAggregationVerifyKey {
     #[prost(bytes = "vec", tag = "1")]
     pub value: ::prost::alloc::vec::Vec<u8>,
 }
 /// Information about a baker.
-#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct BakerInfo {
     /// Identity of the baker. This is actually the account index of
@@ -259,7 +233,6 @@ pub struct BakerInfo {
     pub aggregation_key: ::core::option::Option<BakerAggregationVerifyKey>,
 }
 /// Pending change to the stake either of a baker or delegator.
-#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct StakePendingChange {
     #[prost(oneof = "stake_pending_change::Change", tags = "1, 2")]
@@ -267,7 +240,6 @@ pub struct StakePendingChange {
 }
 /// Nested message and enum types in `StakePendingChange`.
 pub mod stake_pending_change {
-    #[allow(clippy::derive_partial_eq_without_eq)]
     #[derive(Clone, PartialEq, ::prost::Message)]
     pub struct Reduce {
         #[prost(message, optional, tag = "1")]
@@ -276,7 +248,6 @@ pub mod stake_pending_change {
         #[prost(message, optional, tag = "2")]
         pub effective_time: ::core::option::Option<super::Timestamp>,
     }
-    #[allow(clippy::derive_partial_eq_without_eq)]
     #[derive(Clone, PartialEq, ::prost::Oneof)]
     pub enum Change {
         #[prost(message, tag = "1")]
@@ -288,7 +259,6 @@ pub mod stake_pending_change {
     }
 }
 /// A fraction of an amount with a precision of `1/100_000`.
-#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct AmountFraction {
     /// Must not exceed 100000.
@@ -296,7 +266,6 @@ pub struct AmountFraction {
     pub parts_per_hundred_thousand: u32,
 }
 /// Distribution of the rewards for the particular pool.
-#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct CommissionRates {
     /// Fraction of finalization rewards charged by the pool owner.
@@ -311,7 +280,6 @@ pub struct CommissionRates {
 }
 /// Additional information about a baking pool.
 /// This information is added with the introduction of delegation.
-#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct BakerPoolInfo {
     /// Whether the pool allows delegators.
@@ -326,7 +294,6 @@ pub struct BakerPoolInfo {
 }
 /// Information about the account stake, if the account is either a baker or a
 /// delegator.
-#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct AccountStakingInfo {
     #[prost(oneof = "account_staking_info::StakingInfo", tags = "1, 2")]
@@ -334,7 +301,6 @@ pub struct AccountStakingInfo {
 }
 /// Nested message and enum types in `AccountStakingInfo`.
 pub mod account_staking_info {
-    #[allow(clippy::derive_partial_eq_without_eq)]
     #[derive(Clone, PartialEq, ::prost::Message)]
     pub struct Baker {
         /// Amount staked at present.
@@ -355,7 +321,6 @@ pub mod account_staking_info {
         #[prost(message, optional, tag = "5")]
         pub pool_info:        ::core::option::Option<super::BakerPoolInfo>,
     }
-    #[allow(clippy::derive_partial_eq_without_eq)]
     #[derive(Clone, PartialEq, ::prost::Message)]
     pub struct Delegator {
         /// The amount that the account delegates.
@@ -371,7 +336,6 @@ pub mod account_staking_info {
         #[prost(message, optional, tag = "4")]
         pub pending_change:   ::core::option::Option<super::StakePendingChange>,
     }
-    #[allow(clippy::derive_partial_eq_without_eq)]
     #[derive(Clone, PartialEq, ::prost::Oneof)]
     pub enum StakingInfo {
         /// The account is a baker.
@@ -384,7 +348,6 @@ pub mod account_staking_info {
 }
 /// A sequence number that determines the ordering of transactions from the
 /// account. The minimum sequence number is 1.
-#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct SequenceNumber {
     /// The sequence number.
@@ -394,7 +357,6 @@ pub struct SequenceNumber {
 /// A sequence number that determines the ordering of update transactions.
 /// Equivalent to `SequenceNumber` for account transactions.
 /// Update sequence numbers are per update type and the minimum value is 1.
-#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct UpdateSequenceNumber {
     /// The sequence number.
@@ -402,49 +364,42 @@ pub struct UpdateSequenceNumber {
     pub value: u64,
 }
 /// An amount of microCCD.
-#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct Amount {
     #[prost(uint64, tag = "1")]
     pub value: u64,
 }
 /// Index of a credential on an account.
-#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct CredentialIndex {
     #[prost(uint32, tag = "1")]
     pub value: u32,
 }
 /// The number of signatures required to sign.
-#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct SignatureThreshold {
     #[prost(uint32, tag = "1")]
     pub value: u32,
 }
 /// The number of credentials required to sign an account transaction.
-#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct AccountThreshold {
     #[prost(uint32, tag = "1")]
     pub value: u32,
 }
 /// An account encryption key. Always 96 bytes.
-#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct EncryptionKey {
     #[prost(bytes = "vec", tag = "1")]
     pub value: ::prost::alloc::vec::Vec<u8>,
 }
 /// An address of an account. Always 32 bytes.
-#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct AccountAddress {
     #[prost(bytes = "vec", tag = "1")]
     pub value: ::prost::alloc::vec::Vec<u8>,
 }
 /// An address of either a contract or an account.
-#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct Address {
     #[prost(oneof = "address::Type", tags = "1, 2")]
@@ -452,7 +407,6 @@ pub struct Address {
 }
 /// Nested message and enum types in `Address`.
 pub mod address {
-    #[allow(clippy::derive_partial_eq_without_eq)]
     #[derive(Clone, PartialEq, ::prost::Oneof)]
     pub enum Type {
         #[prost(message, tag = "1")]
@@ -462,7 +416,6 @@ pub mod address {
     }
 }
 /// A public key used to verify transaction signatures from an account.
-#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct AccountVerifyKey {
     #[prost(oneof = "account_verify_key::Key", tags = "1")]
@@ -470,7 +423,6 @@ pub struct AccountVerifyKey {
 }
 /// Nested message and enum types in `AccountVerifyKey`.
 pub mod account_verify_key {
-    #[allow(clippy::derive_partial_eq_without_eq)]
     #[derive(Clone, PartialEq, ::prost::Oneof)]
     pub enum Key {
         #[prost(bytes, tag = "1")]
@@ -478,7 +430,6 @@ pub mod account_verify_key {
     }
 }
 /// Public keys of a single credential.
-#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct CredentialPublicKeys {
     #[prost(map = "uint32, message", tag = "1")]
@@ -488,7 +439,6 @@ pub struct CredentialPublicKeys {
 }
 /// A registration ID of a credential, derived from the secret PRF key and a
 /// nonce. This is always 48 bytes long.
-#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct CredentialRegistrationId {
     #[prost(bytes = "vec", tag = "1")]
@@ -496,14 +446,12 @@ pub struct CredentialRegistrationId {
 }
 /// An index of the identity provider that identifies them uniquely in the
 /// context of a specific chain.
-#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct IdentityProviderIdentity {
     #[prost(uint32, tag = "1")]
     pub value: u32,
 }
 /// Representation of the pair of a year and month.
-#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct YearMonth {
     #[prost(uint32, tag = "1")]
@@ -512,7 +460,6 @@ pub struct YearMonth {
     pub month: u32,
 }
 /// Policy on a credential.
-#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct Policy {
     /// The year and month when the identity object from which the credential is
@@ -530,7 +477,6 @@ pub struct Policy {
     pub attributes: ::std::collections::HashMap<u32, ::prost::alloc::vec::Vec<u8>>,
 }
 /// Values contained in an initial credential.
-#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct InitialCredentialValues {
     /// Public keys of the credential.
@@ -549,7 +495,6 @@ pub struct InitialCredentialValues {
 }
 /// Data relating to a single anonymity revoker sent by the account holder to
 /// the chain.
-#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct ChainArData {
     /// Share of the encryption of IdCredPub.
@@ -558,7 +503,6 @@ pub struct ChainArData {
 }
 /// The number of anonymity revokers needed to revoke anonymity of a credential
 /// holder.
-#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct ArThreshold {
     #[prost(uint32, tag = "1")]
@@ -566,14 +510,12 @@ pub struct ArThreshold {
 }
 /// A single commitment in the G1 group of the BLS curve. This is always 48
 /// bytes in length.
-#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct Commitment {
     #[prost(bytes = "vec", tag = "1")]
     pub value: ::prost::alloc::vec::Vec<u8>,
 }
 /// Commitments that are part of a normal credential.
-#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct CredentialCommitments {
     /// Commitment to the PRF key.
@@ -598,7 +540,6 @@ pub struct CredentialCommitments {
     pub id_cred_sec_sharing_coeff: ::prost::alloc::vec::Vec<Commitment>,
 }
 /// Values contained in a normal (non-initial) credential.
-#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct NormalCredentialValues {
     /// Public keys of the credential.
@@ -627,7 +568,6 @@ pub struct NormalCredentialValues {
     pub commitments:  ::core::option::Option<CredentialCommitments>,
 }
 /// Credential that is part of an account.
-#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct AccountCredential {
     #[prost(oneof = "account_credential::CredentialValues", tags = "1, 2")]
@@ -635,7 +575,6 @@ pub struct AccountCredential {
 }
 /// Nested message and enum types in `AccountCredential`.
 pub mod account_credential {
-    #[allow(clippy::derive_partial_eq_without_eq)]
     #[derive(Clone, PartialEq, ::prost::Oneof)]
     pub enum CredentialValues {
         #[prost(message, tag = "1")]
@@ -645,7 +584,6 @@ pub mod account_credential {
     }
 }
 /// Information about the account at a particular point in time.
-#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct AccountInfo {
     /// Next sequence number to be used for transactions signed from this
@@ -692,7 +630,6 @@ pub struct AccountInfo {
     pub address:           ::core::option::Option<AccountAddress>,
 }
 /// Input to queries which take a block as a parameter.
-#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct BlockHashInput {
     #[prost(oneof = "block_hash_input::BlockHashInput", tags = "1, 2, 3, 4, 5")]
@@ -701,7 +638,6 @@ pub struct BlockHashInput {
 /// Nested message and enum types in `BlockHashInput`.
 pub mod block_hash_input {
     /// Request using a relative block height.
-    #[allow(clippy::derive_partial_eq_without_eq)]
     #[derive(Clone, PartialEq, ::prost::Message)]
     pub struct RelativeHeight {
         /// Genesis index to start from.
@@ -716,7 +652,6 @@ pub mod block_hash_input {
         #[prost(bool, tag = "3")]
         pub restrict:      bool,
     }
-    #[allow(clippy::derive_partial_eq_without_eq)]
     #[derive(Clone, PartialEq, ::prost::Oneof)]
     pub enum BlockHashInput {
         /// Query for the best block.
@@ -739,7 +674,6 @@ pub mod block_hash_input {
     }
 }
 /// Input to queries which take an epoch as a parameter.
-#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct EpochRequest {
     #[prost(oneof = "epoch_request::EpochRequestInput", tags = "1, 2")]
@@ -748,7 +682,6 @@ pub struct EpochRequest {
 /// Nested message and enum types in `EpochRequest`.
 pub mod epoch_request {
     /// Request an epoch by number at a given genesis index.
-    #[allow(clippy::derive_partial_eq_without_eq)]
     #[derive(Clone, PartialEq, ::prost::Message)]
     pub struct RelativeEpoch {
         /// The genesis index to query at. The query is restricted to this
@@ -760,7 +693,6 @@ pub mod epoch_request {
         #[prost(message, optional, tag = "2")]
         pub epoch:         ::core::option::Option<super::Epoch>,
     }
-    #[allow(clippy::derive_partial_eq_without_eq)]
     #[derive(Clone, PartialEq, ::prost::Oneof)]
     pub enum EpochRequestInput {
         /// Query by genesis index and epoch number.
@@ -772,7 +704,6 @@ pub mod epoch_request {
     }
 }
 /// Input to queries which take an account as a parameter.
-#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct AccountIdentifierInput {
     #[prost(
@@ -784,7 +715,6 @@ pub struct AccountIdentifierInput {
 }
 /// Nested message and enum types in `AccountIdentifierInput`.
 pub mod account_identifier_input {
-    #[allow(clippy::derive_partial_eq_without_eq)]
     #[derive(Clone, PartialEq, ::prost::Oneof)]
     pub enum AccountIdentifierInput {
         /// Identify the account by the address of the account.
@@ -800,7 +730,6 @@ pub mod account_identifier_input {
     }
 }
 /// Request for account information.
-#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct AccountInfoRequest {
     /// Block in which to query the account information.
@@ -811,7 +740,6 @@ pub struct AccountInfoRequest {
     pub account_identifier: ::core::option::Option<AccountIdentifierInput>,
 }
 /// Information about a finalized block that is part of the streaming response.
-#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct FinalizedBlockInfo {
     /// Hash of the block.
@@ -822,7 +750,6 @@ pub struct FinalizedBlockInfo {
     pub height: ::core::option::Option<AbsoluteBlockHeight>,
 }
 /// Request the ancestors for the given block.
-#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct AncestorsRequest {
     /// The block to get ancestors of.
@@ -833,7 +760,6 @@ pub struct AncestorsRequest {
     pub amount:     u64,
 }
 /// Request for getting the source of a smart contract module.
-#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct ModuleSourceRequest {
     /// The block to be used for the query.
@@ -844,7 +770,6 @@ pub struct ModuleSourceRequest {
     pub module_ref: ::core::option::Option<ModuleRef>,
 }
 /// Address of a smart contract instance.
-#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct ContractAddress {
     /// The index of the smart contract.
@@ -856,7 +781,6 @@ pub struct ContractAddress {
     pub subindex: u64,
 }
 /// Request for getting information about a smart contract instance.
-#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct InstanceInfoRequest {
     /// The block to be used for the query.
@@ -867,7 +791,6 @@ pub struct InstanceInfoRequest {
     pub address:    ::core::option::Option<ContractAddress>,
 }
 /// Information about a smart contract instance.
-#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct InstanceInfo {
     /// The information depends on the smart contract version used by the
@@ -878,7 +801,6 @@ pub struct InstanceInfo {
 /// Nested message and enum types in `InstanceInfo`.
 pub mod instance_info {
     /// Version 0 smart contract instance information.
-    #[allow(clippy::derive_partial_eq_without_eq)]
     #[derive(Clone, PartialEq, ::prost::Message)]
     pub struct V0 {
         /// The state of the instance.
@@ -901,7 +823,6 @@ pub mod instance_info {
         pub source_module: ::core::option::Option<super::ModuleRef>,
     }
     /// Version 1 smart contract instance information.
-    #[allow(clippy::derive_partial_eq_without_eq)]
     #[derive(Clone, PartialEq, ::prost::Message)]
     pub struct V1 {
         /// The account address which deployed the instance.
@@ -922,7 +843,6 @@ pub mod instance_info {
     }
     /// The information depends on the smart contract version used by the
     /// instance.
-    #[allow(clippy::derive_partial_eq_without_eq)]
     #[derive(Clone, PartialEq, ::prost::Oneof)]
     pub enum Version {
         #[prost(message, tag = "1")]
@@ -932,7 +852,6 @@ pub mod instance_info {
     }
 }
 /// A smart contract instance key-value pair.
-#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct InstanceStateKvPair {
     #[prost(bytes = "vec", tag = "1")]
@@ -941,7 +860,6 @@ pub struct InstanceStateKvPair {
     pub value: ::prost::alloc::vec::Vec<u8>,
 }
 /// Request for a specific key of a smart contract instance state.
-#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct InstanceStateLookupRequest {
     /// The block to be used for the query.
@@ -957,7 +875,6 @@ pub struct InstanceStateLookupRequest {
 }
 /// Value at the requested key of a smart contract instance state. For V0
 /// contracts this will always be the entire state of the contract.
-#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct InstanceStateValueAtKey {
     #[prost(bytes = "vec", tag = "1")]
@@ -966,7 +883,6 @@ pub struct InstanceStateValueAtKey {
 /// The receive name of a smart contract function. Expected format:
 /// `<contract_name>.<func_name>`. It must only consist of atmost 100 ASCII
 /// alphanumeric or punctuation characters, and must contain a '.'.
-#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct ReceiveName {
     #[prost(string, tag = "1")]
@@ -976,28 +892,24 @@ pub struct ReceiveName {
 /// `init_<contract_name>`. It must only consist of atmost 100 ASCII
 /// alphanumeric or punctuation characters, must not contain a '.' and must
 /// start with 'init_'.
-#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct InitName {
     #[prost(string, tag = "1")]
     pub value: ::prost::alloc::string::String,
 }
 /// Parameter to a smart contract initialization or invocation.
-#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct Parameter {
     #[prost(bytes = "vec", tag = "1")]
     pub value: ::prost::alloc::vec::Vec<u8>,
 }
 /// A smart contract v0 state.
-#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct ContractStateV0 {
     #[prost(bytes = "vec", tag = "1")]
     pub value: ::prost::alloc::vec::Vec<u8>,
 }
 /// Status of a block item known to the node.
-#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct BlockItemStatus {
     #[prost(oneof = "block_item_status::Status", tags = "1, 2, 3")]
@@ -1005,19 +917,16 @@ pub struct BlockItemStatus {
 }
 /// Nested message and enum types in `BlockItemStatus`.
 pub mod block_item_status {
-    #[allow(clippy::derive_partial_eq_without_eq)]
     #[derive(Clone, PartialEq, ::prost::Message)]
     pub struct Committed {
         #[prost(message, repeated, tag = "1")]
         pub outcomes: ::prost::alloc::vec::Vec<super::BlockItemSummaryInBlock>,
     }
-    #[allow(clippy::derive_partial_eq_without_eq)]
     #[derive(Clone, PartialEq, ::prost::Message)]
     pub struct Finalized {
         #[prost(message, optional, tag = "1")]
         pub outcome: ::core::option::Option<super::BlockItemSummaryInBlock>,
     }
-    #[allow(clippy::derive_partial_eq_without_eq)]
     #[derive(Clone, PartialEq, ::prost::Oneof)]
     pub enum Status {
         /// Block item is received, but not yet in any blocks.
@@ -1035,7 +944,6 @@ pub mod block_item_status {
     }
 }
 /// A block item summary together with a block hash. Used in BlockItemStatus.
-#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct BlockItemSummaryInBlock {
     /// The block hash.
@@ -1047,21 +955,18 @@ pub struct BlockItemSummaryInBlock {
 }
 /// Energy is used to count exact execution cost.
 /// This cost is then converted to CCD amounts.
-#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct Energy {
     #[prost(uint64, tag = "1")]
     pub value: u64,
 }
 /// A number representing a slot for baking a block.
-#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct Slot {
     #[prost(uint64, tag = "1")]
     pub value: u64,
 }
 /// The response for getNextAccountSequenceNumber.
-#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct NextAccountSequenceNumber {
     /// The best guess for the available account sequence number.
@@ -1073,7 +978,6 @@ pub struct NextAccountSequenceNumber {
     pub all_final:       bool,
 }
 /// A duration of milliseconds.
-#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct Duration {
     #[prost(uint64, tag = "1")]
@@ -1082,7 +986,6 @@ pub struct Duration {
 /// A reason for why a transaction was rejected. Rejected means included in a
 /// block, but the desired action was not achieved. The only effect of a
 /// rejected transaction is payment.
-#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct RejectReason {
     #[prost(
@@ -1095,7 +998,6 @@ pub struct RejectReason {
 }
 /// Nested message and enum types in `RejectReason`.
 pub mod reject_reason {
-    #[allow(clippy::derive_partial_eq_without_eq)]
     #[derive(Clone, PartialEq, ::prost::Message)]
     pub struct InvalidInitMethod {
         #[prost(message, optional, tag = "1")]
@@ -1103,7 +1005,6 @@ pub mod reject_reason {
         #[prost(message, optional, tag = "2")]
         pub init_name:  ::core::option::Option<super::InitName>,
     }
-    #[allow(clippy::derive_partial_eq_without_eq)]
     #[derive(Clone, PartialEq, ::prost::Message)]
     pub struct InvalidReceiveMethod {
         #[prost(message, optional, tag = "1")]
@@ -1111,7 +1012,6 @@ pub mod reject_reason {
         #[prost(message, optional, tag = "2")]
         pub receive_name: ::core::option::Option<super::ReceiveName>,
     }
-    #[allow(clippy::derive_partial_eq_without_eq)]
     #[derive(Clone, PartialEq, ::prost::Message)]
     pub struct AmountTooLarge {
         #[prost(message, optional, tag = "1")]
@@ -1119,13 +1019,11 @@ pub mod reject_reason {
         #[prost(message, optional, tag = "2")]
         pub amount:  ::core::option::Option<super::Amount>,
     }
-    #[allow(clippy::derive_partial_eq_without_eq)]
     #[derive(Clone, PartialEq, ::prost::Message)]
     pub struct RejectedInit {
         #[prost(int32, tag = "1")]
         pub reject_reason: i32,
     }
-    #[allow(clippy::derive_partial_eq_without_eq)]
     #[derive(Clone, PartialEq, ::prost::Message)]
     pub struct RejectedReceive {
         #[prost(int32, tag = "1")]
@@ -1137,19 +1035,16 @@ pub mod reject_reason {
         #[prost(message, optional, tag = "4")]
         pub parameter:        ::core::option::Option<super::Parameter>,
     }
-    #[allow(clippy::derive_partial_eq_without_eq)]
     #[derive(Clone, PartialEq, ::prost::Message)]
     pub struct DuplicateCredIds {
         #[prost(message, repeated, tag = "1")]
         pub ids: ::prost::alloc::vec::Vec<super::CredentialRegistrationId>,
     }
-    #[allow(clippy::derive_partial_eq_without_eq)]
     #[derive(Clone, PartialEq, ::prost::Message)]
     pub struct NonExistentCredIds {
         #[prost(message, repeated, tag = "1")]
         pub ids: ::prost::alloc::vec::Vec<super::CredentialRegistrationId>,
     }
-    #[allow(clippy::derive_partial_eq_without_eq)]
     #[derive(Clone, PartialEq, ::prost::Oneof)]
     pub enum Reason {
         /// Raised while validating a Wasm module that is not well formed.
@@ -1341,7 +1236,6 @@ pub mod reject_reason {
     }
 }
 /// Data generated as part of initializing a single contract instance.
-#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct ContractInitializedEvent {
     /// Contract version.
@@ -1365,7 +1259,6 @@ pub struct ContractInitializedEvent {
     pub events:           ::prost::alloc::vec::Vec<ContractEvent>,
 }
 /// An event generated by a smart contract.
-#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct ContractEvent {
     #[prost(bytes = "vec", tag = "1")]
@@ -1374,7 +1267,6 @@ pub struct ContractEvent {
 /// Data generated as part of updating a single contract instance.
 /// In general a single Update transaction will
 /// generate one or more of these events, together with possibly some transfers.
-#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct InstanceUpdatedEvent {
     /// Contract version.
@@ -1403,7 +1295,6 @@ pub struct InstanceUpdatedEvent {
 }
 /// Effects produced by successful smart contract invocations.
 /// A single invocation will produce a sequence of these effects.
-#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct ContractTraceElement {
     #[prost(oneof = "contract_trace_element::Element", tags = "1, 2, 3, 4, 5")]
@@ -1412,7 +1303,6 @@ pub struct ContractTraceElement {
 /// Nested message and enum types in `ContractTraceElement`.
 pub mod contract_trace_element {
     /// A contract transferred an amount to an account.
-    #[allow(clippy::derive_partial_eq_without_eq)]
     #[derive(Clone, PartialEq, ::prost::Message)]
     pub struct Transferred {
         /// Sender contract.
@@ -1428,7 +1318,6 @@ pub mod contract_trace_element {
     /// A contract was interrupted.
     /// This occurs when a contract invokes another contract or makes a transfer
     /// to an account.
-    #[allow(clippy::derive_partial_eq_without_eq)]
     #[derive(Clone, PartialEq, ::prost::Message)]
     pub struct Interrupted {
         /// The contract interrupted.
@@ -1439,7 +1328,6 @@ pub mod contract_trace_element {
         pub events:  ::prost::alloc::vec::Vec<super::ContractEvent>,
     }
     /// A previously interrupted contract was resumed.
-    #[allow(clippy::derive_partial_eq_without_eq)]
     #[derive(Clone, PartialEq, ::prost::Message)]
     pub struct Resumed {
         /// The contract resumed.
@@ -1451,7 +1339,6 @@ pub mod contract_trace_element {
         pub success: bool,
     }
     /// A previously interrupted contract was resumed.
-    #[allow(clippy::derive_partial_eq_without_eq)]
     #[derive(Clone, PartialEq, ::prost::Message)]
     pub struct Upgraded {
         /// The that was upgraded.
@@ -1464,7 +1351,6 @@ pub mod contract_trace_element {
         #[prost(message, optional, tag = "3")]
         pub to:      ::core::option::Option<super::ModuleRef>,
     }
-    #[allow(clippy::derive_partial_eq_without_eq)]
     #[derive(Clone, PartialEq, ::prost::Oneof)]
     pub enum Element {
         /// A contract instance was updated.
@@ -1487,7 +1373,6 @@ pub mod contract_trace_element {
     }
 }
 /// Result of a successful change of baker keys.
-#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct BakerKeysEvent {
     /// ID of the baker whose keys were changed.
@@ -1508,13 +1393,11 @@ pub struct BakerKeysEvent {
     pub aggregation_key: ::core::option::Option<BakerAggregationVerifyKey>,
 }
 /// A memo which can be included as part of a transfer. Max size is 256 bytes.
-#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct Memo {
     #[prost(bytes = "vec", tag = "1")]
     pub value: ::prost::alloc::vec::Vec<u8>,
 }
-#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct BakerStakeUpdatedData {
     /// Affected baker.
@@ -1530,7 +1413,6 @@ pub struct BakerStakeUpdatedData {
 }
 /// Event generated when one or more encrypted amounts are consumed from the
 /// account.
-#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct EncryptedAmountRemovedEvent {
     /// The affected account.
@@ -1547,7 +1429,6 @@ pub struct EncryptedAmountRemovedEvent {
     pub up_to_index:  u64,
 }
 /// Event generated when an account receives a new encrypted amount.
-#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct NewEncryptedAmountEvent {
     /// The account onto which the amount was added.
@@ -1560,7 +1441,6 @@ pub struct NewEncryptedAmountEvent {
     #[prost(message, optional, tag = "3")]
     pub encrypted_amount: ::core::option::Option<EncryptedAmount>,
 }
-#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct EncryptedSelfAmountAddedEvent {
     /// The affected account.
@@ -1574,14 +1454,12 @@ pub struct EncryptedSelfAmountAddedEvent {
     pub amount:     ::core::option::Option<Amount>,
 }
 /// Data registered on the chain with a register data transaction.
-#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct RegisteredData {
     #[prost(bytes = "vec", tag = "1")]
     pub value: ::prost::alloc::vec::Vec<u8>,
 }
 /// Events that may result from the ConfigureBaker transaction.
-#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct BakerEvent {
     #[prost(
@@ -1593,7 +1471,6 @@ pub struct BakerEvent {
 /// Nested message and enum types in `BakerEvent`.
 pub mod baker_event {
     /// A baker was added.
-    #[allow(clippy::derive_partial_eq_without_eq)]
     #[derive(Clone, PartialEq, ::prost::Message)]
     pub struct BakerAdded {
         /// The keys with which the baker registered.
@@ -1609,7 +1486,6 @@ pub mod baker_event {
         pub restake_earnings: bool,
     }
     /// Baker stake increased.
-    #[allow(clippy::derive_partial_eq_without_eq)]
     #[derive(Clone, PartialEq, ::prost::Message)]
     pub struct BakerStakeIncreased {
         /// Baker's id.
@@ -1619,7 +1495,6 @@ pub mod baker_event {
         #[prost(message, optional, tag = "2")]
         pub new_stake: ::core::option::Option<super::Amount>,
     }
-    #[allow(clippy::derive_partial_eq_without_eq)]
     #[derive(Clone, PartialEq, ::prost::Message)]
     pub struct BakerStakeDecreased {
         /// Baker's id.
@@ -1629,7 +1504,6 @@ pub mod baker_event {
         #[prost(message, optional, tag = "2")]
         pub new_stake: ::core::option::Option<super::Amount>,
     }
-    #[allow(clippy::derive_partial_eq_without_eq)]
     #[derive(Clone, PartialEq, ::prost::Message)]
     pub struct BakerRestakeEarningsUpdated {
         /// Baker's id.
@@ -1640,7 +1514,6 @@ pub mod baker_event {
         pub restake_earnings: bool,
     }
     /// Updated open status for a baker pool.
-    #[allow(clippy::derive_partial_eq_without_eq)]
     #[derive(Clone, PartialEq, ::prost::Message)]
     pub struct BakerSetOpenStatus {
         /// Baker's id.
@@ -1651,7 +1524,6 @@ pub mod baker_event {
         pub open_status: i32,
     }
     /// Updated metadata url for a baker pool.
-    #[allow(clippy::derive_partial_eq_without_eq)]
     #[derive(Clone, PartialEq, ::prost::Message)]
     pub struct BakerSetMetadataUrl {
         /// Baker's id.
@@ -1662,7 +1534,6 @@ pub mod baker_event {
         pub url:      ::prost::alloc::string::String,
     }
     /// Updated transaction fee commission for a baker pool.
-    #[allow(clippy::derive_partial_eq_without_eq)]
     #[derive(Clone, PartialEq, ::prost::Message)]
     pub struct BakerSetTransactionFeeCommission {
         /// Baker's id.
@@ -1673,7 +1544,6 @@ pub mod baker_event {
         pub transaction_fee_commission: ::core::option::Option<super::AmountFraction>,
     }
     /// Updated baking reward commission for baker pool
-    #[allow(clippy::derive_partial_eq_without_eq)]
     #[derive(Clone, PartialEq, ::prost::Message)]
     pub struct BakerSetBakingRewardCommission {
         /// Baker's id
@@ -1684,7 +1554,6 @@ pub mod baker_event {
         pub baking_reward_commission: ::core::option::Option<super::AmountFraction>,
     }
     /// Updated finalization reward commission for baker pool
-    #[allow(clippy::derive_partial_eq_without_eq)]
     #[derive(Clone, PartialEq, ::prost::Message)]
     pub struct BakerSetFinalizationRewardCommission {
         /// Baker's id
@@ -1694,7 +1563,6 @@ pub mod baker_event {
         #[prost(message, optional, tag = "2")]
         pub finalization_reward_commission: ::core::option::Option<super::AmountFraction>,
     }
-    #[allow(clippy::derive_partial_eq_without_eq)]
     #[derive(Clone, PartialEq, ::prost::Oneof)]
     pub enum Event {
         /// A baker was added.
@@ -1733,13 +1601,11 @@ pub mod baker_event {
     }
 }
 /// The identifier for a delegator.
-#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct DelegatorId {
     #[prost(message, optional, tag = "1")]
     pub id: ::core::option::Option<AccountIndex>,
 }
-#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct DelegationEvent {
     #[prost(oneof = "delegation_event::Event", tags = "1, 2, 3, 4, 5, 6")]
@@ -1747,7 +1613,6 @@ pub struct DelegationEvent {
 }
 /// Nested message and enum types in `DelegationEvent`.
 pub mod delegation_event {
-    #[allow(clippy::derive_partial_eq_without_eq)]
     #[derive(Clone, PartialEq, ::prost::Message)]
     pub struct DelegationStakeIncreased {
         /// Delegator's id
@@ -1757,7 +1622,6 @@ pub mod delegation_event {
         #[prost(message, optional, tag = "2")]
         pub new_stake:    ::core::option::Option<super::Amount>,
     }
-    #[allow(clippy::derive_partial_eq_without_eq)]
     #[derive(Clone, PartialEq, ::prost::Message)]
     pub struct DelegationStakeDecreased {
         /// Delegator's id
@@ -1767,7 +1631,6 @@ pub mod delegation_event {
         #[prost(message, optional, tag = "2")]
         pub new_stake:    ::core::option::Option<super::Amount>,
     }
-    #[allow(clippy::derive_partial_eq_without_eq)]
     #[derive(Clone, PartialEq, ::prost::Message)]
     pub struct DelegationSetRestakeEarnings {
         /// Delegator's id
@@ -1777,7 +1640,6 @@ pub mod delegation_event {
         #[prost(bool, tag = "2")]
         pub restake_earnings: bool,
     }
-    #[allow(clippy::derive_partial_eq_without_eq)]
     #[derive(Clone, PartialEq, ::prost::Message)]
     pub struct DelegationSetDelegationTarget {
         /// Delegator's id
@@ -1787,7 +1649,6 @@ pub mod delegation_event {
         #[prost(message, optional, tag = "2")]
         pub delegation_target: ::core::option::Option<super::DelegationTarget>,
     }
-    #[allow(clippy::derive_partial_eq_without_eq)]
     #[derive(Clone, PartialEq, ::prost::Oneof)]
     pub enum Event {
         /// The delegator's stake increased.
@@ -1812,7 +1673,6 @@ pub mod delegation_event {
 }
 /// Effects of an account transaction. All variants except `None`
 /// correspond to a unique transaction that was successful.
-#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct AccountTransactionEffects {
     #[prost(
@@ -1825,7 +1685,6 @@ pub struct AccountTransactionEffects {
 pub mod account_transaction_effects {
     /// No effects other than payment from this transaction.
     /// The rejection reason indicates why the transaction failed.
-    #[allow(clippy::derive_partial_eq_without_eq)]
     #[derive(Clone, PartialEq, ::prost::Message)]
     pub struct None {
         /// Transaction type of a failed transaction, if known.
@@ -1838,7 +1697,6 @@ pub mod account_transaction_effects {
     }
     /// A contract update transaction was issued and produced the given trace.
     /// This is the result of Update transaction.
-    #[allow(clippy::derive_partial_eq_without_eq)]
     #[derive(Clone, PartialEq, ::prost::Message)]
     pub struct ContractUpdateIssued {
         #[prost(message, repeated, tag = "1")]
@@ -1846,7 +1704,6 @@ pub mod account_transaction_effects {
     }
     /// A simple account to account transfer occurred. This is the result of a
     /// successful Transfer transaction.
-    #[allow(clippy::derive_partial_eq_without_eq)]
     #[derive(Clone, PartialEq, ::prost::Message)]
     pub struct AccountTransfer {
         /// Amount that was transferred.
@@ -1861,7 +1718,6 @@ pub mod account_transaction_effects {
     }
     /// An account was deregistered as a baker. This is the result of a
     /// successful UpdateBakerStake transaction.
-    #[allow(clippy::derive_partial_eq_without_eq)]
     #[derive(Clone, PartialEq, ::prost::Message)]
     pub struct BakerStakeUpdated {
         /// If the stake was updated (that is, it changed and did not stay the
@@ -1871,7 +1727,6 @@ pub mod account_transaction_effects {
     }
     /// An encrypted amount was transferred. This is the result of a successful
     /// EncryptedAmountTransfer transaction.
-    #[allow(clippy::derive_partial_eq_without_eq)]
     #[derive(Clone, PartialEq, ::prost::Message)]
     pub struct EncryptedAmountTransferred {
         #[prost(message, optional, tag = "1")]
@@ -1884,7 +1739,6 @@ pub mod account_transaction_effects {
     /// An account transferred part of its encrypted balance to its public
     /// balance. This is the result of a successful TransferToPublic
     /// transaction.
-    #[allow(clippy::derive_partial_eq_without_eq)]
     #[derive(Clone, PartialEq, ::prost::Message)]
     pub struct TransferredToPublic {
         #[prost(message, optional, tag = "1")]
@@ -1894,7 +1748,6 @@ pub mod account_transaction_effects {
     }
     /// A transfer with schedule was performed. This is the result of a
     /// successful TransferWithSchedule transaction.
-    #[allow(clippy::derive_partial_eq_without_eq)]
     #[derive(Clone, PartialEq, ::prost::Message)]
     pub struct TransferredWithSchedule {
         /// Receiver account.
@@ -1909,7 +1762,6 @@ pub mod account_transaction_effects {
     }
     /// Account's credentials were updated. This is the result of a
     /// successful UpdateCredentials transaction.
-    #[allow(clippy::derive_partial_eq_without_eq)]
     #[derive(Clone, PartialEq, ::prost::Message)]
     pub struct CredentialsUpdated {
         /// The credential ids that were added.
@@ -1924,7 +1776,6 @@ pub mod account_transaction_effects {
     }
     /// A baker was configured. The details of what happened are contained in
     /// the list of BakerEvents.
-    #[allow(clippy::derive_partial_eq_without_eq)]
     #[derive(Clone, PartialEq, ::prost::Message)]
     pub struct BakerConfigured {
         #[prost(message, repeated, tag = "1")]
@@ -1932,13 +1783,11 @@ pub mod account_transaction_effects {
     }
     /// An account configured delegation. The details of what happened are
     /// contained in the list of DelegationEvents.
-    #[allow(clippy::derive_partial_eq_without_eq)]
     #[derive(Clone, PartialEq, ::prost::Message)]
     pub struct DelegationConfigured {
         #[prost(message, repeated, tag = "1")]
         pub events: ::prost::alloc::vec::Vec<super::DelegationEvent>,
     }
-    #[allow(clippy::derive_partial_eq_without_eq)]
     #[derive(Clone, PartialEq, ::prost::Oneof)]
     pub enum Effect {
         /// No effects other than payment from this transaction.
@@ -2006,7 +1855,6 @@ pub mod account_transaction_effects {
     }
 }
 /// Election difficulty parameter.
-#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct ElectionDifficulty {
     #[prost(message, optional, tag = "1")]
@@ -2014,7 +1862,6 @@ pub struct ElectionDifficulty {
 }
 /// Parameters that determine timeouts in the consensus protocol used from
 /// protocol version 6.
-#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct TimeoutParameters {
     /// The base value for triggering a timeout
@@ -2028,7 +1875,6 @@ pub struct TimeoutParameters {
     pub timeout_decrease: ::core::option::Option<Ratio>,
 }
 /// Finalization committee parameters used from protocol version 6
-#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct FinalizationCommitteeParameters {
     /// The minimum size of a finalization committee before
@@ -2045,7 +1891,6 @@ pub struct FinalizationCommitteeParameters {
     pub finalizer_relative_stake_threshold: ::core::option::Option<AmountFraction>,
 }
 /// Parameters for the consensus protocol used from protocol version 6.
-#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct ConsensusParametersV1 {
     /// Parameters controlling round timeouts.
@@ -2059,14 +1904,12 @@ pub struct ConsensusParametersV1 {
     pub block_energy_limit: ::core::option::Option<Energy>,
 }
 /// Represents an exchange rate.
-#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct ExchangeRate {
     #[prost(message, optional, tag = "1")]
     pub value: ::core::option::Option<Ratio>,
 }
 /// Represents a ratio, i.e., 'numerator / denominator'.
-#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct Ratio {
     /// The numerator.
@@ -2077,7 +1920,6 @@ pub struct Ratio {
     pub denominator: u64,
 }
 /// A public key used for chain updates.
-#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct UpdatePublicKey {
     #[prost(bytes = "vec", tag = "1")]
@@ -2085,7 +1927,6 @@ pub struct UpdatePublicKey {
 }
 /// The threshold for how many UpdatePublicKeys are need to make a certain chain
 /// update.
-#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct UpdateKeysThreshold {
     /// Is ensured to be within between 1 and 2^16.
@@ -2093,14 +1934,12 @@ pub struct UpdateKeysThreshold {
     pub value: u32,
 }
 /// Index of a key in an authorizations update payload.
-#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct UpdateKeysIndex {
     #[prost(uint32, tag = "1")]
     pub value: u32,
 }
 /// Represents root or level 1 keys.
-#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct HigherLevelKeys {
     /// The keys.
@@ -2114,7 +1953,6 @@ pub struct HigherLevelKeys {
 /// HigherLevelKeys that are allowed to make chain update of a specific type.
 /// The threshold defines the minimum number of allowed keys needed to make the
 /// actual update.
-#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct AccessStructure {
     /// Unique indexes into the set of keys in AuthorizationV0.
@@ -2127,7 +1965,6 @@ pub struct AccessStructure {
 /// The set of keys authorized for chain updates, together with access
 /// structures determining which keys are authorized for which update types.
 /// This is the payload of an update to authorization.
-#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct AuthorizationsV0 {
     /// The set of keys authorized for chain updates.
@@ -2175,7 +2012,6 @@ pub struct AuthorizationsV0 {
 /// The set of keys authorized for chain updates, together with access
 /// structures determining which keys are authorized for which update types.
 /// This is the payload of an update to authorization.
-#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct AuthorizationsV1 {
     #[prost(message, optional, tag = "1")]
@@ -2190,7 +2026,6 @@ pub struct AuthorizationsV1 {
 }
 /// Description either of an anonymity revoker or identity provider.
 /// Metadata that should be visible on the chain.
-#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct Description {
     /// The name.
@@ -2206,7 +2041,6 @@ pub struct Description {
 }
 /// Information on a single anonymity revoker help by the identity provider.
 /// Typically an identity provider will hold more than one.
-#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct ArInfo {
     /// Unique identifier of the anonymity revoker.
@@ -2223,14 +2057,12 @@ pub struct ArInfo {
 pub mod ar_info {
     /// Identity of the anonymity revoker on the chain. This defines their
     /// evaluateion point for secret sharing, and thus it cannot be 0.
-    #[allow(clippy::derive_partial_eq_without_eq)]
     #[derive(Clone, PartialEq, ::prost::Message)]
     pub struct ArIdentity {
         #[prost(uint32, tag = "1")]
         pub value: u32,
     }
     /// Public key of an anonymity revoker.
-    #[allow(clippy::derive_partial_eq_without_eq)]
     #[derive(Clone, PartialEq, ::prost::Message)]
     pub struct ArPublicKey {
         #[prost(bytes = "vec", tag = "1")]
@@ -2240,14 +2072,12 @@ pub mod ar_info {
 /// A succinct identifier of an identity provider on the chain.
 /// In credential deployments, and other interactions with the chain this is
 /// used to identify which identity provider is meant.
-#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct IpIdentity {
     #[prost(uint32, tag = "1")]
     pub value: u32,
 }
 /// Public information about an identity provider.
-#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct IpInfo {
     /// Unique identifier of the identity provider.
@@ -2266,14 +2096,12 @@ pub struct IpInfo {
 /// Nested message and enum types in `IpInfo`.
 pub mod ip_info {
     /// Pointcheval-Sanders public key of the identity provider.
-    #[allow(clippy::derive_partial_eq_without_eq)]
     #[derive(Clone, PartialEq, ::prost::Message)]
     pub struct IpVerifyKey {
         #[prost(bytes = "vec", tag = "1")]
         pub value: ::prost::alloc::vec::Vec<u8>,
     }
     /// Ed25519 public key of the identity provider.
-    #[allow(clippy::derive_partial_eq_without_eq)]
     #[derive(Clone, PartialEq, ::prost::Message)]
     pub struct IpCdiVerifyKey {
         #[prost(bytes = "vec", tag = "1")]
@@ -2281,14 +2109,12 @@ pub mod ip_info {
     }
 }
 /// A duration in seconds.
-#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct DurationSeconds {
     #[prost(uint64, tag = "1")]
     pub value: u64,
 }
 /// Inclusive range of amount fractions.
-#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct InclusiveRangeAmountFraction {
     #[prost(message, optional, tag = "1")]
@@ -2297,7 +2123,6 @@ pub struct InclusiveRangeAmountFraction {
     pub max: ::core::option::Option<AmountFraction>,
 }
 /// Ranges of allowed commission values that pools may choose from.
-#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct CommissionRanges {
     /// The range of allowed finalization commissions.
@@ -2312,28 +2137,24 @@ pub struct CommissionRanges {
 }
 /// A bound on the relative share of the total staked capital that a baker can
 /// have as its stake. This is required to be greater than 0.
-#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct CapitalBound {
     #[prost(message, optional, tag = "1")]
     pub value: ::core::option::Option<AmountFraction>,
 }
 /// A leverage factor.
-#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct LeverageFactor {
     #[prost(message, optional, tag = "1")]
     pub value: ::core::option::Option<Ratio>,
 }
 /// A chain epoch.
-#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct Epoch {
     #[prost(uint64, tag = "1")]
     pub value: u64,
 }
 /// A round.
-#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct Round {
     #[prost(uint64, tag = "1")]
@@ -2341,7 +2162,6 @@ pub struct Round {
 }
 /// Length of a reward period in epochs.
 /// Must always be a strictly positive number.
-#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct RewardPeriodLength {
     #[prost(message, optional, tag = "1")]
@@ -2349,7 +2169,6 @@ pub struct RewardPeriodLength {
 }
 /// A minting rate of CCD.
 /// The value is `mantissa * 10^(-exponent)`.
-#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct MintRate {
     #[prost(uint32, tag = "1")]
@@ -2358,7 +2177,6 @@ pub struct MintRate {
     #[prost(uint32, tag = "2")]
     pub exponent: u32,
 }
-#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct CooldownParametersCpv1 {
     /// Number of seconds that pool owners must cooldown
@@ -2371,7 +2189,6 @@ pub struct CooldownParametersCpv1 {
     pub delegator_cooldown:  ::core::option::Option<DurationSeconds>,
 }
 /// Parameters related to staking pools.
-#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct PoolParametersCpv1 {
     /// Fraction of finalization rewards charged by the passive delegation.
@@ -2401,7 +2218,6 @@ pub struct PoolParametersCpv1 {
 /// The time parameters are introduced as of protocol version 4, and consist of
 /// the reward period length and the mint rate per payday. These are coupled as
 /// a change to either affects the overall rate of minting.
-#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct TimeParametersCpv1 {
     #[prost(message, optional, tag = "1")]
@@ -2410,7 +2226,6 @@ pub struct TimeParametersCpv1 {
     pub mint_per_payday:      ::core::option::Option<MintRate>,
 }
 /// Mint distribution payload as it looks in protocol version 4 and onward.
-#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct MintDistributionCpv1 {
     #[prost(message, optional, tag = "1")]
@@ -2418,7 +2233,6 @@ pub struct MintDistributionCpv1 {
     #[prost(message, optional, tag = "2")]
     pub finalization_reward: ::core::option::Option<AmountFraction>,
 }
-#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct ProtocolUpdate {
     /// A brief message about the update.
@@ -2438,7 +2252,6 @@ pub struct ProtocolUpdate {
 /// finalizers, and the foundation account. It must be the case that
 /// baking_reward + finalization_reward <= 1. The remaining amount is the
 /// platform development charge.
-#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct MintDistributionCpv0 {
     /// Mint rate per slot.
@@ -2452,7 +2265,6 @@ pub struct MintDistributionCpv0 {
     pub finalization_reward: ::core::option::Option<AmountFraction>,
 }
 /// Parameters determining the distribution of transaction fees.
-#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct TransactionFeeDistribution {
     /// The fraction allocated to the baker.
@@ -2463,7 +2275,6 @@ pub struct TransactionFeeDistribution {
     pub gas_account: ::core::option::Option<AmountFraction>,
 }
 /// Distribution of gas rewards for chain parameters version 0 and 1.
-#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct GasRewards {
     /// The fraction paid to the baker.
@@ -2481,7 +2292,6 @@ pub struct GasRewards {
     pub chain_update:       ::core::option::Option<AmountFraction>,
 }
 /// Distribution of gas rewards for chain parameters version 2.
-#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct GasRewardsCpv2 {
     /// The fraction paid to the baker.
@@ -2497,7 +2307,6 @@ pub struct GasRewardsCpv2 {
 }
 /// Minimum stake needed to become a baker. This only applies to protocol
 /// version 1-3.
-#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct BakerStakeThreshold {
     /// Minimum threshold required for registering as a baker.
@@ -2507,7 +2316,6 @@ pub struct BakerStakeThreshold {
 /// Root updates are the highest kind of key updates. They can update every
 /// other set of keys, even themselves. They can only be performed by Root level
 /// keys.
-#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct RootUpdate {
     #[prost(oneof = "root_update::UpdateType", tags = "1, 2, 3, 4")]
@@ -2515,7 +2323,6 @@ pub struct RootUpdate {
 }
 /// Nested message and enum types in `RootUpdate`.
 pub mod root_update {
-    #[allow(clippy::derive_partial_eq_without_eq)]
     #[derive(Clone, PartialEq, ::prost::Oneof)]
     pub enum UpdateType {
         /// The root keys were updated.
@@ -2536,7 +2343,6 @@ pub mod root_update {
 /// Level 1 updates are the intermediate update kind.
 /// They can update themselves or level 2 keys. They can only be performed by
 /// level 1 keys.
-#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct Level1Update {
     #[prost(oneof = "level1_update::UpdateType", tags = "1, 2, 3")]
@@ -2544,7 +2350,6 @@ pub struct Level1Update {
 }
 /// Nested message and enum types in `Level1Update`.
 pub mod level1_update {
-    #[allow(clippy::derive_partial_eq_without_eq)]
     #[derive(Clone, PartialEq, ::prost::Oneof)]
     pub enum UpdateType {
         /// The level 1 keys were updated.
@@ -2560,7 +2365,6 @@ pub mod level1_update {
     }
 }
 /// The payload of a chain update.
-#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct UpdatePayload {
     #[prost(
@@ -2571,7 +2375,6 @@ pub struct UpdatePayload {
 }
 /// Nested message and enum types in `UpdatePayload`.
 pub mod update_payload {
-    #[allow(clippy::derive_partial_eq_without_eq)]
     #[derive(Clone, PartialEq, ::prost::Oneof)]
     pub enum Payload {
         /// The protocol version was updated.
@@ -2644,7 +2447,6 @@ pub mod update_payload {
     }
 }
 /// Details about an account transaction.
-#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct AccountTransactionDetails {
     /// The cost of the transaction. Paid by the sender.
@@ -2660,7 +2462,6 @@ pub struct AccountTransactionDetails {
 /// Details of an account creation. These transactions are free, and we only
 /// ever get a response for them if the account is created, hence no failure
 /// cases.
-#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct AccountCreationDetails {
     /// Whether this is an initial or normal account.
@@ -2674,7 +2475,6 @@ pub struct AccountCreationDetails {
     pub reg_id:          ::core::option::Option<CredentialRegistrationId>,
 }
 /// Transaction time specified as seconds since unix epoch.
-#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct TransactionTime {
     #[prost(uint64, tag = "1")]
@@ -2683,7 +2483,6 @@ pub struct TransactionTime {
 /// Details of an update instruction. These are free, and we only ever get a
 /// response for them if the update is successfully enqueued, hence no failure
 /// cases.
-#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct UpdateDetails {
     /// The time at which the update will be effective.
@@ -2695,7 +2494,6 @@ pub struct UpdateDetails {
 }
 /// Summary of the outcome of a block item in structured form.
 /// The summary determines which transaction type it was.
-#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct BlockItemSummary {
     /// Index of the transaction in the block where it is included.
@@ -2713,17 +2511,15 @@ pub struct BlockItemSummary {
 }
 /// Nested message and enum types in `BlockItemSummary`.
 pub mod block_item_summary {
-    #[allow(clippy::derive_partial_eq_without_eq)]
     #[derive(Clone, PartialEq, ::prost::Message)]
     pub struct TransactionIndex {
         #[prost(uint64, tag = "1")]
         pub value: u64,
     }
     /// Details that are specific to different transaction types.
-    #[allow(clippy::derive_partial_eq_without_eq)]
     #[derive(Clone, PartialEq, ::prost::Oneof)]
     pub enum Details {
-        /// Detailsa about an account transaction.
+        /// Details about an account transaction.
         #[prost(message, tag = "4")]
         AccountTransaction(super::AccountTransactionDetails),
         /// Details about an account creation.
@@ -2738,14 +2534,12 @@ pub mod block_item_summary {
 /// protocol update instruction might not change the protocol version
 /// specified in the previous field, but it always increments the genesis
 /// index.
-#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct GenesisIndex {
     #[prost(uint32, tag = "1")]
     pub value: u32,
 }
 /// The response for GetConsensusInfo.
-#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct ConsensusInfo {
     /// Hash of the current best block.
@@ -2868,7 +2662,6 @@ pub struct ConsensusInfo {
     pub trigger_block_time:          ::core::option::Option<Timestamp>,
 }
 /// Information about an arrived block that is part of the streaming response.
-#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct ArrivedBlockInfo {
     /// Hash of the block.
@@ -2879,7 +2672,6 @@ pub struct ArrivedBlockInfo {
     pub height: ::core::option::Option<AbsoluteBlockHeight>,
 }
 /// The response for GetCryptographicParameters.
-#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct CryptographicParameters {
     /// A free-form string used to distinguish between different chains even if
@@ -2900,7 +2692,6 @@ pub struct CryptographicParameters {
     pub on_chain_commitment_key: ::prost::alloc::vec::Vec<u8>,
 }
 /// The response for GetBlockInfo.
-#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct BlockInfo {
     /// Hash of the block.
@@ -2968,7 +2759,6 @@ pub struct BlockInfo {
     pub epoch:                    ::core::option::Option<Epoch>,
 }
 /// Request for GetPoolInfo.
-#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct PoolInfoRequest {
     /// Block in which to query the pool information.
@@ -2979,7 +2769,6 @@ pub struct PoolInfoRequest {
     pub baker:      ::core::option::Option<BakerId>,
 }
 /// A pending change to a baker pool.
-#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct PoolPendingChange {
     #[prost(oneof = "pool_pending_change::Change", tags = "1, 2")]
@@ -2988,7 +2777,6 @@ pub struct PoolPendingChange {
 /// Nested message and enum types in `PoolPendingChange`.
 pub mod pool_pending_change {
     /// A reduction in baker equity capital is pending.
-    #[allow(clippy::derive_partial_eq_without_eq)]
     #[derive(Clone, PartialEq, ::prost::Message)]
     pub struct Reduce {
         /// New baker equity capital.
@@ -2999,14 +2787,12 @@ pub mod pool_pending_change {
         pub effective_time:         ::core::option::Option<super::Timestamp>,
     }
     /// Removal of the pool is pending.
-    #[allow(clippy::derive_partial_eq_without_eq)]
     #[derive(Clone, PartialEq, ::prost::Message)]
     pub struct Remove {
         /// Timestamp when the change takes effect.
         #[prost(message, optional, tag = "1")]
         pub effective_time: ::core::option::Option<super::Timestamp>,
     }
-    #[allow(clippy::derive_partial_eq_without_eq)]
     #[derive(Clone, PartialEq, ::prost::Oneof)]
     pub enum Change {
         #[prost(message, tag = "1")]
@@ -3016,7 +2802,6 @@ pub mod pool_pending_change {
     }
 }
 /// Information about a baker pool in the current reward period.
-#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct PoolCurrentPaydayInfo {
     /// The number of blocks baked in the current reward period.
@@ -3048,7 +2833,6 @@ pub struct PoolCurrentPaydayInfo {
 }
 /// Type for the response of GetPoolInfo.
 /// Contains information about a given pool at the end of a given block.
-#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct PoolInfoResponse {
     /// The 'BakerId' of the pool owner.
@@ -3083,7 +2867,6 @@ pub struct PoolInfoResponse {
 }
 /// Type for the response of GetPassiveDelegationInfo.
 /// Contains information about passive delegators at the end of a given block.
-#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct PassiveDelegationInfo {
     /// The total capital delegated passively.
@@ -3105,7 +2888,6 @@ pub struct PassiveDelegationInfo {
     pub all_pool_total_capital: ::core::option::Option<Amount>,
 }
 /// Request for GetBlocksAtHeight.
-#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct BlocksAtHeightRequest {
     #[prost(oneof = "blocks_at_height_request::BlocksAtHeight", tags = "1, 2")]
@@ -3114,7 +2896,6 @@ pub struct BlocksAtHeightRequest {
 /// Nested message and enum types in `BlocksAtHeightRequest`.
 pub mod blocks_at_height_request {
     /// Request using an absolute block height.
-    #[allow(clippy::derive_partial_eq_without_eq)]
     #[derive(Clone, PartialEq, ::prost::Message)]
     pub struct Absolute {
         /// The absolute block height.
@@ -3122,7 +2903,6 @@ pub mod blocks_at_height_request {
         pub height: ::core::option::Option<super::AbsoluteBlockHeight>,
     }
     /// Request using a relative block height.
-    #[allow(clippy::derive_partial_eq_without_eq)]
     #[derive(Clone, PartialEq, ::prost::Message)]
     pub struct Relative {
         /// Genesis index to start from.
@@ -3137,7 +2917,6 @@ pub mod blocks_at_height_request {
         #[prost(bool, tag = "3")]
         pub restrict:      bool,
     }
-    #[allow(clippy::derive_partial_eq_without_eq)]
     #[derive(Clone, PartialEq, ::prost::Oneof)]
     pub enum BlocksAtHeight {
         #[prost(message, tag = "1")]
@@ -3147,7 +2926,6 @@ pub mod blocks_at_height_request {
     }
 }
 /// Response for GetBlocksAtHeight.
-#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct BlocksAtHeightResponse {
     /// Live blocks at the given height.
@@ -3156,7 +2934,6 @@ pub struct BlocksAtHeightResponse {
 }
 /// Type for the response of GetTokenomicsInfo.
 /// Contains information related to tokenomics at the end of a given block.
-#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct TokenomicsInfo {
     #[prost(oneof = "tokenomics_info::Tokenomics", tags = "1, 2")]
@@ -3165,7 +2942,6 @@ pub struct TokenomicsInfo {
 /// Nested message and enum types in `TokenomicsInfo`.
 pub mod tokenomics_info {
     /// Version 0 tokenomics.
-    #[allow(clippy::derive_partial_eq_without_eq)]
     #[derive(Clone, PartialEq, ::prost::Message)]
     pub struct V0 {
         /// The total CCD in existence.
@@ -3188,7 +2964,6 @@ pub mod tokenomics_info {
         pub protocol_version:            i32,
     }
     /// Version 1 tokenomics.
-    #[allow(clippy::derive_partial_eq_without_eq)]
     #[derive(Clone, PartialEq, ::prost::Message)]
     pub struct V1 {
         /// The total CCD in existence.
@@ -3224,7 +2999,6 @@ pub mod tokenomics_info {
         #[prost(enumeration = "super::ProtocolVersion", tag = "10")]
         pub protocol_version:               i32,
     }
-    #[allow(clippy::derive_partial_eq_without_eq)]
     #[derive(Clone, PartialEq, ::prost::Oneof)]
     pub enum Tokenomics {
         #[prost(message, tag = "1")]
@@ -3234,7 +3008,6 @@ pub mod tokenomics_info {
     }
 }
 /// Request for InvokeInstance.
-#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct InvokeInstanceRequest {
     /// Block to invoke the contract. The invocation will be at the end of the
@@ -3267,7 +3040,6 @@ pub struct InvokeInstanceRequest {
     pub energy:     ::core::option::Option<Energy>,
 }
 /// Response type for InvokeInstance.
-#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct InvokeInstanceResponse {
     #[prost(oneof = "invoke_instance_response::Result", tags = "1, 2")]
@@ -3276,7 +3048,6 @@ pub struct InvokeInstanceResponse {
 /// Nested message and enum types in `InvokeInstanceResponse`.
 pub mod invoke_instance_response {
     /// Contract execution failed.
-    #[allow(clippy::derive_partial_eq_without_eq)]
     #[derive(Clone, PartialEq, ::prost::Message)]
     pub struct Failure {
         /// If invoking a V0 contract this is not provided, otherwise it is
@@ -3294,7 +3065,6 @@ pub mod invoke_instance_response {
         pub reason:       ::core::option::Option<super::RejectReason>,
     }
     /// Contract execution succeeded.
-    #[allow(clippy::derive_partial_eq_without_eq)]
     #[derive(Clone, PartialEq, ::prost::Message)]
     pub struct Success {
         /// If invoking a V0 contract this is absent. Otherwise it is the return
@@ -3308,7 +3078,6 @@ pub mod invoke_instance_response {
         #[prost(message, repeated, tag = "3")]
         pub effects:      ::prost::alloc::vec::Vec<super::ContractTraceElement>,
     }
-    #[allow(clippy::derive_partial_eq_without_eq)]
     #[derive(Clone, PartialEq, ::prost::Oneof)]
     pub enum Result {
         #[prost(message, tag = "1")]
@@ -3318,7 +3087,6 @@ pub mod invoke_instance_response {
     }
 }
 /// Request for GetPoolDelegators and GetPoolDelegatorsRewardPeriod.
-#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct GetPoolDelegatorsRequest {
     /// Block in which to query the delegators.
@@ -3329,7 +3097,6 @@ pub struct GetPoolDelegatorsRequest {
     pub baker:      ::core::option::Option<BakerId>,
 }
 /// Stream item for GetPoolDelegators and GetPassiveDelegators.
-#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct DelegatorInfo {
     /// The delegator account address.
@@ -3344,7 +3111,6 @@ pub struct DelegatorInfo {
 }
 /// Stream item for GetPoolDelegatorsRewardPeriod and
 /// GetPassiveDelegatorsRewardPeriod.
-#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct DelegatorRewardPeriodInfo {
     /// The delegator account address.
@@ -3355,7 +3121,6 @@ pub struct DelegatorRewardPeriodInfo {
     pub stake:   ::core::option::Option<Amount>,
 }
 /// Response type for GetBranches.
-#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct Branch {
     /// The hash of the block.
@@ -3368,7 +3133,6 @@ pub struct Branch {
 /// The leadership election nonce is an unpredictable value updated once an
 /// epoch to make sure that bakers cannot predict too far in the future when
 /// they will win the right to bake blocks.
-#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct LeadershipElectionNonce {
     #[prost(bytes = "vec", tag = "1")]
@@ -3376,7 +3140,6 @@ pub struct LeadershipElectionNonce {
 }
 /// Response type for GetElectionInfo.
 /// Contains information related to baker election for a perticular block.
-#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct ElectionInfo {
     /// Baking lottery election difficulty. Present only in protocol versions
@@ -3392,7 +3155,6 @@ pub struct ElectionInfo {
 }
 /// Nested message and enum types in `ElectionInfo`.
 pub mod election_info {
-    #[allow(clippy::derive_partial_eq_without_eq)]
     #[derive(Clone, PartialEq, ::prost::Message)]
     pub struct Baker {
         /// The ID of the baker.
@@ -3410,7 +3172,6 @@ pub mod election_info {
 /// A protocol generated event that is not directly caused by a transaction.
 /// This includes minting new CCD, rewarding different bakers and delegators,
 /// etc.
-#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct BlockSpecialEvent {
     #[prost(oneof = "block_special_event::Event", tags = "1, 2, 3, 4, 5, 6, 7, 8")]
@@ -3419,7 +3180,6 @@ pub struct BlockSpecialEvent {
 /// Nested message and enum types in `BlockSpecialEvent`.
 pub mod block_special_event {
     /// A representation of a mapping from an account address to an amount.
-    #[allow(clippy::derive_partial_eq_without_eq)]
     #[derive(Clone, PartialEq, ::prost::Message)]
     pub struct AccountAmounts {
         #[prost(message, repeated, tag = "1")]
@@ -3428,7 +3188,6 @@ pub mod block_special_event {
     /// Nested message and enum types in `AccountAmounts`.
     pub mod account_amounts {
         /// The entry for the map.
-        #[allow(clippy::derive_partial_eq_without_eq)]
         #[derive(Clone, PartialEq, ::prost::Message)]
         pub struct Entry {
             /// The key type
@@ -3441,7 +3200,6 @@ pub mod block_special_event {
     }
     /// Payment to each baker of a previous epoch, in proportion to the number
     /// of blocks they contributed.
-    #[allow(clippy::derive_partial_eq_without_eq)]
     #[derive(Clone, PartialEq, ::prost::Message)]
     pub struct BakingRewards {
         /// The amount awarded to each baker.
@@ -3452,7 +3210,6 @@ pub mod block_special_event {
         pub remainder:     ::core::option::Option<super::Amount>,
     }
     /// Minting of new CCD.
-    #[allow(clippy::derive_partial_eq_without_eq)]
     #[derive(Clone, PartialEq, ::prost::Message)]
     pub struct Mint {
         /// The amount allocated to the banking reward account.
@@ -3470,7 +3227,6 @@ pub mod block_special_event {
     }
     /// Payment to each finalizer on inclusion of a finalization record in a
     /// block.
-    #[allow(clippy::derive_partial_eq_without_eq)]
     #[derive(Clone, PartialEq, ::prost::Message)]
     pub struct FinalizationRewards {
         /// The amount awarded to each finalizer.
@@ -3485,7 +3241,6 @@ pub mod block_special_event {
     ///
     /// ```transaction_fees + old_gas_account = new_gas_account + baker_reward +
     /// foundation_charge```
-    #[allow(clippy::derive_partial_eq_without_eq)]
     #[derive(Clone, PartialEq, ::prost::Message)]
     pub struct BlockReward {
         /// The total fees paid for transactions in the block.
@@ -3511,7 +3266,6 @@ pub mod block_special_event {
         pub foundation_account: ::core::option::Option<super::AccountAddress>,
     }
     /// Foundation tax.
-    #[allow(clippy::derive_partial_eq_without_eq)]
     #[derive(Clone, PartialEq, ::prost::Message)]
     pub struct PaydayFoundationReward {
         /// The account that got rewarded.
@@ -3522,7 +3276,6 @@ pub mod block_special_event {
         pub development_charge: ::core::option::Option<super::Amount>,
     }
     /// Reward payment to the given account.
-    #[allow(clippy::derive_partial_eq_without_eq)]
     #[derive(Clone, PartialEq, ::prost::Message)]
     pub struct PaydayAccountReward {
         /// The account that got rewarded.
@@ -3539,7 +3292,6 @@ pub mod block_special_event {
         pub finalization_reward: ::core::option::Option<super::Amount>,
     }
     /// Amounts accrued to accounts for each baked block.
-    #[allow(clippy::derive_partial_eq_without_eq)]
     #[derive(Clone, PartialEq, ::prost::Message)]
     pub struct BlockAccrueReward {
         /// The total fees paid for transactions in the block.
@@ -3565,7 +3317,6 @@ pub mod block_special_event {
         pub baker:             ::core::option::Option<super::BakerId>,
     }
     /// Payment distributed to a pool or passive delegators.
-    #[allow(clippy::derive_partial_eq_without_eq)]
     #[derive(Clone, PartialEq, ::prost::Message)]
     pub struct PaydayPoolReward {
         /// The pool owner (passive delegators when not present).
@@ -3581,7 +3332,6 @@ pub mod block_special_event {
         #[prost(message, optional, tag = "4")]
         pub finalization_reward: ::core::option::Option<super::Amount>,
     }
-    #[allow(clippy::derive_partial_eq_without_eq)]
     #[derive(Clone, PartialEq, ::prost::Oneof)]
     pub enum Event {
         #[prost(message, tag = "1")]
@@ -3603,7 +3353,6 @@ pub mod block_special_event {
     }
 }
 /// A pending update.
-#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct PendingUpdate {
     /// The effective time of the update.
@@ -3620,7 +3369,6 @@ pub struct PendingUpdate {
 /// Nested message and enum types in `PendingUpdate`.
 pub mod pending_update {
     /// The effect of the update.
-    #[allow(clippy::derive_partial_eq_without_eq)]
     #[derive(Clone, PartialEq, ::prost::Oneof)]
     pub enum Effect {
         /// Updates to the root keys.
@@ -3705,7 +3453,6 @@ pub mod pending_update {
     }
 }
 /// The response for `GetNextUpdateSequenceNumbers`.
-#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct NextUpdateSequenceNumbers {
     /// Updates to the root keys.
@@ -3774,7 +3521,6 @@ pub struct NextUpdateSequenceNumbers {
 }
 /// A request to send a new block item to the chain.
 /// An IP address
-#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct IpAddress {
     #[prost(string, tag = "1")]
@@ -3783,7 +3529,6 @@ pub struct IpAddress {
 /// A port
 /// Valid port numbers are expected thus
 /// the value is expected to be in the range (0..u16::MAX).
-#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct Port {
     #[prost(uint32, tag = "1")]
@@ -3791,7 +3536,6 @@ pub struct Port {
 }
 /// A socket address consisting of
 /// an IP + port.
-#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct IpSocketAddress {
     #[prost(message, optional, tag = "1")]
@@ -3805,14 +3549,12 @@ pub struct IpSocketAddress {
 /// The underlying value is simply a u64.
 /// Note. There is no authenticity of the peer id and
 /// as such it is only used for logging purposes.
-#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct PeerId {
     #[prost(string, tag = "1")]
     pub value: ::prost::alloc::string::String,
 }
 /// A banned peer
-#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct BannedPeer {
     /// The IP address of the banned peer.
@@ -3821,7 +3563,6 @@ pub struct BannedPeer {
 }
 /// The banned peers given by
 /// their IP addresses.
-#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct BannedPeers {
     #[prost(message, repeated, tag = "1")]
@@ -3830,14 +3571,12 @@ pub struct BannedPeers {
 /// A peer to ban specified by its IP.
 /// Note. This will ban all peers located behind the
 /// specified IP even though they are using different ports.
-#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct PeerToBan {
     #[prost(message, optional, tag = "1")]
     pub ip_address: ::core::option::Option<IpAddress>,
 }
 /// Request to enable dumping of network packages.
-#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct DumpRequest {
     /// Which file to dump the packages into.
@@ -3849,7 +3588,6 @@ pub struct DumpRequest {
     pub raw:  bool,
 }
 /// Peers and their associated network related statistics
-#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct PeersInfo {
     #[prost(message, repeated, tag = "1")]
@@ -3858,7 +3596,6 @@ pub struct PeersInfo {
 /// Nested message and enum types in `PeersInfo`.
 pub mod peers_info {
     /// A peer that the node is connected to.
-    #[allow(clippy::derive_partial_eq_without_eq)]
     #[derive(Clone, PartialEq, ::prost::Message)]
     pub struct Peer {
         /// The identifier of the peer that it
@@ -3878,7 +3615,6 @@ pub mod peers_info {
     /// Nested message and enum types in `Peer`.
     pub mod peer {
         /// Network statistics for the peer
-        #[allow(clippy::derive_partial_eq_without_eq)]
         #[derive(Clone, PartialEq, ::prost::Message)]
         pub struct NetworkStats {
             /// The number of messages sent to the peer.
@@ -3936,20 +3672,8 @@ pub mod peers_info {
                     CatchupStatus::Catchingup => "CATCHINGUP",
                 }
             }
-
-            /// Creates an enum from field names used in the ProtoBuf
-            /// definition.
-            pub fn from_str_name(value: &str) -> ::core::option::Option<Self> {
-                match value {
-                    "UPTODATE" => Some(Self::Uptodate),
-                    "PENDING" => Some(Self::Pending),
-                    "CATCHINGUP" => Some(Self::Catchingup),
-                    _ => None,
-                }
-            }
         }
         /// consensus related information of the peer.
-        #[allow(clippy::derive_partial_eq_without_eq)]
         #[derive(Clone, PartialEq, ::prost::Oneof)]
         pub enum ConsensusInfo {
             /// The peer is of type `Bootstrapper` is not participating in
@@ -3966,7 +3690,6 @@ pub mod peers_info {
 /// Node info response
 /// Contains various information of the
 /// enquired node.
-#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct NodeInfo {
     /// The version of the node.
@@ -3989,7 +3712,6 @@ pub struct NodeInfo {
 /// Nested message and enum types in `NodeInfo`.
 pub mod node_info {
     /// Network related information of the node.
-    #[allow(clippy::derive_partial_eq_without_eq)]
     #[derive(Clone, PartialEq, ::prost::Message)]
     pub struct NetworkInfo {
         /// The node id.
@@ -4009,7 +3731,6 @@ pub mod node_info {
         pub avg_bps_out:         u64,
     }
     /// Consensus info for a node configured with baker keys.
-    #[allow(clippy::derive_partial_eq_without_eq)]
     #[derive(Clone, PartialEq, ::prost::Message)]
     pub struct BakerConsensusInfo {
         #[prost(message, optional, tag = "1")]
@@ -4023,13 +3744,11 @@ pub mod node_info {
         /// Tagging message type for a node that
         /// is configured with baker keys and active in
         /// the current baking committee
-        #[allow(clippy::derive_partial_eq_without_eq)]
         #[derive(Clone, PartialEq, ::prost::Message)]
         pub struct ActiveBakerCommitteeInfo {}
         /// Tagging message type for a node that
         /// is configured with baker keys and active in
         /// the current finalizer committee (and also baking committee).
-        #[allow(clippy::derive_partial_eq_without_eq)]
         #[derive(Clone, PartialEq, ::prost::Message)]
         pub struct ActiveFinalizerCommitteeInfo {}
         /// The committee information of a node configured with
@@ -4067,20 +3786,8 @@ pub mod node_info {
                     PassiveCommitteeInfo::AddedButWrongKeys => "ADDED_BUT_WRONG_KEYS",
                 }
             }
-
-            /// Creates an enum from field names used in the ProtoBuf
-            /// definition.
-            pub fn from_str_name(value: &str) -> ::core::option::Option<Self> {
-                match value {
-                    "NOT_IN_COMMITTEE" => Some(Self::NotInCommittee),
-                    "ADDED_BUT_NOT_ACTIVE_IN_COMMITTEE" => Some(Self::AddedButNotActiveInCommittee),
-                    "ADDED_BUT_WRONG_KEYS" => Some(Self::AddedButWrongKeys),
-                    _ => None,
-                }
-            }
         }
         /// Status of the baker configured node.
-        #[allow(clippy::derive_partial_eq_without_eq)]
         #[derive(Clone, PartialEq, ::prost::Oneof)]
         pub enum Status {
             /// The node is currently not baking.
@@ -4097,7 +3804,6 @@ pub mod node_info {
         }
     }
     /// The node is a regular node.
-    #[allow(clippy::derive_partial_eq_without_eq)]
     #[derive(Clone, PartialEq, ::prost::Message)]
     pub struct Node {
         #[prost(oneof = "node::ConsensusStatus", tags = "1, 2, 3")]
@@ -4105,7 +3811,6 @@ pub mod node_info {
     }
     /// Nested message and enum types in `Node`.
     pub mod node {
-        #[allow(clippy::derive_partial_eq_without_eq)]
         #[derive(Clone, PartialEq, ::prost::Oneof)]
         pub enum ConsensusStatus {
             /// The node is not running consensus.
@@ -4128,7 +3833,6 @@ pub mod node_info {
         }
     }
     /// Details of the node.
-    #[allow(clippy::derive_partial_eq_without_eq)]
     #[derive(Clone, PartialEq, ::prost::Oneof)]
     pub enum Details {
         /// The node is a bootstrapper and is not running consensus.
@@ -4140,7 +3844,6 @@ pub mod node_info {
         Node(Node),
     }
 }
-#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct SendBlockItemRequest {
     #[prost(oneof = "send_block_item_request::BlockItem", tags = "1, 2, 3")]
@@ -4148,7 +3851,6 @@ pub struct SendBlockItemRequest {
 }
 /// Nested message and enum types in `SendBlockItemRequest`.
 pub mod send_block_item_request {
-    #[allow(clippy::derive_partial_eq_without_eq)]
     #[derive(Clone, PartialEq, ::prost::Oneof)]
     pub enum BlockItem {
         /// Account transactions are messages which are signed and paid for by
@@ -4170,7 +3872,6 @@ pub mod send_block_item_request {
 /// Credential deployments create new accounts. They are not paid for
 /// directly by the sender. Instead, bakers are rewarded by the protocol for
 /// including them.
-#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct CredentialDeployment {
     #[prost(message, optional, tag = "1")]
@@ -4182,7 +3883,6 @@ pub struct CredentialDeployment {
 /// Nested message and enum types in `CredentialDeployment`.
 pub mod credential_deployment {
     /// The credential to be added.
-    #[allow(clippy::derive_partial_eq_without_eq)]
     #[derive(Clone, PartialEq, ::prost::Oneof)]
     pub enum Payload {
         /// A raw payload, which is just the encoded payload.
@@ -4193,7 +3893,6 @@ pub mod credential_deployment {
 }
 /// A single signature. Used when sending block items to a node with
 /// `SendBlockItem`.
-#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct Signature {
     #[prost(bytes = "vec", tag = "1")]
@@ -4201,7 +3900,6 @@ pub struct Signature {
 }
 /// Wrapper for a map from indexes to signatures.
 /// Needed because protobuf doesn't allow nested maps directly.
-#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct SignatureMap {
     #[prost(map = "uint32, message", tag = "1")]
@@ -4210,13 +3908,11 @@ pub struct SignatureMap {
 /// Wrapper for a map from indexes to signatures.
 /// Needed because protobuf doesn't allow nested maps directly.
 /// The keys in the SignatureMap must not exceed 2^8.
-#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct AccountSignatureMap {
     #[prost(map = "uint32, message", tag = "1")]
     pub signatures: ::std::collections::HashMap<u32, Signature>,
 }
-#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct AccountTransactionSignature {
     /// A map from `CredentialIndex` to `SignatureMap`s.
@@ -4228,7 +3924,6 @@ pub struct AccountTransactionSignature {
 /// Header of an account transaction that contains basic data to check whether
 /// the sender and the transaction are valid. The header is shared by all
 /// transaction types.
-#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct AccountTransactionHeader {
     /// Sender of the transaction.
@@ -4237,7 +3932,7 @@ pub struct AccountTransactionHeader {
     /// Sequence number of the transaction.
     #[prost(message, optional, tag = "2")]
     pub sequence_number: ::core::option::Option<SequenceNumber>,
-    /// Maximum amount of nergy the transaction can take to execute.
+    /// Maximum amount of energy the transaction can take to execute.
     #[prost(message, optional, tag = "3")]
     pub energy_amount:   ::core::option::Option<Energy>,
     /// Latest time the transaction can included in a block.
@@ -4245,7 +3940,6 @@ pub struct AccountTransactionHeader {
     pub expiry:          ::core::option::Option<TransactionTime>,
 }
 /// Data required to initialize a new contract instance.
-#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct InitContractPayload {
     /// Amount of CCD to send to the instance.
@@ -4263,7 +3957,6 @@ pub struct InitContractPayload {
     pub parameter:  ::core::option::Option<Parameter>,
 }
 /// Data required to update a contract instance.
-#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct UpdateContractPayload {
     /// Amount of CCD to send to the instance.
@@ -4281,7 +3974,6 @@ pub struct UpdateContractPayload {
     pub parameter:    ::core::option::Option<Parameter>,
 }
 /// Payload of a transfer between two accounts.
-#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct TransferPayload {
     /// Amount of CCD to send.
@@ -4292,7 +3984,6 @@ pub struct TransferPayload {
     pub receiver: ::core::option::Option<AccountAddress>,
 }
 /// Payload of a transfer between two accounts with a memo.
-#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct TransferWithMemoPayload {
     /// Amount of CCD to send.
@@ -4306,7 +3997,6 @@ pub struct TransferWithMemoPayload {
     pub memo:     ::core::option::Option<Memo>,
 }
 /// The payload for an account transaction.
-#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct AccountTransactionPayload {
     #[prost(
@@ -4317,7 +4007,6 @@ pub struct AccountTransactionPayload {
 }
 /// Nested message and enum types in `AccountTransactionPayload`.
 pub mod account_transaction_payload {
-    #[allow(clippy::derive_partial_eq_without_eq)]
     #[derive(Clone, PartialEq, ::prost::Oneof)]
     pub enum Payload {
         /// A pre-serialized payload in the binary serialization format defined
@@ -4341,7 +4030,6 @@ pub mod account_transaction_payload {
 }
 /// An unsigned account transaction. This is used with the
 /// `GetTransactionSignHash` endpoint to obtain the message to sign.
-#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct PreAccountTransaction {
     #[prost(message, optional, tag = "1")]
@@ -4351,7 +4039,6 @@ pub struct PreAccountTransaction {
 }
 /// Account transactions are messages which are signed and paid for by the
 /// sender account.
-#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct AccountTransaction {
     #[prost(message, optional, tag = "1")]
@@ -4361,7 +4048,6 @@ pub struct AccountTransaction {
     #[prost(message, optional, tag = "3")]
     pub payload:   ::core::option::Option<AccountTransactionPayload>,
 }
-#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct UpdateInstructionSignature {
     /// A map from `UpdateKeysIndex` to `Signature`.
@@ -4370,7 +4056,6 @@ pub struct UpdateInstructionSignature {
     #[prost(map = "uint32, message", tag = "1")]
     pub signatures: ::std::collections::HashMap<u32, Signature>,
 }
-#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct UpdateInstructionHeader {
     #[prost(message, optional, tag = "1")]
@@ -4381,7 +4066,6 @@ pub struct UpdateInstructionHeader {
     pub timeout:         ::core::option::Option<TransactionTime>,
 }
 /// The payload for an UpdateInstruction.
-#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct UpdateInstructionPayload {
     #[prost(oneof = "update_instruction_payload::Payload", tags = "3")]
@@ -4389,7 +4073,6 @@ pub struct UpdateInstructionPayload {
 }
 /// Nested message and enum types in `UpdateInstructionPayload`.
 pub mod update_instruction_payload {
-    #[allow(clippy::derive_partial_eq_without_eq)]
     #[derive(Clone, PartialEq, ::prost::Oneof)]
     pub enum Payload {
         /// A raw payload encoded according to the format defined by the
@@ -4398,7 +4081,6 @@ pub mod update_instruction_payload {
         RawPayload(::prost::alloc::vec::Vec<u8>),
     }
 }
-#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct UpdateInstruction {
     /// A map from `UpdateKeysIndex` to `Signature`. Keys must not exceed 2^16.
@@ -4411,7 +4093,6 @@ pub struct UpdateInstruction {
 }
 /// Signature on an account transaction is defined to be the signature on the
 /// hash of the `PreAccountTransaction`.
-#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct AccountTransactionSignHash {
     #[prost(bytes = "vec", tag = "1")]
@@ -4419,14 +4100,12 @@ pub struct AccountTransactionSignHash {
 }
 /// The number of credential deployments allowed in a block. This in effect
 /// determines the number of accounts that can be created in a block.
-#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct CredentialsPerBlockLimit {
     #[prost(uint32, tag = "1")]
     pub value: u32,
 }
 /// Updatable chain parameters that apply to protocol versions 1-3.
-#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct ChainParametersV0 {
     /// Election difficulty for consensus lottery.
@@ -4471,7 +4150,6 @@ pub struct ChainParametersV0 {
     pub level2_keys:                  ::core::option::Option<AuthorizationsV0>,
 }
 /// Updatable chain parameters that apply to protocol versions 4-5.
-#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct ChainParametersV1 {
     /// Election difficulty for consensus lottery.
@@ -4521,7 +4199,6 @@ pub struct ChainParametersV1 {
     pub level2_keys:                  ::core::option::Option<AuthorizationsV1>,
 }
 /// Updatable chain parameters that apply to protocol versions 6.
-#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct ChainParametersV2 {
     /// Consensus parameters.
@@ -4574,7 +4251,6 @@ pub struct ChainParametersV2 {
     pub finalization_committee_parameters: ::core::option::Option<FinalizationCommitteeParameters>,
 }
 /// Chain parameters.
-#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct ChainParameters {
     #[prost(oneof = "chain_parameters::Parameters", tags = "1, 2, 3")]
@@ -4582,7 +4258,6 @@ pub struct ChainParameters {
 }
 /// Nested message and enum types in `ChainParameters`.
 pub mod chain_parameters {
-    #[allow(clippy::derive_partial_eq_without_eq)]
     #[derive(Clone, PartialEq, ::prost::Oneof)]
     pub enum Parameters {
         /// Chain parameters that apply when the block is a protocol version 1-3
@@ -4600,7 +4275,6 @@ pub mod chain_parameters {
     }
 }
 /// Details about a finalizer for the finalization round.
-#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct FinalizationSummaryParty {
     /// Baker ID. Every finalizer is in particular a baker.
@@ -4617,14 +4291,12 @@ pub struct FinalizationSummaryParty {
 }
 /// Index of the finalization round. This increases on each successfully
 /// completed finalization.
-#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct FinalizationIndex {
     #[prost(uint64, tag = "1")]
     pub value: u64,
 }
 /// Details about a finalization record included in a block.
-#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct FinalizationSummary {
     /// Block that was finalized by the finalization record.
@@ -4642,7 +4314,6 @@ pub struct FinalizationSummary {
     pub finalizers: ::prost::alloc::vec::Vec<FinalizationSummaryParty>,
 }
 /// Finalization summary that may or may not be part of the block.
-#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct BlockFinalizationSummary {
     #[prost(oneof = "block_finalization_summary::Summary", tags = "1, 2")]
@@ -4650,7 +4321,6 @@ pub struct BlockFinalizationSummary {
 }
 /// Nested message and enum types in `BlockFinalizationSummary`.
 pub mod block_finalization_summary {
-    #[allow(clippy::derive_partial_eq_without_eq)]
     #[derive(Clone, PartialEq, ::prost::Oneof)]
     pub enum Summary {
         /// There is no finalization data in the block.
@@ -4661,7 +4331,6 @@ pub mod block_finalization_summary {
         Record(super::FinalizationSummary),
     }
 }
-#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct BlockItem {
     /// The hash of the block item that identifies it to the chain.
@@ -4672,7 +4341,6 @@ pub struct BlockItem {
 }
 /// Nested message and enum types in `BlockItem`.
 pub mod block_item {
-    #[allow(clippy::derive_partial_eq_without_eq)]
     #[derive(Clone, PartialEq, ::prost::Oneof)]
     pub enum BlockItem {
         /// Account transactions are messages which are signed and paid for by
@@ -4693,7 +4361,6 @@ pub mod block_item {
 }
 /// Information about a particular baker with respect to
 /// the current reward period.
-#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct BakerRewardPeriodInfo {
     /// The baker id and public keys for the baker.
@@ -4719,7 +4386,6 @@ pub struct BakerRewardPeriodInfo {
     pub is_finalizer:      bool,
 }
 /// The signature of a 'QuorumCertificate'.
-#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct QuorumSignature {
     /// The bytes representing the raw aggregate signature.
@@ -4731,7 +4397,6 @@ pub struct QuorumSignature {
 /// finalization comittee issues in order to certify a block.
 /// A block must be certified before it will be part of the
 /// authorative part of the chain.
-#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct QuorumCertificate {
     /// The hash of the block that the quorum certificate refers to.
@@ -4756,7 +4421,6 @@ pub struct QuorumCertificate {
 /// The finalizer round is a map from a 'Round'
 /// to the list of finalizers (identified by their 'BakerId') that signed
 /// off the round.
-#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct FinalizerRound {
     /// The round that was signed off.
@@ -4768,7 +4432,6 @@ pub struct FinalizerRound {
     pub finalizers: ::prost::alloc::vec::Vec<BakerId>,
 }
 /// The signature of a 'TimeoutCertificate'.
-#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct TimeoutSignature {
     /// The bytes representing the raw aggregate signature.
@@ -4780,7 +4443,6 @@ pub struct TimeoutSignature {
 /// finalization committee issues when a round times out,
 /// thus making it possible for the protocol to proceed to the
 /// next round.
-#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct TimeoutCertificate {
     /// The round that timed out.
@@ -4806,7 +4468,6 @@ pub struct TimeoutCertificate {
 /// A proof that establishes that the successor block of
 /// a 'EpochFinalizationEntry' is the immediate successor of
 /// the finalized block.
-#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct SuccessorProof {
     /// The proof represented as raw bytes.
@@ -4818,7 +4479,6 @@ pub struct SuccessorProof {
 /// makes the protocol able to advance to a new epoch.
 /// I.e. the 'EpochFinalizationEntry' is present if and only if
 /// the block is the first block of a new 'Epoch'.
-#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct EpochFinalizationEntry {
     /// The quorum certificate for the finalized block.
@@ -4835,7 +4495,6 @@ pub struct EpochFinalizationEntry {
 }
 /// Certificates for a block for protocols supporting
 /// ConcordiumBFT.
-#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct BlockCertificates {
     /// The quorum certificate. Is present if and only if the block is
@@ -4853,7 +4512,6 @@ pub struct BlockCertificates {
 }
 /// Details of which baker won the lottery in a given round in consensus version
 /// 1.
-#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct WinningBaker {
     /// The round number.
@@ -4866,6 +4524,375 @@ pub struct WinningBaker {
     /// and False otherwise.
     #[prost(bool, tag = "3")]
     pub present: bool,
+}
+/// An operation to dry run.
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct DryRunRequest {
+    #[prost(oneof = "dry_run_request::Request", tags = "1, 2, 3")]
+    pub request: ::core::option::Option<dry_run_request::Request>,
+}
+/// Nested message and enum types in `DryRunRequest`.
+pub mod dry_run_request {
+    #[derive(Clone, PartialEq, ::prost::Oneof)]
+    pub enum Request {
+        /// Load the state of the specified block to use for subsequent
+        /// requests. The state is taken at the end of execution of the
+        /// block, and the block’s timestamp is used as the current
+        /// timestamp.
+        #[prost(message, tag = "1")]
+        LoadBlockState(super::BlockHashInput),
+        /// Run a query on the state.
+        #[prost(message, tag = "2")]
+        StateQuery(super::DryRunStateQuery),
+        /// Run a (non-transaction) operation to modify the state.
+        #[prost(message, tag = "3")]
+        StateOperation(super::DryRunStateOperation),
+    }
+}
+/// Run a query as part of a dry run. Queries do not update the block state.
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct DryRunStateQuery {
+    #[prost(oneof = "dry_run_state_query::Query", tags = "1, 2, 3")]
+    pub query: ::core::option::Option<dry_run_state_query::Query>,
+}
+/// Nested message and enum types in `DryRunStateQuery`.
+pub mod dry_run_state_query {
+    #[derive(Clone, PartialEq, ::prost::Oneof)]
+    pub enum Query {
+        /// Look up information on a particular account.
+        #[prost(message, tag = "1")]
+        GetAccountInfo(super::AccountIdentifierInput),
+        /// Look up information about a particular smart contract.
+        #[prost(message, tag = "2")]
+        GetInstanceInfo(super::ContractAddress),
+        /// Invoke an entrypoint on a smart contract instance.
+        /// No changes made to the state are retained at the completion of the
+        /// operation.
+        #[prost(message, tag = "3")]
+        InvokeInstance(super::DryRunInvokeInstance),
+    }
+}
+/// Invoke an entrypoint on a smart contract instance.
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct DryRunInvokeInstance {
+    /// Invoker of the contract. If this is not supplied then the contract will
+    /// be invoked by an account with address 0, no credentials and
+    /// sufficient amount of CCD to cover the transfer amount. If given, the
+    /// relevant address (either account or contract) must exist in the
+    /// blockstate.
+    #[prost(message, optional, tag = "1")]
+    pub invoker:    ::core::option::Option<Address>,
+    /// Address of the contract instance to invoke.
+    #[prost(message, optional, tag = "2")]
+    pub instance:   ::core::option::Option<ContractAddress>,
+    /// Amount to invoke the smart contract instance with.
+    #[prost(message, optional, tag = "3")]
+    pub amount:     ::core::option::Option<Amount>,
+    /// The entrypoint of the smart contract instance to invoke.
+    #[prost(message, optional, tag = "4")]
+    pub entrypoint: ::core::option::Option<ReceiveName>,
+    /// The parameter bytes to include in the invocation of the entrypoint.
+    #[prost(message, optional, tag = "5")]
+    pub parameter:  ::core::option::Option<Parameter>,
+    /// The maximum energy to allow for the invocation. Note that the node
+    /// imposes an energy quota that is enforced in addition to this limit.
+    #[prost(message, optional, tag = "6")]
+    pub energy:     ::core::option::Option<Energy>,
+}
+/// An operation that can update the state as part of a dry run.
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct DryRunStateOperation {
+    #[prost(oneof = "dry_run_state_operation::Operation", tags = "1, 2, 3")]
+    pub operation: ::core::option::Option<dry_run_state_operation::Operation>,
+}
+/// Nested message and enum types in `DryRunStateOperation`.
+pub mod dry_run_state_operation {
+    #[derive(Clone, PartialEq, ::prost::Oneof)]
+    pub enum Operation {
+        /// Sets the current block time to the given timestamp for the purposes
+        /// of future transactions.
+        #[prost(message, tag = "1")]
+        SetTimestamp(super::Timestamp),
+        /// Add a specified amount of newly-minted CCDs to a specified account.
+        /// The amount cannot cause the total circulating supply to overflow.
+        #[prost(message, tag = "2")]
+        MintToAccount(super::DryRunMintToAccount),
+        /// Dry run a transaction, updating the state if it succeeds.
+        #[prost(message, tag = "3")]
+        RunTransaction(super::DryRunTransaction),
+    }
+}
+/// Mint a specified amount and credit it to the specified account as part of a
+/// dry run.
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct DryRunMintToAccount {
+    /// The account to mint to.
+    #[prost(message, optional, tag = "1")]
+    pub account: ::core::option::Option<AccountAddress>,
+    /// The amount to mint and credit to the account.
+    #[prost(message, optional, tag = "2")]
+    pub amount:  ::core::option::Option<Amount>,
+}
+/// Dry run an account transaction
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct DryRunTransaction {
+    /// The account to use as the sender of the transaction.
+    #[prost(message, optional, tag = "1")]
+    pub sender:        ::core::option::Option<AccountAddress>,
+    /// The energy limit set for executing the transaction.
+    #[prost(message, optional, tag = "2")]
+    pub energy_amount: ::core::option::Option<Energy>,
+    /// The payload of the transaction.
+    #[prost(message, optional, tag = "3")]
+    pub payload:       ::core::option::Option<AccountTransactionPayload>,
+    /// Which credentials and keys should be treated as having signed the
+    /// transaction. If none is given, then the transaction is treated as
+    /// having one signature for credential 0, key 0. Therefore, this is
+    /// only required when the transaction is from a multi-signature
+    /// account. There two reason why you might want to specify signatures:
+    ///    * The cost of the transaction depends on the number of signatures, so
+    ///      if you want to get the correct cost for a multi-signature
+    ///      transaction, then specifying the signatures supports this.
+    ///    * When changing account keys on a multi-credential account, the
+    ///      transaction must be signed by the credential whose keys are being
+    ///      changed.
+    ///
+    /// Note that the signature thresholds are not checked as part of the dry
+    /// run. Duplicated signatures are only counted once.
+    #[prost(message, repeated, tag = "4")]
+    pub signatures:    ::prost::alloc::vec::Vec<DryRunSignature>,
+}
+/// A dry run signature is a pair of a credential index and key index,
+/// identifying the credential and key that is presumed to have signed the
+/// transaction. No actual cryptographic signature is included.
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct DryRunSignature {
+    /// Credential index. Must not exceed 255.
+    #[prost(uint32, tag = "1")]
+    pub credential: u32,
+    /// Key index. Must not exceed 255.
+    #[prost(uint32, tag = "2")]
+    pub key:        u32,
+}
+/// A response to a `DryRunRequest`.
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct DryRunResponse {
+    /// The remaining available energy quota after the dry run operation.
+    #[prost(message, optional, tag = "3")]
+    pub quota_remaining: ::core::option::Option<Energy>,
+    #[prost(oneof = "dry_run_response::Response", tags = "1, 2")]
+    pub response:        ::core::option::Option<dry_run_response::Response>,
+}
+/// Nested message and enum types in `DryRunResponse`.
+pub mod dry_run_response {
+    #[derive(Clone, PartialEq, ::prost::Oneof)]
+    pub enum Response {
+        /// The request produced an error. The request otherwise has no effect
+        /// on the state.
+        #[prost(message, tag = "1")]
+        Error(super::DryRunErrorResponse),
+        /// The request was successful.
+        #[prost(message, tag = "2")]
+        Success(super::DryRunSuccessResponse),
+    }
+}
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct DryRunErrorResponse {
+    #[prost(
+        oneof = "dry_run_error_response::Error",
+        tags = "1, 2, 3, 4, 5, 6, 8, 10"
+    )]
+    pub error: ::core::option::Option<dry_run_error_response::Error>,
+}
+/// Nested message and enum types in `DryRunErrorResponse`.
+pub mod dry_run_error_response {
+    #[derive(Clone, PartialEq, ::prost::Oneof)]
+    pub enum Error {
+        /// The current block state is undefined. It should be initialized with
+        /// a 'load_block_state' request before any other operations.
+        #[prost(message, tag = "1")]
+        NoState(super::DryRunErrorNoState),
+        /// The requested block was not found, so its state could not be loaded.
+        /// Response to 'load_block_state'.
+        #[prost(message, tag = "2")]
+        BlockNotFound(super::DryRunErrorBlockNotFound),
+        /// The specified account was not found.
+        /// Response to 'get_account_info', 'mint_to_account' and
+        /// 'run_transaction'.
+        #[prost(message, tag = "3")]
+        AccountNotFound(super::DryRunErrorAccountNotFound),
+        /// The specified instance was not found.
+        /// Response to 'get_instance_info'.
+        #[prost(message, tag = "4")]
+        InstanceNotFound(super::DryRunErrorInstanceNotFound),
+        /// The amount to mint would overflow the total CCD supply.
+        /// Response to 'mint_to_account'.
+        #[prost(message, tag = "5")]
+        AmountOverLimit(super::DryRunErrorAmountOverLimit),
+        /// The balance of the sender account is not sufficient to pay for the
+        /// operation. Response to 'run_transaction'.
+        #[prost(message, tag = "6")]
+        BalanceInsufficient(super::DryRunErrorBalanceInsufficient),
+        /// The energy supplied for the transaction was not sufficient to
+        /// perform the basic checks. Response to 'run_transaction'.
+        #[prost(message, tag = "8")]
+        EnergyInsufficient(super::DryRunErrorEnergyInsufficient),
+        /// The contract invocation failed.
+        /// Response to 'invoke_instance'.
+        #[prost(message, tag = "10")]
+        InvokeFailed(super::DryRunErrorInvokeFailure),
+    }
+}
+/// The current block state is undefined. It should be initialized with
+/// a 'load_block_state' request before any other operations.
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct DryRunErrorNoState {}
+/// The requested block was not found, so its state could not be loaded.
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct DryRunErrorBlockNotFound {}
+/// The specified account was not found.
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct DryRunErrorAccountNotFound {}
+/// The specified instance was not found.
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct DryRunErrorInstanceNotFound {}
+/// The amount that was requested to be minted would overflow the total supply.
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct DryRunErrorAmountOverLimit {
+    /// The maximum amount that can be minted without overflowing the supply.
+    #[prost(message, optional, tag = "1")]
+    pub amount_limit: ::core::option::Option<Amount>,
+}
+/// The sender account for the transaction has insufficient balance to pay the
+/// preliminary fees for the transaction to be included in a block.
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct DryRunErrorBalanceInsufficient {
+    /// The minimum balance required to perform the operation.
+    #[prost(message, optional, tag = "1")]
+    pub required_amount:  ::core::option::Option<Amount>,
+    /// The currently-available balance on the account to pay for the operation.
+    #[prost(message, optional, tag = "2")]
+    pub available_amount: ::core::option::Option<Amount>,
+}
+/// The energy made available for the transaction is insufficient to cover the
+/// basic processing required to include a transaction in a block.
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct DryRunErrorEnergyInsufficient {
+    /// The minimum energy required for the transaction to be included in the
+    /// chain. Note that this does not guarantee that
+    #[prost(message, optional, tag = "1")]
+    pub energy_required: ::core::option::Option<Energy>,
+}
+/// Invoking the smart contract instance failed.
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct DryRunErrorInvokeFailure {
+    /// If invoking a V0 contract this is not provided, otherwise it is
+    /// potentially return value produced by the call unless the call failed
+    /// with out of energy or runtime error. If the V1 contract terminated
+    /// with a logic error then the return value is present.
+    #[prost(bytes = "vec", optional, tag = "1")]
+    pub return_value: ::core::option::Option<::prost::alloc::vec::Vec<u8>>,
+    /// Energy used by the execution.
+    #[prost(message, optional, tag = "2")]
+    pub used_energy:  ::core::option::Option<Energy>,
+    /// Contract execution failed for the given reason.
+    #[prost(message, optional, tag = "3")]
+    pub reason:       ::core::option::Option<RejectReason>,
+}
+/// The dry run operation completed successfully.
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct DryRunSuccessResponse {
+    #[prost(
+        oneof = "dry_run_success_response::Response",
+        tags = "1, 2, 3, 4, 5, 6, 7, 8"
+    )]
+    pub response: ::core::option::Option<dry_run_success_response::Response>,
+}
+/// Nested message and enum types in `DryRunSuccessResponse`.
+pub mod dry_run_success_response {
+    #[derive(Clone, PartialEq, ::prost::Oneof)]
+    pub enum Response {
+        /// The state from the specified block was successfully loaded.
+        /// Response to 'load_block_state'.
+        #[prost(message, tag = "1")]
+        BlockStateLoaded(super::DryRunBlockStateLoaded),
+        /// Details of the requested account.
+        /// Response to 'get_account_info'.
+        #[prost(message, tag = "2")]
+        AccountInfo(super::AccountInfo),
+        /// Details of the requested smart contract instance.
+        /// Response to 'get_instance_info'.
+        #[prost(message, tag = "3")]
+        InstanceInfo(super::InstanceInfo),
+        /// The state of the contract instance at the specified key.
+        /// Response to 'get_instance_state'.
+        #[prost(message, tag = "4")]
+        InstancePartialState(super::InstanceStateValueAtKey),
+        /// The current timestamp was set successfully.
+        /// Response to 'set_timestamp'.
+        #[prost(message, tag = "5")]
+        TimestampSet(super::DryRunTimestampSet),
+        /// The specified amount was minted and credited to the account.
+        /// Response to 'mint_to_account'.
+        #[prost(message, tag = "6")]
+        MintedToAccount(super::DryRunMintedToAccount),
+        /// The specified transaction was executed. Note that the transaction
+        /// could still have been rejected.
+        /// Response to 'run_transaction'.
+        #[prost(message, tag = "7")]
+        TransactionExecuted(super::DryRunTransactionExecuted),
+        /// The smart contract instance was invoked successfully.
+        #[prost(message, tag = "8")]
+        InvokeSucceeded(super::DryRunInvokeSuccess),
+    }
+}
+/// The block state at the specified block was successfully loaded.
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct DryRunBlockStateLoaded {
+    /// The timestamp of the block, taken to be the current timestamp.
+    #[prost(message, optional, tag = "1")]
+    pub current_timestamp: ::core::option::Option<Timestamp>,
+    /// The hash of the block that was loaded.
+    #[prost(message, optional, tag = "2")]
+    pub block_hash:        ::core::option::Option<BlockHash>,
+    /// The protocol version at the specified block. The behavior of operations
+    /// can vary across protocol versions.
+    #[prost(enumeration = "ProtocolVersion", tag = "3")]
+    pub protocol_version:  i32,
+}
+/// The current apparent timestamp was updated to the specified value.
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct DryRunTimestampSet {}
+/// The specified amount was minted to the specified account.
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct DryRunMintedToAccount {}
+/// The transaction was executed.
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct DryRunTransactionExecuted {
+    /// The amount of energy actually expended in executing the transaction.
+    #[prost(message, optional, tag = "1")]
+    pub energy_cost:  ::core::option::Option<Energy>,
+    /// The details of the outcome of the transaction.
+    #[prost(message, optional, tag = "2")]
+    pub details:      ::core::option::Option<AccountTransactionDetails>,
+    /// If this is an invocation of a V1 contract that produced a return value,
+    /// this is that value. Otherwise it is absent.
+    #[prost(bytes = "vec", optional, tag = "3")]
+    pub return_value: ::core::option::Option<::prost::alloc::vec::Vec<u8>>,
+}
+/// The smart contract instance was invoked successfully.
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct DryRunInvokeSuccess {
+    /// If invoking a V0 contract this is absent. Otherwise it is the return
+    /// value produced by the contract.
+    #[prost(bytes = "vec", optional, tag = "1")]
+    pub return_value: ::core::option::Option<::prost::alloc::vec::Vec<u8>>,
+    /// Energy used by the execution.
+    #[prost(message, optional, tag = "2")]
+    pub used_energy:  ::core::option::Option<Energy>,
+    /// Effects produced by contract execution.
+    #[prost(message, repeated, tag = "3")]
+    pub effects:      ::prost::alloc::vec::Vec<ContractTraceElement>,
 }
 /// Information about how open the pool is to new delegators.
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, ::prost::Enumeration)]
@@ -4888,16 +4915,6 @@ impl OpenStatus {
             OpenStatus::ClosedForAll => "OPEN_STATUS_CLOSED_FOR_ALL",
         }
     }
-
-    /// Creates an enum from field names used in the ProtoBuf definition.
-    pub fn from_str_name(value: &str) -> ::core::option::Option<Self> {
-        match value {
-            "OPEN_STATUS_OPEN_FOR_ALL" => Some(Self::OpenForAll),
-            "OPEN_STATUS_CLOSED_FOR_NEW" => Some(Self::ClosedForNew),
-            "OPEN_STATUS_CLOSED_FOR_ALL" => Some(Self::ClosedForAll),
-            _ => None,
-        }
-    }
 }
 /// Version of smart contract.
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, ::prost::Enumeration)]
@@ -4916,15 +4933,6 @@ impl ContractVersion {
         match self {
             ContractVersion::V0 => "V0",
             ContractVersion::V1 => "V1",
-        }
-    }
-
-    /// Creates an enum from field names used in the ProtoBuf definition.
-    pub fn from_str_name(value: &str) -> ::core::option::Option<Self> {
-        match value {
-            "V0" => Some(Self::V0),
-            "V1" => Some(Self::V1),
-            _ => None,
         }
     }
 }
@@ -4947,15 +4955,6 @@ impl CredentialType {
         match self {
             CredentialType::Initial => "CREDENTIAL_TYPE_INITIAL",
             CredentialType::Normal => "CREDENTIAL_TYPE_NORMAL",
-        }
-    }
-
-    /// Creates an enum from field names used in the ProtoBuf definition.
-    pub fn from_str_name(value: &str) -> ::core::option::Option<Self> {
-        match value {
-            "CREDENTIAL_TYPE_INITIAL" => Some(Self::Initial),
-            "CREDENTIAL_TYPE_NORMAL" => Some(Self::Normal),
-            _ => None,
         }
     }
 }
@@ -5014,35 +5013,6 @@ impl UpdateType {
             UpdateType::UpdateFinalizationCommitteeParameters => {
                 "UPDATE_FINALIZATION_COMMITTEE_PARAMETERS"
             }
-        }
-    }
-
-    /// Creates an enum from field names used in the ProtoBuf definition.
-    pub fn from_str_name(value: &str) -> ::core::option::Option<Self> {
-        match value {
-            "UPDATE_PROTOCOL" => Some(Self::UpdateProtocol),
-            "UPDATE_ELECTION_DIFFICULTY" => Some(Self::UpdateElectionDifficulty),
-            "UPDATE_EURO_PER_ENERGY" => Some(Self::UpdateEuroPerEnergy),
-            "UPDATE_MICRO_CCD_PER_EURO" => Some(Self::UpdateMicroCcdPerEuro),
-            "UPDATE_FOUNDATION_ACCOUNT" => Some(Self::UpdateFoundationAccount),
-            "UPDATE_MINT_DISTRIBUTION" => Some(Self::UpdateMintDistribution),
-            "UPDATE_TRANSACTION_FEE_DISTRIBUTION" => Some(Self::UpdateTransactionFeeDistribution),
-            "UPDATE_GAS_REWARDS" => Some(Self::UpdateGasRewards),
-            "UPDATE_POOL_PARAMETERS" => Some(Self::UpdatePoolParameters),
-            "ADD_ANONYMITY_REVOKER" => Some(Self::AddAnonymityRevoker),
-            "ADD_IDENTITY_PROVIDER" => Some(Self::AddIdentityProvider),
-            "UPDATE_ROOT_KEYS" => Some(Self::UpdateRootKeys),
-            "UPDATE_LEVEL1_KEYS" => Some(Self::UpdateLevel1Keys),
-            "UPDATE_LEVEL2_KEYS" => Some(Self::UpdateLevel2Keys),
-            "UPDATE_COOLDOWN_PARAMETERS" => Some(Self::UpdateCooldownParameters),
-            "UPDATE_TIME_PARAMETERS" => Some(Self::UpdateTimeParameters),
-            "UPDATE_TIMEOUT_PARAMETERS" => Some(Self::UpdateTimeoutParameters),
-            "UPDATE_MIN_BLOCK_TIME" => Some(Self::UpdateMinBlockTime),
-            "UPDATE_BLOCK_ENERGY_LIMIT" => Some(Self::UpdateBlockEnergyLimit),
-            "UPDATE_FINALIZATION_COMMITTEE_PARAMETERS" => {
-                Some(Self::UpdateFinalizationCommitteeParameters)
-            }
-            _ => None,
         }
     }
 }
@@ -5105,34 +5075,6 @@ impl TransactionType {
             TransactionType::ConfigureDelegation => "CONFIGURE_DELEGATION",
         }
     }
-
-    /// Creates an enum from field names used in the ProtoBuf definition.
-    pub fn from_str_name(value: &str) -> ::core::option::Option<Self> {
-        match value {
-            "DEPLOY_MODULE" => Some(Self::DeployModule),
-            "INIT_CONTRACT" => Some(Self::InitContract),
-            "UPDATE" => Some(Self::Update),
-            "TRANSFER" => Some(Self::Transfer),
-            "ADD_BAKER" => Some(Self::AddBaker),
-            "REMOVE_BAKER" => Some(Self::RemoveBaker),
-            "UPDATE_BAKER_STAKE" => Some(Self::UpdateBakerStake),
-            "UPDATE_BAKER_RESTAKE_EARNINGS" => Some(Self::UpdateBakerRestakeEarnings),
-            "UPDATE_BAKER_KEYS" => Some(Self::UpdateBakerKeys),
-            "UPDATE_CREDENTIAL_KEYS" => Some(Self::UpdateCredentialKeys),
-            "ENCRYPTED_AMOUNT_TRANSFER" => Some(Self::EncryptedAmountTransfer),
-            "TRANSFER_TO_ENCRYPTED" => Some(Self::TransferToEncrypted),
-            "TRANSFER_TO_PUBLIC" => Some(Self::TransferToPublic),
-            "TRANSFER_WITH_SCHEDULE" => Some(Self::TransferWithSchedule),
-            "UPDATE_CREDENTIALS" => Some(Self::UpdateCredentials),
-            "REGISTER_DATA" => Some(Self::RegisterData),
-            "TRANSFER_WITH_MEMO" => Some(Self::TransferWithMemo),
-            "ENCRYPTED_AMOUNT_TRANSFER_WITH_MEMO" => Some(Self::EncryptedAmountTransferWithMemo),
-            "TRANSFER_WITH_SCHEDULE_AND_MEMO" => Some(Self::TransferWithScheduleAndMemo),
-            "CONFIGURE_BAKER" => Some(Self::ConfigureBaker),
-            "CONFIGURE_DELEGATION" => Some(Self::ConfigureDelegation),
-            _ => None,
-        }
-    }
 }
 /// The different versions of the protocol.
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, ::prost::Enumeration)]
@@ -5159,19 +5101,6 @@ impl ProtocolVersion {
             ProtocolVersion::ProtocolVersion4 => "PROTOCOL_VERSION_4",
             ProtocolVersion::ProtocolVersion5 => "PROTOCOL_VERSION_5",
             ProtocolVersion::ProtocolVersion6 => "PROTOCOL_VERSION_6",
-        }
-    }
-
-    /// Creates an enum from field names used in the ProtoBuf definition.
-    pub fn from_str_name(value: &str) -> ::core::option::Option<Self> {
-        match value {
-            "PROTOCOL_VERSION_1" => Some(Self::ProtocolVersion1),
-            "PROTOCOL_VERSION_2" => Some(Self::ProtocolVersion2),
-            "PROTOCOL_VERSION_3" => Some(Self::ProtocolVersion3),
-            "PROTOCOL_VERSION_4" => Some(Self::ProtocolVersion4),
-            "PROTOCOL_VERSION_5" => Some(Self::ProtocolVersion5),
-            "PROTOCOL_VERSION_6" => Some(Self::ProtocolVersion6),
-            _ => None,
         }
     }
 }
@@ -6154,8 +6083,8 @@ pub mod queries_client {
             self.inner.unary(request.into_request(), path, codec).await
         }
 
-        /// / Get a list of the peers that the node is connected to
-        /// / and assoicated network related information for each peer.
+        //// Get a list of the peers that the node is connected to
+        //// and assoicated network related information for each peer.
         pub async fn get_peers_info(
             &mut self,
             request: impl tonic::IntoRequest<super::Empty>,
@@ -6361,13 +6290,13 @@ pub mod queries_client {
         ///  * `NOT_FOUND` if the query specifies an unknown block.
         ///  * `UNAVAILABLE` if the query is for an epoch that is not finalized
         ///    in the current genesis
-        /// /    index, or is for a future genesis index.
+        ////    index, or is for a future genesis index.
         ///  * `INVALID_ARGUMENT` if the query is for an epoch that is not
         ///    finalized for a past genesis index.
         ///  * `INVALID_ARGUMENT` if the query is for a genesis index at
         ///    consensus version 0.
         ///  * `INVALID_ARGUMENT` if the input `EpochRequest` is malformed.
-        ///  * `UNAVAILABLE` if the endpoint is disabled on the node.
+        ///  * `UNIMPLEMENTED` if the endpoint is disabled on the node.
         pub async fn get_winning_bakers_epoch(
             &mut self,
             request: impl tonic::IntoRequest<super::EpochRequest>,
@@ -6398,7 +6327,7 @@ pub mod queries_client {
         ///  * `INVALID_ARGUMENT` if the query is for an epoch with no finalized
         ///    blocks for a past genesis index.
         ///  * `INVALID_ARGUMENT` if the input `EpochRequest` is malformed.
-        ///  * `UNAVAILABLE` if the endpoint is disabled on the node.
+        ///  * `UNIMPLEMENTED` if the endpoint is disabled on the node.
         pub async fn get_first_block_epoch(
             &mut self,
             request: impl tonic::IntoRequest<super::EpochRequest>,
@@ -6413,6 +6342,33 @@ pub mod queries_client {
             let path =
                 http::uri::PathAndQuery::from_static("/concordium.v2.Queries/GetFirstBlockEpoch");
             self.inner.unary(request.into_request(), path, codec).await
+        }
+
+        /// Dry run a series of transactions and operations on a state derived
+        /// from a specified block. The server should send a single
+        /// `DryRunResponse` for each `DryRunRequest` received, unless
+        /// the call fails with an error status code. If a request produces a
+        /// `DryRunErrorResponse`, then the server will still process
+        /// subsequent requests, just as if the request causing the error
+        /// did not happen.
+        ///
+        /// The first request should be `load_block_at_state`
+        pub async fn dry_run(
+            &mut self,
+            request: impl tonic::IntoStreamingRequest<Message = super::DryRunRequest>,
+        ) -> Result<tonic::Response<tonic::codec::Streaming<super::DryRunResponse>>, tonic::Status>
+        {
+            self.inner.ready().await.map_err(|e| {
+                tonic::Status::new(
+                    tonic::Code::Unknown,
+                    format!("Service was not ready: {}", e.into()),
+                )
+            })?;
+            let codec = tonic::codec::ProstCodec::default();
+            let path = http::uri::PathAndQuery::from_static("/concordium.v2.Queries/DryRun");
+            self.inner
+                .streaming(request.into_streaming_request(), path, codec)
+                .await
         }
     }
 }

--- a/src/v2/mod.rs
+++ b/src/v2/mod.rs
@@ -49,6 +49,7 @@ pub use tonic::{
 };
 
 mod conversions;
+pub mod dry_run;
 #[path = "generated/concordium.v2.rs"]
 #[allow(
     clippy::large_enum_variant,
@@ -1591,6 +1592,12 @@ impl Client {
             block_hash,
             response,
         })
+    }
+
+    /// Start a dry-run sequence that can be used to simulate a series of
+    /// transactions and other operations on the node.
+    pub async fn dry_run(&mut self) -> endpoints::QueryResult<dry_run::DryRun> {
+        dry_run::DryRun::new(&mut self.client).await
     }
 
     /// Get information, such as height, timings, and transaction counts for the

--- a/src/v2/mod.rs
+++ b/src/v2/mod.rs
@@ -1597,7 +1597,7 @@ impl Client {
     /// Start a dry-run sequence that can be used to simulate a series of
     /// transactions and other operations on the node.
     pub async fn dry_run(&mut self) -> endpoints::QueryResult<dry_run::DryRun> {
-        dry_run::DryRun::new(&mut self.client).await
+        Ok(dry_run::DryRun::new(&mut self.client).await?)
     }
 
     /// Get information, such as height, timings, and transaction counts for the

--- a/src/v2/mod.rs
+++ b/src/v2/mod.rs
@@ -49,6 +49,8 @@ pub use tonic::{
     Code, Status,
 };
 
+use self::dry_run::WithRemainingQuota;
+
 mod conversions;
 pub mod dry_run;
 #[path = "generated/concordium.v2.rs"]
@@ -1618,8 +1620,23 @@ impl Client {
     /// Before invoking any other operations on the [`dry_run::DryRun`] object,
     /// the state must be loaded by calling
     /// [`dry_run::DryRun::load_block_state`].
-    pub async fn dry_run(&mut self) -> endpoints::QueryResult<dry_run::DryRun> {
+    pub async fn begin_dry_run(&mut self) -> endpoints::QueryResult<dry_run::DryRun> {
         Ok(dry_run::DryRun::new(&mut self.client).await?)
+    }
+
+    /// Start a dry-run sequence that can be used to simulate a series of
+    /// transactions and other operations on the node, starting from the
+    /// specified block.
+    pub async fn dry_run(
+        &mut self,
+        bi: impl IntoBlockIdentifier,
+    ) -> dry_run::DryRunResult<(dry_run::DryRun, dry_run::BlockStateLoaded)> {
+        let mut runner = dry_run::DryRun::new(&mut self.client).await?;
+        let load_result = runner.load_block_state(bi).await?;
+        Ok(WithRemainingQuota {
+            inner:           (runner, load_result.inner),
+            quota_remaining: load_result.quota_remaining,
+        })
     }
 
     /// Get information, such as height, timings, and transaction counts for the

--- a/src/v2/mod.rs
+++ b/src/v2/mod.rs
@@ -1596,6 +1596,10 @@ impl Client {
 
     /// Start a dry-run sequence that can be used to simulate a series of
     /// transactions and other operations on the node.
+    ///
+    /// Before invoking any other operations on the [`dry_run::DryRun`] object,
+    /// the state must be loaded by calling
+    /// [`dry_run::DryRun::load_block_state`].
     pub async fn dry_run(&mut self) -> endpoints::QueryResult<dry_run::DryRun> {
         Ok(dry_run::DryRun::new(&mut self.client).await?)
     }

--- a/src/v2/proto_schema_version.rs
+++ b/src/v2/proto_schema_version.rs
@@ -1,1 +1,1 @@
-pub const PROTO_SCHEMA_VERSION: &str = "ccf5e323e8af9850c89747c77f9a508227b3d63c";
+pub const PROTO_SCHEMA_VERSION: &str = "ac623ef433e41a3fd6fed8ea6d17c8a9d1b15ba4";

--- a/src/v2/proto_schema_version.rs
+++ b/src/v2/proto_schema_version.rs
@@ -1,1 +1,1 @@
-pub const PROTO_SCHEMA_VERSION: &str = "ac623ef433e41a3fd6fed8ea6d17c8a9d1b15ba4";
+pub const PROTO_SCHEMA_VERSION: &str = "127ae875b28c6596eee2350466c4c584c1f8f00a";

--- a/src/v2/proto_schema_version.rs
+++ b/src/v2/proto_schema_version.rs
@@ -1,1 +1,1 @@
-pub const PROTO_SCHEMA_VERSION: &str = "c079fde30b8b39d475f6dd8c049a9357bef0ab3c";
+pub const PROTO_SCHEMA_VERSION: &str = "ccf5e323e8af9850c89747c77f9a508227b3d63c";

--- a/src/v2/proto_schema_version.rs
+++ b/src/v2/proto_schema_version.rs
@@ -1,1 +1,1 @@
-pub const PROTO_SCHEMA_VERSION: &str = "127ae875b28c6596eee2350466c4c584c1f8f00a";
+pub const PROTO_SCHEMA_VERSION: &str = "68c46223ccbc05ddc4923836a20d8e10abad02c4";


### PR DESCRIPTION
## Purpose

Expose the dry run GRPC endpoint in the API.

## Changes

- Implement a `DryRun` struct that encapsulates a dry-run session and exposes each of the operations in a convenient fashion.
- A simple example using the dry run endpoint.

## Checklist

- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [x] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [x] (If necessary) I have updated the CHANGELOG.
