### PR TITLE
remove description of v1 api

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,11 +5,6 @@
 The SDK has support for constructing and sending transactions, and for querying
 various aspects of the chain and the node itself.
 
-The SDK version 2 supports both the old V1 node GRPC API (accessible via the
-`endpoints` module) as well as the new V2 API (accessible via the `v2` module).
-New users should use the API since it is more flexible, has more features, and
-performs better. The V1 API will be deprecated in the next SDK version.
-
 ## Minimum supported Rust version
 
 The minimal supported rust version is stated in the `Cargo.toml` manifest. A
@@ -91,25 +86,6 @@ cargo build --release --example v2_send_transfer
 ## Documentation
 
 The rendered documentation is available at https://docs.rs/concordium-rust-sdk/latest/
-
-## Migration from V1 to V2
-
-The endpoints in V1 and V2 APIs for the most part mirror each other. However
-some endpoints were split in the V2 API to make it possible to only query data
-that is commonly needed faster. The main differences are
-
-- The `V1` endpoint `get_block_summary` has been split into
-  - `get_block_events` (for transaction events, i.e., outcomes of transactions
-    sent by users)
-  - `get_block_special_events` (for special events such as CCD minting, and delegation/baker rewards)
-  - `get_chain_parameters` for chain parameters
-  - `get_update_next_sequence_numbers` for sequence numbers of update instructions
-  - `get_finalization_summary` for the details of finalization records in a
-    block.
-
-- The node information has been consolidated into two endpoints,
-  `get_node_info`, and `get_peers_info`, the latter of which now returns both
-  the list of peers and their details.
 
 ## For developers
 


### PR DESCRIPTION
## Purpose

Remove description of old v1 gRPC api

## Changes

Removed from README.md

## Checklist

- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [x] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [x] (If necessary) I have updated the CHANGELOG.
