### PR TITLE
add parse method for wrapped bytestring of ReturnValue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## Unreleased changes
 
+- Add `parse` method to `ReturnValue` to simplify deserialization of values returned by contract invocations.
+
 ## 6.0.0
 
 - Add functionality for generating, and verifying account signatures.

--- a/src/types/smart_contracts.rs
+++ b/src/types/smart_contracts.rs
@@ -12,6 +12,7 @@ pub use concordium_contracts_common::{
     self, ContractName, ModuleReference, OwnedContractName, OwnedParameter, OwnedReceiveName,
     ReceiveName,
 };
+use concordium_contracts_common::{Cursor, Deserial, Get, ParseError, ParseResult};
 use derive_more::*;
 use std::convert::TryFrom;
 
@@ -233,6 +234,17 @@ fn return_zero_amount() -> Amount { Amount::from_micro_ccd(0) }
 pub struct ReturnValue {
     #[serde(with = "crate::internal::byte_array_hex")]
     pub value: Vec<u8>,
+}
+
+impl ReturnValue {
+    pub fn parse<T: Deserial>(&self) -> ParseResult<T> {
+        let mut cursor = Cursor::new(&self.value);
+        let res = cursor.get()?;
+        if cursor.offset != self.value.len() {
+            return Err(ParseError::default());
+        }
+        Ok(res)
+    }
 }
 
 #[derive(Debug, Clone, SerdeDeserialize)]


### PR DESCRIPTION
Add helper method to parse the inner bytestring contained within ReturnValue instances. Fixes #208.


## Checklist

- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [x] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [x] (If necessary) I have updated the CHANGELOG.

## CLA acceptance

_Remove if not applicable.

By submitting the contribution I accept the terms and conditions of the
Contributor License Agreement v1.0
- link: https://developers.concordium.com/CLAs/Contributor-License-Agreement-v1.0.pdf

- [x] I accept the above linked CLA.
