### PR TITLE
Ensure ProcessorConfig is Send

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## Unreleased changes
 
+- `ProcessorConfig` now requires the future for signaling graceful shutdown is marked `Send` effectively marking `ProcessorConfig` as `Send`. This is a minor breaking change, but expected to be the case for most if not all use cases.
 - Add `parse` method to `ReturnValue` to simplify deserialization of values returned by contract invocations.
 - Add genesis block hash for testnet/mainnet to constants.
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,6 +41,7 @@ concordium_base = { version = "7.0", path = "./concordium-base/rust-src/concordi
 concordium-smart-contract-engine = { version = "6.0", path = "./concordium-base/smart-contracts/wasm-chain-integration/", default-features = false, features = ["async"]}
 aes-gcm = { version = "0.10", features = ["std"] }
 tracing = "0.1"
+base64ct = "=1.6.0" # Remove this direct dependency, when minimum supported rust version is 1.81 or above.
 
 [features]
 generate-protos = ["tonic-build", "git2"]

--- a/src/indexer.rs
+++ b/src/indexer.rs
@@ -713,7 +713,7 @@ pub struct ProcessorConfig {
     /// The amount of time to wait after a failure to process an event.
     wait_after_fail: std::time::Duration,
     /// A future to be signalled to stop processing.
-    stop:            std::pin::Pin<Box<dyn std::future::Future<Output = ()>>>,
+    stop:            std::pin::Pin<Box<dyn std::future::Future<Output = ()> + Send>>,
 }
 
 /// The default implementation behaves the same as
@@ -738,7 +738,10 @@ impl ProcessorConfig {
     ///
     /// An example of such a future would be the `Receiver` end of a oneshot
     /// channel.
-    pub fn set_stop_signal(self, stop: impl std::future::Future<Output = ()> + 'static) -> Self {
+    pub fn set_stop_signal(
+        self,
+        stop: impl std::future::Future<Output = ()> + Send + 'static,
+    ) -> Self {
         Self {
             stop: Box::pin(stop),
             ..self


### PR DESCRIPTION
## Purpose

To be able to pass the processor config to a tokio task it needs to be send.