### PR TITLE
Implement Client::get_token_info and Client::get_token_list

### DIFF
--- a/examples/v2_get_token_info.rs
+++ b/examples/v2_get_token_info.rs
@@ -1,0 +1,35 @@
+//! Test the `GetTokenInfo` endpoint.
+use anyhow::Context;
+use clap::AppSettings;
+use concordium_rust_sdk::{protocol_level_tokens, v2};
+use structopt::StructOpt;
+
+#[derive(StructOpt)]
+struct App {
+    #[structopt(
+        long = "node",
+        help = "GRPC interface of the node.",
+        default_value = "http://localhost:20000"
+    )]
+    endpoint: v2::Endpoint,
+    #[structopt(long = "token", help = "ID of the token to query")]
+    token:    protocol_level_tokens::TokenId,
+    #[structopt(long = "block", help = "Block to query the token info in.")]
+    block:    Option<v2::BlockIdentifier>,
+}
+
+#[tokio::main(flavor = "multi_thread")]
+async fn main() -> anyhow::Result<()> {
+    let app = {
+        let app = App::clap().global_setting(AppSettings::ColoredHelp);
+        let matches = app.get_matches();
+        App::from_clap(&matches)
+    };
+    let block_ident = app.block.unwrap_or(v2::BlockIdentifier::LastFinal);
+    let mut client = v2::Client::new(app.endpoint)
+        .await
+        .context("Cannot connect.")?;
+    let response = client.get_token_info(app.token, &block_ident).await?;
+    println!("{:#?}", response);
+    Ok(())
+}

--- a/examples/v2_get_token_list.rs
+++ b/examples/v2_get_token_list.rs
@@ -1,0 +1,41 @@
+//! Test the `GetTokenList` endpoint.
+
+use anyhow::Context;
+use clap::AppSettings;
+use concordium_rust_sdk::v2;
+use futures::StreamExt;
+use structopt::StructOpt;
+
+#[derive(StructOpt)]
+struct App {
+    #[structopt(
+        long = "node",
+        help = "GRPC interface of the node.",
+        default_value = "http://localhost:20000"
+    )]
+    endpoint: v2::Endpoint,
+}
+
+#[tokio::main(flavor = "multi_thread")]
+async fn main() -> anyhow::Result<()> {
+    let app = {
+        let app = App::clap().global_setting(AppSettings::ColoredHelp);
+        let matches = app.get_matches();
+        App::from_clap(&matches)
+    };
+
+    let mut client = v2::Client::new(app.endpoint)
+        .await
+        .context("Cannot connect.")?;
+    let mut response = client
+        .get_token_list(&v2::BlockIdentifier::LastFinal)
+        .await?;
+    println!(
+        "Listing the Token ID of every protocol level token on chain at the time of block hash {}:",
+        response.block_hash
+    );
+    while let Some(token_id) = response.response.next().await.transpose()? {
+        println!(" - {}", String::from(token_id));
+    }
+    Ok(())
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -40,6 +40,7 @@ pub mod cis0;
 pub mod cis2;
 pub mod cis3;
 pub mod cis4;
+pub mod protocol_level_tokens;
 
 pub mod web3id;
 

--- a/src/protocol_level_tokens/mod.rs
+++ b/src/protocol_level_tokens/mod.rs
@@ -1,0 +1,102 @@
+//! Types and functions for working with Protocol Level Tokens (PLT).
+
+use crate::v2::{generated, Require};
+use concordium_base::protocol_level_tokens;
+
+mod token_account_info;
+mod token_info;
+
+pub use protocol_level_tokens::*;
+pub use token_account_info::*;
+pub use token_info::*;
+
+// gRPC type conversions for the types which are define as part of
+// the `concordium-base` crate.
+
+impl TryFrom<generated::plt::TokenId> for TokenId {
+    type Error = tonic::Status;
+
+    fn try_from(value: generated::plt::TokenId) -> Result<Self, Self::Error> {
+        Self::try_from(value.symbol)
+            .map_err(|err| tonic::Status::internal(format!("Unexpected token identifier: {}", err)))
+    }
+}
+
+impl From<TokenId> for generated::plt::TokenId {
+    fn from(value: protocol_level_tokens::TokenId) -> Self {
+        Self {
+            symbol: value.into(),
+        }
+    }
+}
+
+impl TryFrom<generated::plt::TokenAmount> for TokenAmount {
+    type Error = tonic::Status;
+
+    fn try_from(value: generated::plt::TokenAmount) -> Result<Self, Self::Error> {
+        Ok(Self::from_raw(
+            value.digits,
+            value
+                .nr_of_decimals
+                .try_into()
+                .map_err(|_| tonic::Status::internal("Unexpected token decimals"))?,
+        ))
+    }
+}
+
+impl TryFrom<generated::plt::TokenModuleRef> for TokenModuleRef {
+    type Error = tonic::Status;
+
+    fn try_from(value: generated::plt::TokenModuleRef) -> Result<Self, Self::Error> {
+        let bytes = value
+            .value
+            .try_into()
+            .map_err(|_| tonic::Status::internal("Unexpected module reference format."))?;
+        Ok(Self::new(bytes))
+    }
+}
+
+impl From<generated::plt::CBor> for RawCbor {
+    fn from(wrapper: generated::plt::CBor) -> Self { wrapper.value.into() }
+}
+
+impl TryFrom<generated::plt::TokenHolderEvent> for TokenHolderEvent {
+    type Error = tonic::Status;
+
+    fn try_from(value: generated::plt::TokenHolderEvent) -> Result<Self, Self::Error> {
+        Ok(Self {
+            token_id:   value.token_symbol.require()?.try_into()?,
+            event_type: TokenEventType::try_from(value.r#type)
+                .map_err(|err| tonic::Status::internal(err.to_string()))?,
+            details:    value.details.require()?.into(),
+        })
+    }
+}
+
+impl TryFrom<generated::plt::TokenGovernanceEvent> for TokenGovernanceEvent {
+    type Error = tonic::Status;
+
+    fn try_from(value: generated::plt::TokenGovernanceEvent) -> Result<Self, Self::Error> {
+        Ok(Self {
+            token_id:   value.token_symbol.require()?.try_into()?,
+            event_type: TokenEventType::try_from(value.r#type)
+                .map_err(|err| tonic::Status::internal(err.to_string()))?,
+            details:    value.details.require()?.into(),
+        })
+    }
+}
+
+impl TryFrom<generated::plt::TokenModuleRejectReason>
+    for protocol_level_tokens::TokenModuleRejectReason
+{
+    type Error = tonic::Status;
+
+    fn try_from(value: generated::plt::TokenModuleRejectReason) -> Result<Self, Self::Error> {
+        Ok(Self {
+            token_id:   value.token_symbol.require()?.try_into()?,
+            event_type: protocol_level_tokens::TokenEventType::try_from(value.r#type)
+                .map_err(|err| tonic::Status::internal(err.to_string()))?,
+            details:    value.details.map(|d| d.into()),
+        })
+    }
+}

--- a/src/protocol_level_tokens/token_account_info.rs
+++ b/src/protocol_level_tokens/token_account_info.rs
@@ -1,0 +1,56 @@
+//! Module with the token information part of [`v2::Client::get_account_info`]
+//! response.
+
+use crate::v2::{generated, Require};
+use concordium_base::protocol_level_tokens::{TokenAmount, TokenId};
+
+/// State of a protocol level token associated with some account.
+///
+/// Part of the response for
+/// [`v2::Client::get_account_info`](crate::v2::Client::get_account_info).
+#[derive(Debug, PartialEq, serde::Serialize, serde::Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct AccountToken {
+    /// The unique identifier/symbol for the protocol level token.
+    pub token_id: TokenId,
+    /// The state of the token associated with the account.
+    pub state:    TokenAccountState,
+}
+
+/// State of a protocol level token associated with some account.
+///
+/// Part of the response for
+/// [`Client::get_account_info`](crate::v2::Client::get_account_info).
+#[derive(Debug, PartialEq, serde::Serialize, serde::Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct TokenAccountState {
+    /// The token balance of the account.
+    pub balance:           TokenAmount,
+    /// Whether the account is a member of the allow list.
+    pub member_allow_list: bool,
+    /// Whether the account is a member of the deny list.
+    pub member_deny_list:  bool,
+}
+
+impl TryFrom<generated::account_info::Token> for AccountToken {
+    type Error = tonic::Status;
+
+    fn try_from(value: generated::account_info::Token) -> Result<Self, Self::Error> {
+        Ok(Self {
+            token_id: value.token_id.require()?.try_into()?,
+            state:    value.token_account_state.require()?.try_into()?,
+        })
+    }
+}
+
+impl TryFrom<generated::plt::TokenAccountState> for TokenAccountState {
+    type Error = tonic::Status;
+
+    fn try_from(value: generated::plt::TokenAccountState) -> Result<Self, Self::Error> {
+        Ok(Self {
+            balance:           value.balance.require()?.try_into()?,
+            member_allow_list: value.member_allow_list.require()?,
+            member_deny_list:  value.member_deny_list.require()?,
+        })
+    }
+}

--- a/src/protocol_level_tokens/token_info.rs
+++ b/src/protocol_level_tokens/token_info.rs
@@ -1,0 +1,68 @@
+//! This module contains the type [`TokenInfo`] which is the response for
+//! [`v2::Client::get_token_info`].
+
+use crate::v2::{generated, Require};
+use concordium_base::{
+    contracts_common::AccountAddress,
+    protocol_level_tokens::{RawCbor, TokenAmount, TokenId, TokenModuleRef},
+};
+
+/// The token state at the block level.
+///
+/// Response type for
+/// [`Client::get_token_info`](crate::v2::Client::get_token_info).
+#[derive(Debug)]
+pub struct TokenInfo {
+    /// The unique token id.
+    pub token_id:    TokenId,
+    /// The associated block level state.
+    pub token_state: TokenState,
+}
+
+/// Token state at the block level
+///
+/// Part of the response for
+/// [`Client::get_token_info`](crate::v2::Client::get_token_info).
+#[derive(Debug)]
+pub struct TokenState {
+    /// The reference of the module implementing this token.
+    pub token_module_ref: TokenModuleRef,
+    /// Account address of the issuer. The issuer is the holder of the nominated
+    /// account which can perform token-governance operations.
+    pub issuer:           AccountAddress,
+    /// Number of decimals in the decimal number representation of amounts.
+    pub nr_of_decimals:   u8,
+    /// The total available token supply.
+    pub total_supply:     TokenAmount,
+    /// Token module specific state, such as token name, feature flags, meta
+    /// data.
+    pub module_state:     RawCbor,
+}
+
+impl TryFrom<generated::TokenInfo> for TokenInfo {
+    type Error = tonic::Status;
+
+    fn try_from(value: generated::TokenInfo) -> Result<Self, Self::Error> {
+        Ok(Self {
+            token_id:    value.token_id.require()?.try_into()?,
+            token_state: value.token_state.require()?.try_into()?,
+        })
+    }
+}
+
+impl TryFrom<generated::plt::TokenState> for TokenState {
+    type Error = tonic::Status;
+
+    fn try_from(value: generated::plt::TokenState) -> Result<Self, Self::Error> {
+        Ok(Self {
+            token_module_ref: value.token_module_ref.require()?.try_into()?,
+            issuer:           value.issuer.require()?.try_into()?,
+            nr_of_decimals:   value
+                .nr_of_decimals
+                .try_into()
+                .map_err(|_| tonic::Status::internal("Unexpected token decimals"))?,
+            total_supply:     value.total_supply.require()?.try_into()?,
+            module_state:     value.module_state.require()?.into(),
+        })
+    }
+}

--- a/src/types/mod.rs
+++ b/src/types/mod.rs
@@ -3,7 +3,6 @@ use anyhow::Context;
 pub use concordium_base::hashes;
 // re-export to maintain backwards compatibility.
 pub use concordium_base::id::types::CredentialType;
-use concordium_base::protocol_level_tokens;
 pub mod block_certificates;
 pub mod network;
 pub mod queries;
@@ -11,7 +10,7 @@ pub mod smart_contracts;
 mod summary_helper;
 pub mod transactions;
 
-use crate::constants::*;
+use crate::{constants::*, protocol_level_tokens};
 pub use concordium_base::{
     base::*,
     smart_contracts::{ContractTraceElement, InstanceUpdatedEvent},
@@ -335,28 +334,6 @@ pub struct Cooldown {
     pub status: CooldownStatus,
 }
 
-/// State of a protocol level token associated with some account.
-#[derive(Debug, PartialEq, SerdeSerialize, SerdeDeserialize)]
-#[serde(rename_all = "camelCase")]
-pub struct AccountToken {
-    /// The unique identifier/symbol for the protocol level token.
-    pub token_id: protocol_level_tokens::TokenId,
-    /// The state of the token associated with the account.
-    pub state:    TokenAccountState,
-}
-
-/// State of a protocol level token associated with some account.
-#[derive(Debug, PartialEq, SerdeSerialize, SerdeDeserialize)]
-#[serde(rename_all = "camelCase")]
-pub struct TokenAccountState {
-    /// The token balance of the account.
-    pub balance:           protocol_level_tokens::TokenAmount,
-    /// Whether the account is a member of the allow list.
-    pub member_allow_list: bool,
-    /// Whether the account is a member of the deny list.
-    pub member_deny_list:  bool,
-}
-
 #[derive(SerdeSerialize, SerdeDeserialize, Debug, PartialEq)]
 #[serde(rename_all = "camelCase")]
 /// Account information exposed via the node's API. This is always the state of
@@ -413,7 +390,7 @@ pub struct AccountInfo {
     /// staked or in cooldown (inactive stake).
     pub available_balance: Amount,
     /// The protocol level tokens (PLT) held by the account.
-    pub tokens:            Vec<AccountToken>,
+    pub tokens:            Vec<protocol_level_tokens::AccountToken>,
 }
 
 impl From<&AccountInfo> for AccountAccessStructure {


### PR DESCRIPTION
## Changes

- Export `protocol_level_tokens` module from the rust sdk reexporting the types from `concordium_base`
- Move related grpc conversion code into this module for better organization.

