### PR TITLE
make list fields optional

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## Unreleased
 
+- Make `member_allow_list` and `member_deny_list` optional on `TokenAccountState` to comply with protobuf definition.
 - Extend `BlockItemSummaryDetails` with `TokenCreationDetails` variant including contained PLT events. `TokenCreationDetails` 
   is the summary corresponding to `CreatePlt` updates. 
 - Change JSON serialization of PLT events to align them with Haskell code base.

--- a/src/protocol_level_tokens/token_account_info.rs
+++ b/src/protocol_level_tokens/token_account_info.rs
@@ -27,9 +27,9 @@ pub struct TokenAccountState {
     /// The token balance of the account.
     pub balance:           TokenAmount,
     /// Whether the account is a member of the allow list.
-    pub member_allow_list: bool,
+    pub member_allow_list: Option<bool>,
     /// Whether the account is a member of the deny list.
-    pub member_deny_list:  bool,
+    pub member_deny_list:  Option<bool>,
 }
 
 impl TryFrom<generated::account_info::Token> for AccountToken {
@@ -49,8 +49,8 @@ impl TryFrom<generated::plt::TokenAccountState> for TokenAccountState {
     fn try_from(value: generated::plt::TokenAccountState) -> Result<Self, Self::Error> {
         Ok(Self {
             balance:           value.balance.require()?.try_into()?,
-            member_allow_list: value.member_allow_list.require()?,
-            member_deny_list:  value.member_deny_list.require()?,
+            member_allow_list: value.member_allow_list,
+            member_deny_list:  value.member_deny_list,
         })
     }
 }


### PR DESCRIPTION
## Purpose

Make fields describing allow and deny list inclusion optional in Rust types to match protobuf

## Changes

_Describe the changes that were needed.

## Checklist

- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [x] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [x] (If necessary) I have updated the CHANGELOG.
