### PR TITLE
COR-1664 Token Client mint/burn signature change

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## Unreleased changes
 
 - Add `NextUpdateSequenceNumbers::protocol_level_tokens` and protobuf deserialization of it
+- Changed `TokenClient`'s `burn` and `mint` methods to accept a singular `TokenAmount`, instead of `Vec<TokenAmount>`.
 
 ## 7.0.0-alpha.3
 

--- a/examples/plt-token-client.rs
+++ b/examples/plt-token-client.rs
@@ -116,7 +116,7 @@ async fn main() -> anyhow::Result<()> {
                 ConversionRule::AllowRounding,
             )?;
             token_client.validate_governance_operation(keys.address)?;
-            token_client.mint(&keys, vec![token_amount], meta).await
+            token_client.mint(&keys, token_amount, meta).await
         }
         Action::Burn { amount } => {
             let token_amount = TokenAmount::try_from_rust_decimal(
@@ -125,7 +125,7 @@ async fn main() -> anyhow::Result<()> {
                 ConversionRule::AllowRounding,
             )?;
             token_client.validate_governance_operation(keys.address)?;
-            token_client.burn(&keys, vec![token_amount], meta).await
+            token_client.burn(&keys, token_amount, meta).await
         }
         Action::Transfer { receiver, amount } => {
             let token_amount = TokenAmount::try_from_rust_decimal(

--- a/src/protocol_level_tokens/token_client.rs
+++ b/src/protocol_level_tokens/token_client.rs
@@ -291,8 +291,7 @@ impl TokenClient {
                 self.validate_governance_operation(signer.address)?;
 
                 // check if amount to be minted has the same decimals as the token.
-                if amount.decimals() != self.info.token_state.decimals
-                {
+                if amount.decimals() != self.info.token_state.decimals {
                     return Err(TokenError::InvalidTokenAmount);
                 }
             }
@@ -340,8 +339,7 @@ impl TokenClient {
                 self.validate_governance_operation(signer.address)?;
 
                 // check if amount to be burned has the same decimals as the token.
-                if amount.decimals() != self.info.token_state.decimals
-                {
+                if amount.decimals() != self.info.token_state.decimals {
                     return Err(TokenError::InvalidTokenAmount);
                 }
 

--- a/src/protocol_level_tokens/token_client.rs
+++ b/src/protocol_level_tokens/token_client.rs
@@ -259,13 +259,13 @@ impl TokenClient {
     ///
     /// * `signer` - a [`WalletAccount`] who's address is used as a sender and
     ///   keys as a signer.
-    /// * `amounts` - The amounts of tokens to mint.
+    /// * `amount` - The amount of tokens to mint.
     /// * `meta` - The optional transaction metadata. Includes optional
     ///   expiration, nonce, and validation.
     pub async fn mint(
         &mut self,
         signer: &WalletAccount,
-        amounts: Vec<TokenAmount>,
+        amount: TokenAmount,
         meta: Option<TransactionMetadata>,
     ) -> TokenResult<TransactionHash> {
         let TransactionMetadata {
@@ -290,17 +290,14 @@ impl TokenClient {
                 // check if the signer is authorized to mint tokens.
                 self.validate_governance_operation(signer.address)?;
 
-                // check if every amount ot be minted have the same decimals as the token.
-                if amounts
-                    .iter()
-                    .any(|amount| amount.decimals() != self.info.token_state.decimals)
+                // check if amount to be minted has the same decimals as the token.
+                if amount.decimals() != self.info.token_state.decimals
                 {
                     return Err(TokenError::InvalidTokenAmount);
                 }
             }
         }
-
-        let operations = amounts.into_iter().map(operations::mint_tokens).collect();
+        let operations = [operations::mint_tokens(amount)].into_iter().collect();
 
         self.sign_and_send(signer, operations, expiry, nonce).await
     }
@@ -311,13 +308,13 @@ impl TokenClient {
     ///
     /// * `signer` - A [`WalletAccount`] who's address is used as a sender and
     ///   keys as a signer.
-    /// * `amount` - The amounts of tokens to burn.
+    /// * `amount` - The amount of tokens to burn.
     /// * `meta` - The optional transaction metadata. Includes optional
     ///   expiration, nonce, and validation.
     pub async fn burn(
         &mut self,
         signer: &WalletAccount,
-        amounts: Vec<TokenAmount>,
+        amount: TokenAmount,
         meta: Option<TransactionMetadata>,
     ) -> TokenResult<TransactionHash> {
         let TransactionMetadata {
@@ -342,34 +339,24 @@ impl TokenClient {
                 // check if the signer is authorized to burn tokens.
                 self.validate_governance_operation(signer.address)?;
 
-                // check if every amount ot be burned have the same decimals as the token.
-                if amounts
-                    .iter()
-                    .any(|amount| amount.decimals() != self.info.token_state.decimals)
+                // check if amount to be burned has the same decimals as the token.
+                if amount.decimals() != self.info.token_state.decimals
                 {
                     return Err(TokenError::InvalidTokenAmount);
                 }
 
-                // check if total amount to burn exceeds total token supply
-                let payload_total = TokenAmount::from_raw(
-                    amounts
-                        .iter()
-                        .try_fold(0u64, |acc, x| acc.checked_add(x.value()))
-                        .ok_or(TokenError::InvalidTokenAmount)?,
-                    self.info.token_state.decimals,
-                );
+                // check if amount to be burned exceeds government account's token supply
                 let governer_token_amount = self
                     .balance_of(&signer.address.into(), None::<BlockIdentifier>)
                     .await?
                     .ok_or(TokenError::InsufficientSupply)?;
 
-                if governer_token_amount.value() < payload_total.value() {
+                if governer_token_amount.value() < amount.value() {
                     return Err(TokenError::InsufficientSupply);
                 }
             }
         }
-
-        let operations = amounts.into_iter().map(operations::burn_tokens).collect();
+        let operations = [operations::burn_tokens(amount)].into_iter().collect();
 
         self.sign_and_send(signer, operations, expiry, nonce).await
     }

--- a/src/protocol_level_tokens/token_client.rs
+++ b/src/protocol_level_tokens/token_client.rs
@@ -737,3 +737,9 @@ impl TokenClient {
         Ok(self.client.send_block_item(&block_item).await?)
     }
 }
+
+#[cfg(test)]
+mod tests {
+    #[test]
+    fn validate_account() {}
+}

--- a/src/protocol_level_tokens/token_client.rs
+++ b/src/protocol_level_tokens/token_client.rs
@@ -737,9 +737,3 @@ impl TokenClient {
         Ok(self.client.send_block_item(&block_item).await?)
     }
 }
-
-#[cfg(test)]
-mod tests {
-    #[test]
-    fn validate_account() {}
-}


### PR DESCRIPTION
## Purpose

The mint/burn methods would benefit from receiving singular `TokenAmount` instead of `Vec<TokenAmount>`, both from performance and user experience perspectives.

## Changes

The mint/burn methods now accept singular `TokenAmount` instead of `Vec<TokenAmount>`.

## Checklist

- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [x] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [x] I have documented changes in the CHANGELOG.md.
