### PR TITLE
Add genesis block hash constants for testnet/mainnet.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## Unreleased changes
 
 - Add `parse` method to `ReturnValue` to simplify deserialization of values returned by contract invocations.
+- Add genesis block hash for testnet/mainnet to constants.
 
 ## 6.0.0
 

--- a/src/constants.rs
+++ b/src/constants.rs
@@ -5,3 +5,15 @@ pub use concordium_base::constants::*;
 /// This is also the only currently supported network.
 pub const DEFAULT_NETWORK_ID: super::types::network::NetworkId =
     super::types::network::NetworkId { network_id: 100u16 };
+
+/// Concordium testnet genesis block hash.
+pub const TESTNET_GENESIS_BLOCK_HASH: [u8; 32] = [
+    66, 33, 51, 45, 52, 225, 105, 65, 104, 194, 160, 192, 179, 253, 15, 39, 56, 9, 97, 44, 177, 61,
+    0, 13, 92, 46, 0, 232, 95, 80, 247, 150,
+];
+
+/// Concordium mainnet genesis block hash.
+pub const MAINNET_GENESIS_BLOCK_HASH: [u8; 32] = [
+    157, 217, 202, 77, 25, 233, 57, 56, 119, 210, 196, 75, 112, 248, 154, 203, 252, 8, 131, 194,
+    36, 62, 94, 234, 236, 192, 209, 205, 5, 3, 244, 120,
+];


### PR DESCRIPTION
Genesis block hashes for testnet/mainnet. Fixes #209 (at least for the rust sdk).
 
## Checklist

- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [x] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [x] (If necessary) I have updated the CHANGELOG.

## CLA acceptance

_Remove if not applicable.

By submitting the contribution I accept the terms and conditions of the
Contributor License Agreement v1.0
- link: https://developers.concordium.com/CLAs/Contributor-License-Agreement-v1.0.pdf

- [x] I accept the above linked CLA.
