### PR TITLE
CBOR Representation of PLT Account State

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## Unreleased changes
+
+- Remove `member_allow_list` and `member_deny_list` from `TokenAccountState`, replaced with
+  CBOR-encoded state.
+
 ## 7.0.0-alpha.1
 
 - Make `member_allow_list` and `member_deny_list` optional on `TokenAccountState` to comply with protobuf definition.

--- a/src/v2/generated/concordium.v2.plt.rs
+++ b/src/v2/generated/concordium.v2.plt.rs
@@ -52,21 +52,15 @@ pub struct TokenState {
     pub module_state: ::core::option::Option<CBor>,
 }
 /// Token state at the account level
-#[derive(Clone, Copy, PartialEq, ::prost::Message)]
+#[derive(Clone, PartialEq, ::prost::Message)]
 pub struct TokenAccountState {
     /// The available balance.
     #[prost(message, optional, tag = "1")]
     pub balance: ::core::option::Option<TokenAmount>,
-    /// Whether the account is a member of the allow list of the token.
-    /// If present, tokens can be transferred only, if both sender and receiver are
-    /// members of the allow list of the token.
-    #[prost(bool, optional, tag = "2")]
-    pub member_allow_list: ::core::option::Option<bool>,
-    /// Whether the account is a member of the deny list of the token.
-    /// If present, tokens can be transferred only, if neither sender or receiver
-    /// are members of the deny list.
-    #[prost(bool, optional, tag = "3")]
-    pub member_deny_list: ::core::option::Option<bool>,
+    /// Token module specific account state, such as whether the account is on
+    /// the allow or deny list.
+    #[prost(message, optional, tag = "4")]
+    pub module_state: ::core::option::Option<CBor>,
 }
 /// Single token event originating from a token module as part of a token
 /// transaction.

--- a/src/v2/proto_schema_version.rs
+++ b/src/v2/proto_schema_version.rs
@@ -1,1 +1,1 @@
-pub const PROTO_SCHEMA_VERSION: &str = "f766c2db6f27620aebde9c4cfefa509386fd256a";
+pub const PROTO_SCHEMA_VERSION: &str = "9fb82ad708873c00f91a9281e454f1072d640961";


### PR DESCRIPTION
## Purpose

Closes [COR-1496](https://linear.app/concordium/issue/COR-1496/update-rust-sdk)

Revises `TokenAccountState` to have a `module_state` (CBOR) field instead of the `member_allow_list` and `member_deny_list` fields.

## Changes

- Update `TokenAccountState`
- Add `decode_module_state` for decoding the CBOR data.

## Checklist

- [X] My code follows the style of this project.
- [X] The code compiles without warnings.
- [X] I have performed a self-review of the changes.
- [X] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [X] (If necessary) I have updated the CHANGELOG.
