### PR TITLE
Add new convenience methods to the contract client for sending contract updates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@
 - Add `dry_run_update` and `dry_run_update_raw` methods to the `ContractClient`
   to simulate smart contract updates. The return values of these can be used to
   immediately sign and send a transaction.
+- Update `rand` dependency to `0.8`.
 
 ## 3.2.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,11 @@
 - Support for smart contract debugging when running locally.
 - Remove JSON serialization support of BlockSummary.
 - Add an additional `indexer` to index all transaction outcomes and special events.
+- Make the `energy` field of `ContractContext` optional since it is no longer
+  required by the node.
+- Add `dry_run_update` and `dry_run_update_raw` methods to the `ContractClient`
+  to simulate smart contract updates. The return values of these can be used to
+  immediately sign and send a transaction.
 
 ## 3.2.0
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,9 +28,9 @@ semver = "1"
 anyhow = "1.0"
 # See https://github.com/serde-rs/json/issues/505 for how to be careful.
 rust_decimal = { version = "1.26", features = ["serde-float", "serde-arbitrary-precision"]}
-ed25519-dalek = "1"
+ed25519-dalek = "2"
 sha2 = "0.10"
-rand = {version = "0.7", features = ["small_rng"]}
+rand = {version = "0.8", features = ["small_rng"]}
 num = "0.4"
 num-bigint = "0.4"
 num-traits = "0.2"

--- a/examples/v2_dry_run.rs
+++ b/examples/v2_dry_run.rs
@@ -83,7 +83,7 @@ async fn test_all(endpoint: v2::Endpoint) -> anyhow::Result<()> {
         amount:    Amount::zero(),
         method:    invoke_target.clone(),
         parameter: parameter.clone(),
-        energy:    10000.into(),
+        energy:    None,
     };
     let res5 = dry_run.invoke_instance(&context).await;
     println!("Invoked view on {contract_addr}: {:?}", res5);

--- a/examples/v2_invoke_instance.rs
+++ b/examples/v2_invoke_instance.rs
@@ -40,7 +40,7 @@ async fn main() -> anyhow::Result<()> {
         amount:    Amount::zero(),
         method:    app.receive_name,
         parameter: Default::default(),
-        energy:    1000000.into(),
+        energy:    None,
     };
 
     let info = client

--- a/src/cis0.rs
+++ b/src/cis0.rs
@@ -5,13 +5,11 @@ use crate::{
     types::{self as sdk_types, smart_contracts::ContractContext},
     v2::{BlockIdentifier, QueryResponse},
 };
-use concordium_base::{
-    base::Energy,
-    contracts_common::{Amount, ContractName, EntrypointName, OwnedReceiveName, ParseError},
+use concordium_base::contracts_common::{
+    Amount, ContractName, EntrypointName, OwnedReceiveName, ParseError,
 };
 use sdk_types::{smart_contracts, ContractAddress};
 use smart_contracts::concordium_contracts_common as contracts_common;
-use std::convert::From;
 use thiserror::*;
 
 /// The query result type for whether a smart contract supports a standard.
@@ -222,7 +220,7 @@ pub async fn supports_multi(
         amount: Amount::from_micro_ccd(0),
         method,
         parameter,
-        energy: Energy::from(500_000u64),
+        energy: None,
     };
     let res = client.invoke_instance(bi, &ctx).await?;
     match res.response {

--- a/src/contract_client.rs
+++ b/src/contract_client.rs
@@ -394,6 +394,10 @@ impl ContractUpdateBuilder {
         self
     }
 
+    /// Return the amount of [`Energy`] allowed for execution if
+    /// the transaction was sent with the current parameters.
+    pub fn current_energy(&self) -> Energy { self.energy + self.add_energy.unwrap_or(100.into()) }
+
     /// Send the transaction and return its hash.
     pub async fn send(
         mut self,
@@ -424,11 +428,18 @@ impl ContractUpdateBuilder {
     }
 }
 
+/// A handle returned when sending a smart contract update transaction.
+/// This can be used to get the response of the update.
+///
+/// Note that this handle retains a connection to the node. So if it is not
+/// going to be used it should be dropped.
 pub struct ContractUpdateHandle {
     tx_hash: TransactionHash,
     client:  v2::Client,
 }
 
+/// The [`Display`](std::fmt::Display) implementation displays the hash of the
+/// transaction.
 impl std::fmt::Display for ContractUpdateHandle {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result { self.tx_hash.fmt(f) }
 }
@@ -444,6 +455,9 @@ pub enum ContractUpdateError {
 }
 
 impl ContractUpdateHandle {
+    /// Extract the hash of the transaction underlying this handle.
+    pub fn hash(&self) -> TransactionHash { self.tx_hash }
+
     /// Wait until the transaction is finalized and return the result.
     /// Note that this can potentially wait indefinitely.
     pub async fn wait_for_finalization(

--- a/src/contract_client.rs
+++ b/src/contract_client.rs
@@ -1,15 +1,16 @@
 //! This module contains a generic client that provides conveniences for
 //! interacting with any smart contract instance.
 use crate::{
+    indexer::ContractUpdateInfo,
     types::{
         smart_contracts::{self, ContractContext, InvokeContractResult},
-        transactions, RejectReason,
+        transactions, AccountTransactionEffects, RejectReason,
     },
     v2::{self, BlockIdentifier, Client},
 };
 use concordium_base::{
-    base::Nonce,
-    common::types,
+    base::{Energy, Nonce},
+    common::types::{self, TransactionTime},
     contracts_common::{
         self, AccountAddress, Address, Amount, ContractAddress, NewReceiveNameError,
     },
@@ -19,6 +20,7 @@ use concordium_base::{
 };
 pub use concordium_base::{cis2_types::MetadataUrl, cis4_types::*};
 use std::{marker::PhantomData, sync::Arc};
+use v2::{QueryError, RPCError};
 
 /// A contract client that handles some of the boilerplate such as serialization
 /// and parsing of responses when sending transactions, or invoking smart
@@ -192,11 +194,76 @@ impl<Type> ContractClient<Type> {
             amount,
             method,
             parameter,
-            energy: 1_000_000.into(),
+            energy: None,
         };
 
         let invoke_result = self.client.invoke_instance(bi, &context).await?.response;
         Ok(invoke_result)
+    }
+
+    /// Dry run an update. If the dry run succeeds the return value is an object
+    /// that has a send method to send the transaction that was simulated during
+    /// the dry run.
+    pub async fn dry_run_update<P: contracts_common::Serial, E>(
+        &mut self,
+        entrypoint: &str,
+        amount: Amount,
+        sender: AccountAddress,
+        message: &P,
+    ) -> Result<ContractUpdateBuilder, E>
+    where
+        E: From<NewReceiveNameError>
+            + From<RejectReason>
+            + From<v2::QueryError>
+            + From<ExceedsParameterSize>, {
+        let message = OwnedParameter::from_serial(message)?;
+        self.dry_run_update_raw(entrypoint, amount, sender, message)
+            .await
+    }
+
+    /// Like [`dry_run_update`](Self::dry_run_update) but expects an already
+    /// formed parameter.
+    pub async fn dry_run_update_raw<E>(
+        &mut self,
+        entrypoint: &str,
+        amount: Amount,
+        sender: AccountAddress,
+        message: OwnedParameter,
+    ) -> Result<ContractUpdateBuilder, E>
+    where
+        E: From<NewReceiveNameError> + From<RejectReason> + From<v2::QueryError>, {
+        let contract_name = self.contract_name.as_contract_name().contract_name();
+        let receive_name = OwnedReceiveName::try_from(format!("{contract_name}.{entrypoint}"))?;
+
+        let payload = UpdateContractPayload {
+            amount,
+            address: self.address,
+            receive_name,
+            message,
+        };
+
+        let context = ContractContext::new_from_payload(sender, Energy::from(10_000_000), payload);
+
+        let invoke_result = self
+            .client
+            .invoke_instance(BlockIdentifier::LastFinal, &context)
+            .await?
+            .response;
+        let payload = UpdateContractPayload {
+            amount,
+            address: context.contract,
+            receive_name: context.method,
+            message: context.parameter,
+        };
+        match invoke_result {
+            InvokeContractResult::Success { used_energy, .. } => Ok(ContractUpdateBuilder::new(
+                self.client.clone(),
+                sender,
+                payload,
+                used_energy,
+            )),
+            InvokeContractResult::Failure { reason, .. } => Err(reason.into()),
+        }
     }
 
     /// Make the payload of a contract update with the specified parameter.
@@ -273,5 +340,166 @@ impl<Type> ContractClient<Type> {
             transactions::Payload::Update { payload },
         );
         Ok(tx)
+    }
+}
+
+/// A builder to simplify sending smart contract updates.
+pub struct ContractUpdateBuilder {
+    payload:    UpdateContractPayload,
+    sender:     AccountAddress,
+    energy:     Energy,
+    expiry:     Option<TransactionTime>,
+    add_energy: Option<Energy>,
+    nonce:      Option<Nonce>,
+    client:     v2::Client,
+}
+
+impl ContractUpdateBuilder {
+    /// Construct a new builder.
+    pub fn new(
+        client: v2::Client,
+        sender: AccountAddress,
+        payload: UpdateContractPayload,
+        energy: Energy,
+    ) -> Self {
+        Self {
+            payload,
+            sender,
+            energy,
+            expiry: None,
+            add_energy: None,
+            nonce: None,
+            client,
+        }
+    }
+
+    /// Add extra energy to the call.
+    pub fn extra_energy(mut self, energy: Energy) -> Self {
+        self.add_energy = Some(energy);
+        self
+    }
+
+    /// Set the expiry time for the transaction. If not set the default is one
+    /// hour from the time the transaction is signed.
+    pub fn expiry(mut self, expiry: TransactionTime) -> Self {
+        self.expiry = Some(expiry);
+        self
+    }
+
+    /// Set the nonce for the transaction. If not set the default behaviour is
+    /// to get the nonce from the connected [`Client`](v2::Client) at the
+    /// time the transaction is sent.
+    pub fn nonce(mut self, nonce: Nonce) -> Self {
+        self.nonce = Some(nonce);
+        self
+    }
+
+    /// Send the transaction and return its hash.
+    pub async fn send(
+        mut self,
+        signer: &impl transactions::ExactSizeTransactionSigner,
+    ) -> v2::QueryResult<TransactionHash> {
+        let nonce = if let Some(nonce) = self.nonce {
+            nonce
+        } else {
+            self.client
+                .get_next_account_sequence_number(&self.sender)
+                .await?
+                .nonce
+        };
+        let expiry = self
+            .expiry
+            .unwrap_or_else(|| TransactionTime::hours_after(1));
+        let energy = self.energy + self.add_energy.unwrap_or(100.into());
+        let tx = transactions::send::update_contract(
+            signer,
+            self.sender,
+            nonce,
+            expiry,
+            self.payload,
+            energy,
+        );
+        let hash = self.client.send_account_transaction(tx).await?;
+        Ok(hash)
+    }
+}
+
+pub struct ContractUpdateHandle {
+    tx_hash: TransactionHash,
+    client:  v2::Client,
+}
+
+impl std::fmt::Display for ContractUpdateHandle {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result { self.tx_hash.fmt(f) }
+}
+
+#[derive(Debug, thiserror::Error)]
+/// An error that may occur when querying the result of a smart contract update
+/// transaction.
+pub enum ContractUpdateError {
+    #[error("The status of the transaction could not be ascertained: {0}")]
+    Query(#[from] QueryError),
+    #[error("Contract update failed with reason: {0:?}")]
+    Failed(RejectReason),
+}
+
+impl ContractUpdateHandle {
+    /// Wait until the transaction is finalized and return the result.
+    /// Note that this can potentially wait indefinitely.
+    pub async fn wait_for_finalization(
+        mut self,
+    ) -> Result<ContractUpdateInfo, ContractUpdateError> {
+        let (_, result) = self.client.wait_until_finalized(&self.tx_hash).await?;
+
+        let mk_error = |msg| {
+            Err(ContractUpdateError::from(QueryError::RPCError(
+                RPCError::CallError(tonic::Status::invalid_argument(msg)),
+            )))
+        };
+
+        match result.details {
+            crate::types::BlockItemSummaryDetails::AccountTransaction(at) => match at.effects {
+                AccountTransactionEffects::ContractUpdateIssued { effects } => {
+                    let Some(execution_tree) = crate::types::execution_tree(effects) else {
+                        return mk_error("Expected smart contract update, but received invalid execution tree.");
+                    };
+                    Ok(ContractUpdateInfo {
+                        execution_tree,
+                        energy_cost: result.energy_cost,
+                        cost: at.cost,
+                        transaction_hash: self.tx_hash,
+                        sender: at.sender,
+                    })
+                }
+                AccountTransactionEffects::None {
+                    transaction_type: _,
+                    reject_reason,
+                } => Err(ContractUpdateError::Failed(reject_reason)),
+                _ => mk_error("Expected smart contract update status, but received ."),
+            },
+            crate::types::BlockItemSummaryDetails::AccountCreation(_) => {
+                mk_error("Expected smart contract update status, but received account creation.")
+            }
+            crate::types::BlockItemSummaryDetails::Update(_) => mk_error(
+                "Expected smart contract update status, but received chain update creation.",
+            ),
+        }
+    }
+
+    /// Wait until the transaction is finalized or until the timeout has elapsed
+    /// and return the result.
+    pub async fn wait_for_finalization_timeout(
+        self,
+        timeout: std::time::Duration,
+    ) -> Result<ContractUpdateInfo, ContractUpdateError> {
+        let result = tokio::time::timeout(timeout, self.wait_for_finalization()).await;
+        match result {
+            Ok(r) => r,
+            Err(_elapsed) => Err(ContractUpdateError::Query(QueryError::RPCError(
+                RPCError::CallError(tonic::Status::deadline_exceeded(
+                    "Deadline waiting for result of transaction is exceeded.",
+                )),
+            ))),
+        }
     }
 }

--- a/src/contract_client.rs
+++ b/src/contract_client.rs
@@ -495,7 +495,7 @@ impl ContractUpdateHandle {
                 mk_error("Expected smart contract update status, but received account creation.")
             }
             crate::types::BlockItemSummaryDetails::Update(_) => mk_error(
-                "Expected smart contract update status, but received chain update creation.",
+                "Expected smart contract update status, but received chain update instruction.",
             ),
         }
     }

--- a/src/contract_client.rs
+++ b/src/contract_client.rs
@@ -398,11 +398,12 @@ impl ContractUpdateBuilder {
     /// the transaction was sent with the current parameters.
     pub fn current_energy(&self) -> Energy { self.energy + self.add_energy.unwrap_or(100.into()) }
 
-    /// Send the transaction and return its hash.
+    /// Send the transaction and return a handle that can be queried
+    /// for the status.
     pub async fn send(
         mut self,
         signer: &impl transactions::ExactSizeTransactionSigner,
-    ) -> v2::QueryResult<TransactionHash> {
+    ) -> v2::QueryResult<ContractUpdateHandle> {
         let nonce = if let Some(nonce) = self.nonce {
             nonce
         } else {
@@ -423,8 +424,11 @@ impl ContractUpdateBuilder {
             self.payload,
             energy,
         );
-        let hash = self.client.send_account_transaction(tx).await?;
-        Ok(hash)
+        let tx_hash = self.client.send_account_transaction(tx).await?;
+        Ok(ContractUpdateHandle {
+            tx_hash,
+            client: self.client,
+        })
     }
 }
 

--- a/src/v2/conversions.rs
+++ b/src/v2/conversions.rs
@@ -618,7 +618,7 @@ impl TryFrom<AccountVerifyKey> for crate::id::types::VerifyKey {
     }
 }
 
-impl TryFrom<ip_info::IpCdiVerifyKey> for ed25519_dalek::PublicKey {
+impl TryFrom<ip_info::IpCdiVerifyKey> for ed25519_dalek::VerifyingKey {
     type Error = tonic::Status;
 
     fn try_from(value: ip_info::IpCdiVerifyKey) -> Result<Self, Self::Error> {

--- a/src/v2/dry_run.rs
+++ b/src/v2/dry_run.rs
@@ -337,7 +337,7 @@ impl From<&ContractContext> for DryRunInvokeInstance {
             amount:     Some(context.amount.into()),
             entrypoint: Some(context.method.as_receive_name().into()),
             parameter:  Some(context.parameter.as_ref().into()),
-            energy:     Some(context.energy.into()),
+            energy:     context.energy.map(From::from),
         }
     }
 }

--- a/src/v2/mod.rs
+++ b/src/v2/mod.rs
@@ -994,7 +994,7 @@ impl IntoRequest<generated::InvokeInstanceRequest> for (&BlockIdentifier, &Contr
             amount:     Some(context.amount.into()),
             entrypoint: Some(context.method.as_receive_name().into()),
             parameter:  Some(context.parameter.as_ref().into()),
-            energy:     Some(context.energy.into()),
+            energy:     context.energy.map(From::from),
         })
     }
 }


### PR DESCRIPTION
## Purpose

Make it easier to dry run + send update transaction in the common cases.

## Changes

- Make the `energy` field of ContractContext optional.
- Add `dry_run_update` and `dry_run_update_raw` methods to the contract client, with associated types.

## Checklist

- [ ] My code follows the style of this project.
- [ ] The code compiles without warnings.
- [ ] I have performed a self-review of the changes.
- [ ] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [ ] (If necessary) I have updated the CHANGELOG.
