### PR TITLE
Support chain parameters for P8.

### DIFF
--- a/src/types/mod.rs
+++ b/src/types/mod.rs
@@ -2387,6 +2387,35 @@ pub struct ChainParametersV2 {
     pub finalization_committee_parameters: FinalizationCommitteeParameters,
 }
 
+#[derive(common::Serialize, Debug)]
+/// Values of chain parameters that can be updated via chain updates.
+pub struct ChainParametersV3 {
+    /// Consensus protocol version 2 timeout parameters.
+    pub timeout_parameters:                TimeoutParameters,
+    /// Minimum time interval between blocks.
+    pub min_block_time:                    Duration,
+    /// Maximum energy allowed per block.
+    pub block_energy_limit:                Energy,
+    /// Euro per energy exchange rate.
+    pub euro_per_energy:                   ExchangeRate,
+    /// Micro ccd per euro exchange rate.
+    pub micro_ccd_per_euro:                ExchangeRate,
+    pub cooldown_parameters:               CooldownParameters,
+    pub time_parameters:                   TimeParameters,
+    /// The limit for the number of account creations in a block.
+    pub account_creation_limit:            CredentialsPerBlockLimit,
+    /// Current reward parameters.
+    pub reward_parameters:                 RewardParameters<ChainParameterVersion2>,
+    /// Index of the foundation account.
+    pub foundation_account_index:          AccountIndex,
+    /// Parameters for baker pools.
+    pub pool_parameters:                   PoolParameters,
+    /// The finalization committee parameters.
+    pub finalization_committee_parameters: FinalizationCommitteeParameters,
+    /// Parameter for determining when a validator is considered inactive.
+    pub validator_score_parameters:        ValidatorScoreParameters,
+}
+
 pub trait ChainParametersFamily {
     type Output: std::fmt::Debug;
 }
@@ -2401,6 +2430,10 @@ impl ChainParametersFamily for ChainParameterVersion1 {
 
 impl ChainParametersFamily for ChainParameterVersion2 {
     type Output = ChainParametersV2;
+}
+
+impl ChainParametersFamily for ChainParameterVersion3 {
+    type Output = ChainParametersV3;
 }
 
 pub type ChainParameters<CPV> = <CPV as ChainParametersFamily>::Output;


### PR DESCRIPTION
## Purpose

Depends on: https://github.com/Concordium/concordium-base/pull/589

Support the chain parameters for protocol version 8, required by the genesis tool.

## Changes

- Add `ChainParametersV3`.
- Update base.

## Checklist

- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [x] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [ ] (If necessary) I have updated the CHANGELOG.
