### PR TITLE
Add constructor to cis2 tokenAddress type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## Unreleased changes
 
+- Add constructor `TokenAddress::new` for CIS2 type `TokenAddress`.
 - `ProcessorConfig` now requires the future for signaling graceful shutdown is marked `Send` effectively marking `ProcessorConfig` as `Send`. This is a minor breaking change, but expected to be the case for most if not all use cases.
 - Introduce `ProcessorConfig::process_event_stream` which is equivalent to `ProcessorConfig::process_events` but the `events` argument is generalized to be some implementation of `Stream`.
 - Fix issue in `ProcessorConfig::process_event_stream` and `ProcessorConfig::process_events` where it did not check the stop signal while retrying, preventing a graceful shutdown.

--- a/src/v2/conversions.rs
+++ b/src/v2/conversions.rs
@@ -462,7 +462,9 @@ impl From<super::types::ProtocolVersion> for ProtocolVersion {
             super::types::ProtocolVersion::P6 => ProtocolVersion::ProtocolVersion6,
             super::types::ProtocolVersion::P7 => ProtocolVersion::ProtocolVersion7,
             // TODO: rust-sdk needs to be updated to support protocolVersion 8.
-            super::types::ProtocolVersion::P8 => ProtocolVersion::ProtocolVersion1,
+            super::types::ProtocolVersion::P8 => {
+                unimplemented!("ProtocolVersion 8 is not supported")
+            }
         }
     }
 }

--- a/src/v2/conversions.rs
+++ b/src/v2/conversions.rs
@@ -461,6 +461,8 @@ impl From<super::types::ProtocolVersion> for ProtocolVersion {
             super::types::ProtocolVersion::P5 => ProtocolVersion::ProtocolVersion5,
             super::types::ProtocolVersion::P6 => ProtocolVersion::ProtocolVersion6,
             super::types::ProtocolVersion::P7 => ProtocolVersion::ProtocolVersion7,
+            // TODO: rust-sdk needs to be updated to support protocolVersion 8.
+            super::types::ProtocolVersion::P8 => ProtocolVersion::ProtocolVersion1,
         }
     }
 }


### PR DESCRIPTION
## Purpose

- Add constructor for token address type

Support for `Protocol Version 8` has already been merged into `main` but we need to rebase this PR:
https://github.com/Concordium/concordium-rust-sdk/pull/218/files
https://github.com/Concordium/concordium-rust-sdk/pull/217/files