### PR TITLE
Support validator score parameters sequence number.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
     suspended.
   - New `UpdatePayload` type `ValidatorScoreParametersCPV3`, which updates the maximum number of
     consecutive failures a validator can have before it faces suspension.
+  - `NextUpdateSequenceNumbers`: add `validator_score_parameters`.
 - `ContractInitializedEvent` adds the `parameter` used to initialize the contract (supported from
   node version >= 8).
 - New functionality for querying which accounts have scheduled releases or cooldowns (supported

--- a/examples/update-validator-score-param.rs
+++ b/examples/update-validator-score-param.rs
@@ -1,0 +1,123 @@
+//! An example showing how to do a simple update of the validator score
+//! parameters.
+use anyhow::Context;
+use clap::AppSettings;
+use concordium_base::updates::ValidatorScoreParameters;
+use concordium_rust_sdk::{
+    common::types::TransactionTime,
+    types::{
+        transactions::{update, BlockItem, Payload},
+        TransactionStatus, UpdateKeyPair, UpdatePayload,
+    },
+    v2::{self, BlockIdentifier, ChainParameters},
+};
+use std::path::PathBuf;
+use structopt::StructOpt;
+use tokio_stream::StreamExt;
+
+#[derive(StructOpt)]
+struct App {
+    #[structopt(
+        long = "node",
+        help = "GRPC interface of the node.",
+        default_value = "http://localhost:20000"
+    )]
+    endpoint: v2::Endpoint,
+    #[structopt(long = "key", help = "Path to update keys to use.")]
+    keys:     Vec<PathBuf>,
+}
+
+#[tokio::main(flavor = "multi_thread")]
+async fn main() -> anyhow::Result<()> {
+    let app = {
+        let app = App::clap().global_setting(AppSettings::ColoredHelp);
+        let matches = app.get_matches();
+        App::from_clap(&matches)
+    };
+
+    let kps: Vec<UpdateKeyPair> = app
+        .keys
+        .iter()
+        .map(|p| {
+            serde_json::from_reader(std::fs::File::open(p).context("Could not open file.")?)
+                .context("Could not read keys from file.")
+        })
+        .collect::<anyhow::Result<_>>()?;
+
+    let mut client = v2::Client::new(app.endpoint).await?;
+
+    // Get the key indices, as well as the next sequence number from the last
+    // finalized block.
+    let summary: ChainParameters = client
+        .get_block_chain_parameters(BlockIdentifier::LastFinal)
+        .await
+        .context("Could not obtain last finalized block's chain parameters")?
+        .response;
+
+    // find the key indices to sign with
+    let signer = summary
+        .common_update_keys()
+        .construct_update_signer(&summary.common_update_keys().micro_gtu_per_euro, kps)
+        .context("Invalid keys supplied.")?;
+
+    let seq_number = client
+        .get_next_update_sequence_numbers(BlockIdentifier::LastFinal)
+        .await?
+        .response;
+    let seq_number = seq_number.validator_score_parameters;
+
+    let now = chrono::offset::Utc::now().timestamp() as u64;
+    let effective_time = TransactionTime::from_seconds(now + 300); // effective in 5min
+    let timeout = TransactionTime::from_seconds(now + 60); // 1min expiry.
+    let payload = UpdatePayload::ValidatorScoreParametersCPV3(ValidatorScoreParameters {
+        max_missed_rounds: 10,
+    });
+    let block_item: BlockItem<Payload> =
+        update::update(&signer, seq_number, effective_time, timeout, payload).into();
+
+    let submission_id = client
+        .send_block_item(&block_item)
+        .await
+        .context("Could not send the update instruction.")?;
+
+    println!("Submitted update with hash {}", submission_id);
+
+    // wait until it's finalized.
+    let mut interval = tokio::time::interval(tokio::time::Duration::from_secs(1));
+    loop {
+        interval.tick().await;
+        match client
+            .get_block_item_status(&submission_id)
+            .await
+            .context("Could not query submission status.")?
+        {
+            TransactionStatus::Finalized(blocks) => {
+                println!(
+                    "Submission is finalized in blocks {:?}",
+                    blocks.keys().collect::<Vec<_>>()
+                );
+                break;
+            }
+            TransactionStatus::Committed(blocks) => {
+                println!(
+                    "Submission is committed to blocks {:?}",
+                    blocks.keys().collect::<Vec<_>>()
+                );
+            }
+            TransactionStatus::Received => {
+                println!("Submission is received.")
+            }
+        }
+    }
+    let mut pending_updates = client
+        .get_block_pending_updates(BlockIdentifier::LastFinal)
+        .await?
+        .response;
+    while let Some(update) = pending_updates.next().await.transpose()? {
+        // Display the update with the serde JSON serialization.
+        let update = serde_json::to_string_pretty(&update)?;
+        println!("Pending update: {}", update);
+    }
+
+    Ok(())
+}

--- a/src/types/queries.rs
+++ b/src/types/queries.rs
@@ -368,4 +368,7 @@ pub struct NextUpdateSequenceNumbers {
     pub block_energy_limit: UpdateSequenceNumber,
     /// Updates to the consensus version 2 finalization committee parameters
     pub finalization_committee_parameters: UpdateSequenceNumber,
+    /// Updates to the validator score parameters for chain parameters version 3
+    /// onwards.
+    pub validator_score_parameters: UpdateSequenceNumber,
 }

--- a/src/v2/conversions.rs
+++ b/src/v2/conversions.rs
@@ -3332,6 +3332,10 @@ impl TryFrom<NextUpdateSequenceNumbers> for super::types::queries::NextUpdateSeq
                 .finalization_committee_parameters
                 .require()?
                 .into(),
+            validator_score_parameters: message
+                .validator_score_parameters
+                .map(Into::into)
+                .unwrap_or_default(),
         })
     }
 }


### PR DESCRIPTION
## Purpose

Add the validator score parameters to `NextSequenceNumbers`.

## Changes

- Example for updating the validator score parameters.
- Add `validator_score_parameters` to `NextUpdateSequenceNumbers`.
- Fix conversion of `NextUpdateSequenceNumbers`, using the de

## Checklist

- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [x] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [x] (If necessary) I have updated the CHANGELOG.
