### PR TITLE
COR-1665 `TokenClient`'s `validate_transfer` test

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,6 +40,7 @@ concordium_base = { version = "8.0.0-alpha.1", path = "./concordium-base/rust-sr
 concordium-smart-contract-engine = { version = "6.0", path = "./concordium-base/smart-contracts/wasm-chain-integration/", default-features = false, features = ["async"]}
 aes-gcm = { version = "0.10", features = ["std"] }
 tracing = "0.1"
+assert_matches = "1.5.0"
 
 
 [dev-dependencies]

--- a/src/protocol_level_tokens/token_account_info.rs
+++ b/src/protocol_level_tokens/token_account_info.rs
@@ -11,7 +11,7 @@ use concordium_base::{
 ///
 /// Part of the response for
 /// [`v2::Client::get_account_info`](crate::v2::Client::get_account_info).
-#[derive(Debug, PartialEq, serde::Serialize, serde::Deserialize)]
+#[derive(Debug, PartialEq, serde::Serialize, serde::Deserialize, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct AccountToken {
     /// The unique identifier/symbol for the protocol level token.
@@ -24,7 +24,7 @@ pub struct AccountToken {
 ///
 /// Part of the response for
 /// [`Client::get_account_info`](crate::v2::Client::get_account_info).
-#[derive(Debug, PartialEq, serde::Serialize, serde::Deserialize)]
+#[derive(Debug, PartialEq, serde::Serialize, serde::Deserialize, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct TokenAccountState {
     /// The token balance of the account.

--- a/src/protocol_level_tokens/token_client.rs
+++ b/src/protocol_level_tokens/token_client.rs
@@ -686,7 +686,7 @@ impl TokenClient {
         for account in accounts {
             let token_state = account
                 .tokens()
-                .into_iter()
+                .iter()
                 .find(|t| t.token_id == *token_id)
                 .cloned()
                 .map(|t| t.state)

--- a/src/protocol_level_tokens/token_client.rs
+++ b/src/protocol_level_tokens/token_client.rs
@@ -600,196 +600,193 @@ impl TokenClient {
         // Fetching latest final token info
         self.update_token_info().await?;
 
-        let module_state = self.info.token_state.decode_module_state()?;
-
-        // Check if the token is paused
-        if module_state.paused.unwrap_or_default() {
         let client = self.client.clone();
         let token_id = &self.info.token_id;
         let decimals = self.info.token_state.decimals;
-        let token_module_state = self.info.token_state.decode_module_state()?;
+        let module_state = self.info.token_state.decode_module_state()?;
         Self::inner_validate_transfer(
             client,
             token_id,
             decimals,
-            token_module_state,
+            module_state,
             sender,
             payload,
         )
         .await
     }
 
-    async fn inner_validate_transfer(
-        mut client: impl AccountInfoFetch + Clone,
-        token_id: &TokenId,
-        decimals: u8,
-        token_module_state: TokenModuleState,
-        sender: AccountAddress,
-        payload: Vec<TransferTokens>,
-    ) -> TokenResult<()> {
-        // check for pause
-        if token_module_state.paused.unwrap_or_default() {
-            return Err(TokenError::Paused);
-        }
+        async fn inner_validate_transfer(
+            mut client: impl AccountInfoFetch + Clone,
+            token_id: &TokenId,
+            decimals: u8,
+            module_state: TokenModuleState,
+            sender: AccountAddress,
+            payload: Vec<TransferTokens>,
+        ) -> TokenResult<()> {
+            // check for pause
+            if module_state.paused.unwrap_or_default() {
+                return Err(TokenError::Paused);
+            }
 
-        // Validate all amounts
-        if payload
-            .iter()
-            .any(|transfer| transfer.amount.decimals() != decimals)
-        {
-            return Err(TokenError::InvalidTokenAmount);
-        }
-
-        let sender_info = client
-            .get_account_info(&sender.into(), BlockIdentifier::LastFinal)
-            .await?
-            .response;
-
-        // Check the sender ballance
-        let sender_balance = sender_info
-            .token_amount(&token_id)
-            .unwrap_or(TokenAmount::from_raw(0, decimals));
-
-        let payload_total = TokenAmount::from_raw(
-            payload
+            // Validate all amounts
+            if payload
                 .iter()
-                .try_fold(0u64, |acc, x| acc.checked_add(x.amount.value()))
-                .ok_or(TokenError::InvalidTokenAmount)?,
-            decimals,
-        );
-
-        if payload_total > sender_balance {
-            return Err(TokenError::InsufficientFunds);
-        }
-
-        // Check if token has no allow and deny lists
-        if !module_state.allow_list.unwrap_or_default()
-            && !module_state.deny_list.unwrap_or_default()
-        {
-            return Ok(());
-        }
-
-        // Check sender and recievers for allow and deny lists
-        let mut accounts = Vec::with_capacity(payload.len() + 1);
-        accounts.push(sender_info);
-
-        let futures = payload.into_iter().map(|transfer| {
-            let holder = transfer.recipient;
-            let mut client = client.clone();
-            async move {
-                client
-                    .get_account_info(&holder.into(), BlockIdentifier::LastFinal)
-                    .await
-            }
-        });
-
-        let recepients = futures::future::try_join_all(futures).await?;
-        for recepient in recepients {
-            let info = recepient.response;
-            accounts.push(info);
-        }
-
-        for account in accounts {
-            let token_state = account
-                .tokens
-                .into_iter()
-                .find(|t| t.token_id == *token_id)
-                .map(|t| t.state)
-                .unwrap_or(TokenAccountState {
-                    balance:      TokenAmount::from_raw(0, self.info.token_state.decimals),
-                    module_state: None,
-                });
-
-            let account_module_state = token_state.decode_module_state()?;
-            if module_state.deny_list.unwrap_or_default()
-                && account_module_state.deny_list.unwrap_or_default()
+                .any(|transfer| transfer.amount.decimals() != decimals)
             {
-                return Err(TokenError::NotAllowed);
+                return Err(TokenError::InvalidTokenAmount);
             }
 
-            if module_state.allow_list.unwrap_or_default()
-                && !account_module_state.allow_list.unwrap_or_default()
+            let sender_info = client
+                .get_account_info(&sender.into(), BlockIdentifier::LastFinal)
+                .await?
+                .response;
+
+            // Check the sender ballance
+            let sender_balance = sender_info
+                .token_amount(&token_id)
+                .unwrap_or(TokenAmount::from_raw(0, decimals));
+
+            let payload_total = TokenAmount::from_raw(
+                payload
+                    .iter()
+                    .try_fold(0u64, |acc, x| acc.checked_add(x.amount.value()))
+                    .ok_or(TokenError::InvalidTokenAmount)?,
+                decimals,
+            );
+
+            if payload_total > sender_balance {
+                return Err(TokenError::InsufficientFunds);
+            }
+
+            // Check if token has no allow and deny lists
+            if !module_state.allow_list.unwrap_or_default()
+                && !module_state.deny_list.unwrap_or_default()
             {
-                return Err(TokenError::NotAllowed);
+                return Ok(());
             }
+
+            // Check sender and recievers for allow and deny lists
+            let mut accounts = Vec::with_capacity(payload.len() + 1);
+            accounts.push(sender_info);
+
+            let futures = payload.into_iter().map(|transfer| {
+                let holder = transfer.recipient;
+                let mut client = client.clone();
+                async move {
+                    client
+                        .get_account_info(&holder.into(), BlockIdentifier::LastFinal)
+                        .await
+                }
+            });
+
+            let recepients = futures::future::try_join_all(futures).await?;
+            for recepient in recepients {
+                let info = recepient.response;
+                accounts.push(info);
+            }
+
+            for account in accounts {
+                let token_state = account
+                    .tokens
+                    .into_iter()
+                    .find(|t| t.token_id == *token_id)
+                    .map(|t| t.state)
+                    .unwrap_or(TokenAccountState {
+                        balance:      TokenAmount::from_raw(0, decimals),
+                        module_state: None,
+                    });
+
+                let account_module_state = token_state.decode_module_state()?;
+                if module_state.deny_list.unwrap_or_default()
+                    && account_module_state.deny_list.unwrap_or_default()
+                {
+                    return Err(TokenError::NotAllowed);
+                }
+
+                if module_state.allow_list.unwrap_or_default()
+                    && !account_module_state.allow_list.unwrap_or_default()
+                {
+                    return Err(TokenError::NotAllowed);
+                }
+            }
+            Ok(())
         }
-        Ok(())
+
+        /// Initiates a transaction with a list of PLT operations for a given
+        /// token.
+        ///
+        /// # Arguments
+        ///
+        /// * `signer` - A [`WalletAccount`] who's address is used as a sender
+        ///   and keys as a signer.
+        /// * `expiry` - The optional expiry time for the transaction.
+        /// * `operations` - A list of protocol level token operations.
+        /// * `meta` - The optional transaction metadata. Includes optional
+        ///   expiration, nonce. Validation is ignored for this method.
+        pub async fn send_operations(
+            &mut self,
+            signer: &WalletAccount,
+            operations: TokenOperations,
+            meta: Option<TransactionMetadata>,
+        ) -> TokenResult<TransactionHash> {
+            let TransactionMetadata { expiry, nonce, .. } = meta.unwrap_or_default();
+            self.sign_and_send(signer, operations, expiry, nonce).await
+        }
+
+        /// Updates token's info to a last finilized block. The method can be
+        /// ommited before calling the validation methods.
+        pub async fn update_token_info(&mut self) -> TokenResult<()> {
+            self.info = self
+                .client
+                .get_token_info(self.info.token_id.clone(), BlockIdentifier::LastFinal)
+                .await?
+                .response;
+            Ok(())
+        }
+
+        /// Helper method containing the common logic related to signing and
+        /// sending PLT operations.
+        ///
+        /// # Arguments
+        ///
+        /// * `signer` - A [`WalletAccount`] who's address is used as a sender
+        ///   and keys as a signer.
+        /// * `operations` - A list of protocol level token operations.
+        /// * `expiry` - The expiry time for the transaction.
+        /// * `nonce` - Option
+        async fn sign_and_send(
+            &mut self,
+            signer: &WalletAccount,
+            operations: TokenOperations,
+            expiry: Option<TransactionTime>,
+            nonce: Option<Nonce>,
+        ) -> TokenResult<TransactionHash> {
+            let expiry = expiry.unwrap_or(TransactionTime::seconds_after(self.default_expiry));
+
+            let nonce = match nonce {
+                Some(nonce) => nonce,
+                None => {
+                    self.client
+                        .get_next_account_sequence_number(&signer.address)
+                        .await?
+                        .nonce
+                }
+            };
+
+            let token_id = self.info.token_id.clone();
+
+            let transaction = send::token_update_operations(
+                &signer,
+                signer.address,
+                nonce,
+                expiry,
+                token_id,
+                operations,
+            )?;
+            let block_item = BlockItem::AccountTransaction(transaction);
+            Ok(self.client.send_block_item(&block_item).await?)
+        }
     }
-
-    /// Initiates a transaction with a list of PLT operations for a given token.
-    ///
-    /// # Arguments
-    ///
-    /// * `signer` - A [`WalletAccount`] who's address is used as a sender and
-    ///   keys as a signer.
-    /// * `expiry` - The optional expiry time for the transaction.
-    /// * `operations` - A list of protocol level token operations.
-    /// * `meta` - The optional transaction metadata. Includes optional
-    ///   expiration, nonce. Validation is ignored for this method.
-    pub async fn send_operations(
-        &mut self,
-        signer: &WalletAccount,
-        operations: TokenOperations,
-        meta: Option<TransactionMetadata>,
-    ) -> TokenResult<TransactionHash> {
-        let TransactionMetadata { expiry, nonce, .. } = meta.unwrap_or_default();
-        self.sign_and_send(signer, operations, expiry, nonce).await
-    }
-
-    /// Updates token's info to a last finilized block. The method can be
-    /// ommited before calling the validation methods.
-    pub async fn update_token_info(&mut self) -> TokenResult<()> {
-        self.info = self
-            .client
-            .get_token_info(self.info.token_id.clone(), BlockIdentifier::LastFinal)
-            .await?
-            .response;
-        Ok(())
-    }
-
-    /// Helper method containing the common logic related to signing and sending
-    /// PLT operations.
-    ///
-    /// # Arguments
-    ///
-    /// * `signer` - A [`WalletAccount`] who's address is used as a sender and
-    ///   keys as a signer.
-    /// * `operations` - A list of protocol level token operations.
-    /// * `expiry` - The expiry time for the transaction.
-    /// * `nonce` - Option
-    async fn sign_and_send(
-        &mut self,
-        signer: &WalletAccount,
-        operations: TokenOperations,
-        expiry: Option<TransactionTime>,
-        nonce: Option<Nonce>,
-    ) -> TokenResult<TransactionHash> {
-        let expiry = expiry.unwrap_or(TransactionTime::seconds_after(self.default_expiry));
-
-        let nonce = match nonce {
-            Some(nonce) => nonce,
-            None => {
-                self.client
-                    .get_next_account_sequence_number(&signer.address)
-                    .await?
-                    .nonce
-            }
-        };
-
-        let token_id = self.info.token_id.clone();
-
-        let transaction = send::token_update_operations(
-            &signer,
-            signer.address,
-            nonce,
-            expiry,
-            token_id,
-            operations,
-        )?;
-        let block_item = BlockItem::AccountTransaction(transaction);
-        Ok(self.client.send_block_item(&block_item).await?)
-    }
-}
 
 /// Helper trait for testing the transfer validation.
 trait AccountInfoFetch {
@@ -812,14 +809,14 @@ impl AccountInfoFetch for Client {
 
 #[cfg(test)]
 mod tests {
-    use concordium_base::{protocol_level_tokens::{CborHolderAccount, MetadataUrl}};
+    use concordium_base::protocol_level_tokens::{CborHolderAccount, MetadataUrl};
 
     use super::*;
-    use std::{collections::{HashMap}, str::FromStr};
+    use std::{collections::HashMap, str::FromStr};
 
     #[derive(Debug, Clone)]
     struct MockClient {
-        responses: HashMap<AccountAddress, QueryResponse<AccountInfo>>
+        responses: HashMap<AccountAddress, QueryResponse<AccountInfo>>,
     }
 
     impl MockClient {
@@ -839,7 +836,7 @@ mod tests {
             let AccountIdentifier::Address(address) = address else {
                 return Err(QueryError::NotFound);
             };
-            
+
             self.responses
                 .get(address)
                 .cloned()

--- a/src/protocol_level_tokens/token_client.rs
+++ b/src/protocol_level_tokens/token_client.rs
@@ -636,7 +636,7 @@ impl TokenClient {
 
         // Check the sender ballance
         let sender_balance = sender_info
-            .token_amount(&token_id)
+            .token_amount(token_id)
             .unwrap_or(TokenAmount::from_raw(0, decimals));
 
         let payload_total = TokenAmount::from_raw(

--- a/src/protocol_level_tokens/token_client.rs
+++ b/src/protocol_level_tokens/token_client.rs
@@ -836,15 +836,14 @@ mod tests {
             address: &AccountIdentifier,
             _block: BlockIdentifier,
         ) -> endpoints::QueryResult<QueryResponse<AccountInfo>> {
-            let AccountIdentifier::Address(_address) = address else {
+            let AccountIdentifier::Address(address) = address else {
                 return Err(QueryError::NotFound);
             };
-            // self.responses
-            //     .get(address)
-            //     .cloned()
-            //     .map(|x| QueryResponse { response: x.response.0, ..x})
-            //     .ok_or(QueryError::NotFound)
-            Err(QueryError::NotFound)
+            
+            self.responses
+                .get(address)
+                .cloned()
+                .ok_or(QueryError::NotFound)
         }
     }
 

--- a/src/protocol_level_tokens/token_client.rs
+++ b/src/protocol_level_tokens/token_client.rs
@@ -831,10 +831,7 @@ mod tests {
         common::cbor,
         protocol_level_tokens::{CborHolderAccount, CborTokenHolder, MetadataUrl},
     };
-    use concordium_base::{
-        hashes::HashBytes,
-        protocol_level_tokens::{TokenModuleAccountState},
-    };
+    use concordium_base::{hashes::HashBytes, protocol_level_tokens::TokenModuleAccountState};
 
     use super::*;
     use std::{collections::HashMap, str::FromStr};
@@ -916,9 +913,9 @@ mod tests {
         fn payload(&self, entries: usize, amount: u64) -> Vec<TransferTokens> {
             (0..entries)
                 .map(|_| TransferTokens {
-                    amount: TokenAmount::from_raw(amount, self.decimals),
+                    amount:    TokenAmount::from_raw(amount, self.decimals),
                     recipient: self.recipient,
-                    memo: None,
+                    memo:      None,
                 })
                 .collect()
         }
@@ -1254,7 +1251,8 @@ mod tests {
         assert!(
             matches!(result, Err(TokenError::NotAllowed)),
             "expected TokenError::NotAllowed, got: {result:?}"
-        );    }
+        );
+    }
 
     #[tokio::test]
     async fn fail_validate_transfer_recipient_not_in_allow_list() {
@@ -1297,7 +1295,10 @@ mod tests {
         // create and populate mock client
         let mut client = MockClient::new();
         // sender is both in allow and deny lists
-        client.add_account_info(fixture.sender, fixture.account_info(1_000_000, Some(true), Some(true)));
+        client.add_account_info(
+            fixture.sender,
+            fixture.account_info(1_000_000, Some(true), Some(true)),
+        );
         client.add_account_info(fixture.recipient, fixture.account_info(0, None, None));
 
         // creating token module state with allow and deny list
@@ -1329,7 +1330,10 @@ mod tests {
 
         // create and populate mock client
         let mut client = MockClient::new();
-        client.add_account_info(fixture.sender, fixture.account_info(1_000_000, Some(true), Some(true)));
+        client.add_account_info(
+            fixture.sender,
+            fixture.account_info(1_000_000, Some(true), Some(true)),
+        );
         // recipient is both in allow and deny lists
         client.add_account_info(fixture.recipient, fixture.account_info(0, None, None));
 

--- a/src/types/mod.rs
+++ b/src/types/mod.rs
@@ -51,7 +51,7 @@ use std::{
 /// zero-knowledge proofs.
 pub type CryptographicParameters = crate::id::types::GlobalContext<crate::id::constants::ArCurve>;
 
-#[derive(SerdeSerialize, PartialEq, Eq, SerdeDeserialize, Debug)]
+#[derive(SerdeSerialize, PartialEq, Eq, SerdeDeserialize, Debug, Clone)]
 #[serde(rename_all = "camelCase")]
 /// The state of the encrypted balance of an account.
 pub struct AccountEncryptedAmount {
@@ -217,7 +217,7 @@ impl AccountEncryptedAmount {
         }
     }
 }
-#[derive(SerdeSerialize, SerdeDeserialize, Debug, Eq, PartialEq)]
+#[derive(SerdeSerialize, SerdeDeserialize, Debug, Eq, PartialEq, Clone)]
 #[serde(rename_all = "camelCase")]
 /// State of the account's release schedule. This is the balance of the account
 /// that is owned by the account, but cannot be used until the release point.
@@ -228,7 +228,7 @@ pub struct AccountReleaseSchedule {
     pub schedule: Vec<Release>,
 }
 
-#[derive(SerdeSerialize, SerdeDeserialize, Debug, Eq, PartialEq)]
+#[derive(SerdeSerialize, SerdeDeserialize, Debug, Eq, PartialEq, Clone)]
 #[serde(rename_all = "camelCase")]
 /// An individual release of a locked balance.
 pub struct Release {
@@ -303,7 +303,7 @@ impl AccountStakingInfo {
 /// a payday) it enters the pre-cooldown state. At the subsequent payday, it
 /// enters the cooldown state. At the payday after the end of the cooldown
 /// period, the stake is finally released.
-#[derive(SerdeSerialize, SerdeDeserialize, Debug, PartialEq)]
+#[derive(SerdeSerialize, SerdeDeserialize, Debug, PartialEq, Clone)]
 pub enum CooldownStatus {
     /// The amount is in cooldown and will expire at the specified time,
     /// becoming available at the subsequent pay day.
@@ -322,7 +322,7 @@ pub enum CooldownStatus {
     PrePreCooldown,
 }
 
-#[derive(SerdeSerialize, SerdeDeserialize, Debug, PartialEq)]
+#[derive(SerdeSerialize, SerdeDeserialize, Debug, PartialEq, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct Cooldown {
     /// The time in milliseconds since the Unix epoch when the cooldown period
@@ -337,7 +337,7 @@ pub struct Cooldown {
     pub status: CooldownStatus,
 }
 
-#[derive(SerdeSerialize, SerdeDeserialize, Debug, PartialEq)]
+#[derive(SerdeSerialize, SerdeDeserialize, Debug, PartialEq, Clone)]
 #[serde(rename_all = "camelCase")]
 /// Account information exposed via the node's API. This is always the state of
 /// an account in a specific block.


### PR DESCRIPTION
## Purpose

Adding the unit tests for the `validate_transfer` method of the `TokenClient`.

## Changes
- Added unit testing for `validate_transfer`.
- Added `#[derive(Clone)]` to the `AccountToken`, `AccountTokenState`.

## Checklist

- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [x] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [x] (If necessary) I have updated the CHANGELOG.

## CLA acceptance

By submitting the contribution I accept the terms and conditions of the
Contributor License Agreement v1.0
- link: https://developers.concordium.com/CLAs/Contributor-License-Agreement-v1.0.pdf

- [x] I accept the above linked CLA.
