### PR TITLE
Add indexer for all transaction outcomes and special outcomes.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 - Support protocol version 7.
 - Support for smart contract debugging when running locally.
 - Remove JSON serialization support of BlockSummary.
+- Add an additional `indexer` to index all transaction outcomes and special events.
 
 ## 3.2.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
   the chain.
 - Support protocol version 7.
 - Support for smart contract debugging when running locally.
+- Remove JSON serialization support of BlockSummary.
 
 ## 3.2.0
 


### PR DESCRIPTION
## Purpose

Add an additional indexer to index both normal and special events.

Remove obsolete JSON serialization of blocksummary. Not needed since V1 API has been removed.

## Checklist

- [ ] My code follows the style of this project.
- [ ] The code compiles without warnings.
- [ ] I have performed a self-review of the changes.
- [ ] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [ ] (If necessary) I have updated the CHANGELOG.
