### PR TITLE
Make BlockInfo and ConsensusInfo forward-compatible

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## Unreleased changes
 
+
+- Introduce `ProtocolVersionInt` newtype, wrapping the `u64` representation of the `ProtocolVersion`. This type is forward-compatible, meaning future protocol versions can be represented using this type.
+- Change type for field `protocol_version` in struct `BlockInfo` and `ConsensusInfo` to `ProtocolVersionInt` making these types forward-compatible.
 - Add `NextUpdateSequenceNumbers::protocol_level_tokens` and protobuf deserialization of it
 - Changed `TokenClient`'s `burn` and `mint` methods to accept a singular `TokenAmount`, instead of `Vec<TokenAmount>`.
 - Added `PartialEq`, `Eq`, `Hash` to `TokenInfo`

--- a/examples/protocol-updates.rs
+++ b/examples/protocol-updates.rs
@@ -320,7 +320,7 @@ async fn send_and_wait(
     pv: ProtocolVersion,
 ) -> anyhow::Result<bool> {
     let ci = client.get_consensus_info().await?;
-    if ci.protocol_version == pv {
+    if ci.protocol_version == pv.into() {
         let submission_id = client
             .send_block_item(block_item)
             .await
@@ -341,7 +341,7 @@ async fn send_and_wait(
         loop {
             interval.tick().await;
             let ci = client.get_consensus_info().await?;
-            if ci.protocol_version > pv {
+            if ci.protocol_version > pv.into() {
                 break;
             }
         }

--- a/src/types/queries.rs
+++ b/src/types/queries.rs
@@ -9,6 +9,23 @@ use concordium_base::{
 };
 use std::net::IpAddr;
 
+/// Integer representation of the protocol version.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, SerdeSerialize, SerdeDeserialize)]
+#[repr(transparent)]
+pub struct ProtocolVersionInt(pub u64);
+
+impl TryFrom<ProtocolVersionInt> for ProtocolVersion {
+    type Error = UnknownProtocolVersion;
+
+    fn try_from(value: ProtocolVersionInt) -> Result<Self, Self::Error> {
+        ProtocolVersion::try_from(value.0)
+    }
+}
+
+impl From<ProtocolVersion> for ProtocolVersionInt {
+    fn from(value: ProtocolVersion) -> Self { Self(value.into()) }
+}
+
 #[derive(SerdeDeserialize, Debug, SerdeSerialize)]
 #[serde(rename_all = "camelCase")]
 /// Metadata about a given block.
@@ -57,7 +74,7 @@ pub struct BlockInfo {
     /// going to always be `Some`.
     pub block_baker:             Option<BakerId>,
     /// Protocol version to which the block belongs.
-    pub protocol_version:        ProtocolVersion,
+    pub protocol_version:        ProtocolVersionInt,
     /// The round of the block. Present from protocol version 6.
     pub round:                   Option<Round>,
     /// The epoch of the block. Present from protocol version 6.
@@ -145,7 +162,7 @@ pub struct ConsensusInfo {
     /// The time (local time of the node) that a block was last received.
     pub block_last_received_time:       Option<chrono::DateTime<chrono::Utc>>,
     /// Currently active protocol version.
-    pub protocol_version:               ProtocolVersion,
+    pub protocol_version:               ProtocolVersionInt,
     /// The number of chain restarts via a protocol update. An effected
     /// protocol update instruction might not change the protocol version
     /// specified in the previous field, but it always increments the genesis


### PR DESCRIPTION
## Purpose

Ref COR-1717

## Changes

- Introduce `ProtocolVersionInt` newtype, wrapping the `u64` representation of the `ProtocolVersion`. This type is forward-compatible, meaning future protocol versions can be represented using this type.
- Change type for field `protocol_version` in struct `BlockInfo` and `ConsensusInfo` to `ProtocolVersionInt` making these types forward-compatible.
