### PR TITLE
It is better to use the repository field

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ license-file = "LICENSE"
 readme = "README.md"
 include = ["src/", "examples/", "CHANGELOG.md"]
 description = "An SDK to use the Concordium blockchain."
-homepage = "https://github.com/Concordium/concordium-rust-sdk"
+repository = "https://github.com/Concordium/concordium-rust-sdk"
 
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html


### PR DESCRIPTION
To allow [Crates.io](https://crates.io/) , [lib.rs](https://lib.rs/) and the [Rust Digger](https://rust-digger.code-maven.com/) to link to it. See also [the manifest](https://doc.rust-lang.org/cargo/reference/manifest.html#the-repository-field).