### PR TITLE
Remove fixed base64ct version

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,7 +41,6 @@ concordium_base = { version = "7.0", path = "./concordium-base/rust-src/concordi
 concordium-smart-contract-engine = { version = "6.0", path = "./concordium-base/smart-contracts/wasm-chain-integration/", default-features = false, features = ["async"]}
 aes-gcm = { version = "0.10", features = ["std"] }
 tracing = "0.1"
-base64ct = "=1.6.0" # Remove this direct dependency, when minimum supported rust version is 1.81 or above.
 
 [dev-dependencies]
 structopt = "0.3"


### PR DESCRIPTION
## Purpose

This was only fixed to prevent increasing the MSRV, now that we are at 1.81, there is no need to fix it.