### PR TITLE
fix: add partial eq to tokeninfo for use in the state compare tool

### DIFF
--- a/src/protocol_level_tokens/token_info.rs
+++ b/src/protocol_level_tokens/token_info.rs
@@ -11,10 +11,10 @@ use concordium_base::{
 ///
 /// Response type for
 /// [`Client::get_token_info`](crate::v2::Client::get_token_info).
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq)]
 pub struct TokenInfo {
     /// The unique token id.
-    pub token_id:    TokenId,
+    pub token_id: TokenId,
     /// The associated block level state.
     pub token_state: TokenState,
 }
@@ -23,17 +23,17 @@ pub struct TokenInfo {
 ///
 /// Part of the response for
 /// [`Client::get_token_info`](crate::v2::Client::get_token_info).
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq)]
 pub struct TokenState {
     /// The reference of the module implementing this token.
     pub token_module_ref: TokenModuleRef,
     /// Number of decimals in the decimal number representation of amounts.
-    pub decimals:         u8,
+    pub decimals: u8,
     /// The total available token supply.
-    pub total_supply:     TokenAmount,
+    pub total_supply: TokenAmount,
     /// Token module specific state, such as token name, feature flags, meta
     /// data.
-    pub module_state:     RawCbor,
+    pub module_state: RawCbor,
 }
 
 impl TokenState {
@@ -48,7 +48,7 @@ impl TryFrom<generated::TokenInfo> for TokenInfo {
 
     fn try_from(value: generated::TokenInfo) -> Result<Self, Self::Error> {
         Ok(Self {
-            token_id:    value.token_id.require()?.try_into()?,
+            token_id: value.token_id.require()?.try_into()?,
             token_state: value.token_state.require()?.try_into()?,
         })
     }
@@ -60,12 +60,12 @@ impl TryFrom<generated::plt::TokenState> for TokenState {
     fn try_from(value: generated::plt::TokenState) -> Result<Self, Self::Error> {
         Ok(Self {
             token_module_ref: value.token_module_ref.require()?.try_into()?,
-            decimals:         value
+            decimals: value
                 .decimals
                 .try_into()
                 .map_err(|_| tonic::Status::internal("Unexpected token decimals"))?,
-            total_supply:     value.total_supply.require()?.try_into()?,
-            module_state:     value.module_state.require()?.into(),
+            total_supply: value.total_supply.require()?.try_into()?,
+            module_state: value.module_state.require()?.into(),
         })
     }
 }


### PR DESCRIPTION
## Purpose

Update token info to derive partial EQ for equality comparison

## Changes

Added derive partial eq for the token info for equality comparison

## Checklist

- [ ] My code follows the style of this project.
- [ ] The code compiles without warnings.
- [ ] I have performed a self-review of the changes.
- [ ] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [ ] (If necessary) I have updated the CHANGELOG.

