### PR TITLE
Forward-compatible: AccountTransactionDetails

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,10 +2,17 @@
 
 - Introduce `ProtocolVersionInt` newtype, wrapping the `u64` representation of the `ProtocolVersion`. This type is forward-compatible, meaning future protocol versions can be represented using this type.
 - Change type for field `protocol_version` in struct `BlockInfo` and `ConsensusInfo` to `ProtocolVersionInt` making these types forward-compatible.
-- Introduce `Upward<A>` for representing types, which might get extended in a future version of the Concordium Node API and allows the consumer of this library to decide how to handle some unknown future data, like new transaction types.
-- Change type for field `details` in struct `BlockItemSummary` from `BlockItemSummaryDetails` to `Upward<BlockItemSummaryDetails>` preventing queries producing this type from failing due to future unknown data.
-- Change `BlockItemSummary::affected_addresses` return type from `Vec<AccountAddress>` to `Upward<Vec<AccountAddress>>` which now returns `Upward::Unknown` when block item summary contains any unknown data introduced in a later node API version.
-- Change `BlockItemSummary::affected_contracts` return type from `Vec<ContractAddress>` to `Upward<Vec<ContractAddress>>` which now returns `Upward::Unknown` when block item summary contains any unknown data introduced in a later node API version.
+- Introduce `Upward<A>` for representing types, which might get extended in a future version of the Concordium Node API and allows the consumer of this library to decide how to handle some unknown future data, like new transaction types and chain events.
+- BREAKING: Change types related to gRPC API responses to wrap `Upward` for values which might be extended in a future version of the API of the Concordium Node.
+
+  The changes are for:
+
+  - Type `BlockItemSummary` field `details`.
+  - Method `BlockItemSummary::affected_addresses` return value.
+  - Method `BlockItemSummary::affected_contracts` return value.
+  - Type `AccountTransactionDetails` field `effects`.
+  - Method `AccountTransactionDetails::transaction_type` return value.
+
 - Add `NextUpdateSequenceNumbers::protocol_level_tokens` and protobuf deserialization of it
 - Changed `TokenClient`'s `burn` and `mint` methods to accept a singular `TokenAmount`, instead of `Vec<TokenAmount>`.
 - Added `PartialEq`, `Eq`, `Hash` to `TokenInfo`

--- a/examples/list-all-transactions.rs
+++ b/examples/list-all-transactions.rs
@@ -82,20 +82,24 @@ async fn main() -> anyhow::Result<()> {
             }
         }
         for bisummary in summary {
-            if let Upward::Known(BlockItemSummaryDetails::AccountTransaction(at)) =
-                &bisummary.details
-            {
-                if types.is_empty() || at.transaction_type().is_some_and(|tt| types.contains(&tt)) {
-                    let is_success = !matches!(&at.effects, AccountTransactionEffects::None { .. });
-                    let type_string = at
-                        .transaction_type()
-                        .map_or_else(|| "N/A".into(), |tt| tt.to_string());
-                    println!(
-                        "{}, {}, {}, {}, {}",
-                        bi.block_slot_time, bi.block_hash, bisummary.hash, is_success, type_string
-                    )
-                }
+            let Upward::Known(BlockItemSummaryDetails::AccountTransaction(at)) = &bisummary.details
+            else {
+                continue;
+            };
+            let Upward::Known(effects) = &at.effects else {
+                continue;
+            };
+            let Some(transaction_type) = effects.transaction_type() else {
+                continue;
+            };
+            if !types.is_empty() && !types.contains(&transaction_type) {
+                continue;
             }
+            let is_success = !matches!(effects, AccountTransactionEffects::None { .. });
+            println!(
+                "{}, {}, {}, {}, {}",
+                bi.block_slot_time, bi.block_hash, bisummary.hash, is_success, transaction_type
+            );
         }
     }
     Ok(())

--- a/examples/transfer-indexer.rs
+++ b/examples/transfer-indexer.rs
@@ -57,8 +57,11 @@ impl indexer::ProcessEvent for StoreTransfers {
             let Upward::Known(BlockItemSummaryDetails::AccountTransaction(at)) = &tx.details else {
                 continue;
             };
+            let Upward::Known(effects) = &at.effects else {
+                continue;
+            };
             // we only look at transfers or transfers with memo.
-            let (amount, to) = match at.effects {
+            let (amount, to) = match effects {
                 AccountTransactionEffects::AccountTransfer { amount, to } => (amount, to),
                 AccountTransactionEffects::AccountTransferWithMemo {
                     amount,

--- a/examples/v2_get_account_info.rs
+++ b/examples/v2_get_account_info.rs
@@ -2,7 +2,7 @@
 use anyhow::Context;
 use clap::AppSettings;
 use concordium_base::hashes::BlockHash;
-use concordium_rust_sdk::{types::AccountIndex, v2};
+use concordium_rust_sdk::v2;
 use structopt::StructOpt;
 
 #[derive(StructOpt)]
@@ -14,7 +14,7 @@ struct App {
     )]
     endpoint: v2::Endpoint,
     #[structopt(long = "address", help = "Account address to query.")]
-    address:  AccountIndex,
+    address:  v2::AccountIdentifier,
     #[structopt(long = "block", help = "Block to query the account in.")]
     block:    Option<BlockHash>,
 }
@@ -36,10 +36,8 @@ async fn main() -> anyhow::Result<()> {
         .context("Cannot connect.")?;
 
     {
-        let ai = client
-            .get_account_info(&app.address.into(), &block_ident)
-            .await?;
-        println!("{:#?}", ai);
+        let ai = client.get_account_info(&app.address, &block_ident).await?;
+        println!("{ai:#?}");
     }
 
     Ok(())

--- a/src/contract_client.rs
+++ b/src/contract_client.rs
@@ -443,7 +443,7 @@ impl<Type> ContractInitBuilder<Type> {
             .await?
             .inner;
 
-        let data = match result.details.effects.ok_or_else(|| {
+        let data = match result.details.effects.known_or_else(|| {
             dry_run::DryRunError::CallError(tonic::Status::invalid_argument(
                 "Unexpected response from dry-running a contract initialization.",
             ))
@@ -565,7 +565,7 @@ impl ModuleDeployBuilder {
             .await?
             .inner;
 
-        let module_ref = match result.details.effects.ok_or_else(|| {
+        let module_ref = match result.details.effects.known_or_else(|| {
             dry_run::DryRunError::CallError(tonic::Status::invalid_argument(
                 "Unexpected response from dry-running a module deployment.",
             ))

--- a/src/contract_client.rs
+++ b/src/contract_client.rs
@@ -299,19 +299,28 @@ impl<Type> ContractInitHandle<Type> {
             );
         };
         match details {
-            crate::types::BlockItemSummaryDetails::AccountTransaction(at) => match at.effects {
-                AccountTransactionEffects::ContractInitialized { data } => {
-                    let contract_client = ContractClient::create(self.client, data.address).await?;
-                    Ok((contract_client, data.events))
+            crate::types::BlockItemSummaryDetails::AccountTransaction(at) => {
+                let v2::upward::Upward::Known(effects) = at.effects else {
+                    return mk_error(
+                        "Expected smart contract initialization status, but received unknown \
+                         block item details.",
+                    );
+                };
+                match effects {
+                    AccountTransactionEffects::ContractInitialized { data } => {
+                        let contract_client =
+                            ContractClient::create(self.client, data.address).await?;
+                        Ok((contract_client, data.events))
+                    }
+                    AccountTransactionEffects::None {
+                        transaction_type: _,
+                        reject_reason,
+                    } => Err(ContractInitError::Failed(reject_reason)),
+                    _ => mk_error(
+                        "Expected smart contract initialization status, but did not receive it.",
+                    ),
                 }
-                AccountTransactionEffects::None {
-                    transaction_type: _,
-                    reject_reason,
-                } => Err(ContractInitError::Failed(reject_reason)),
-                _ => mk_error(
-                    "Expected smart contract initialization status, but did not receive it.",
-                ),
-            },
+            }
             crate::types::BlockItemSummaryDetails::AccountCreation(_) => mk_error(
                 "Expected smart contract initialization status, but received account creation.",
             ),
@@ -434,7 +443,11 @@ impl<Type> ContractInitBuilder<Type> {
             .await?
             .inner;
 
-        let data = match result.details.effects {
+        let data = match result.details.effects.ok_or_else(|| {
+            dry_run::DryRunError::CallError(tonic::Status::invalid_argument(
+                "Unexpected response from dry-running a contract initialization.",
+            ))
+        })? {
             AccountTransactionEffects::None {
                 transaction_type: _,
                 reject_reason,
@@ -552,7 +565,11 @@ impl ModuleDeployBuilder {
             .await?
             .inner;
 
-        let module_ref = match result.details.effects {
+        let module_ref = match result.details.effects.ok_or_else(|| {
+            dry_run::DryRunError::CallError(tonic::Status::invalid_argument(
+                "Unexpected response from dry-running a module deployment.",
+            ))
+        })? {
             AccountTransactionEffects::None {
                 transaction_type: _,
                 reject_reason,
@@ -561,7 +578,7 @@ impl ModuleDeployBuilder {
             _ => {
                 return Err(
                     dry_run::DryRunError::CallError(tonic::Status::invalid_argument(
-                        "Unexpected response from dry-running a contract initialization.",
+                        "Unexpected response from dry-running a module deployment.",
                     ))
                     .into(),
                 )
@@ -647,18 +664,27 @@ impl ModuleDeployHandle {
             );
         };
         match details {
-            crate::types::BlockItemSummaryDetails::AccountTransaction(at) => match at.effects {
-                AccountTransactionEffects::ModuleDeployed { module_ref } => Ok(ModuleDeployData {
-                    energy:           result.energy_cost,
-                    cost:             at.cost,
-                    module_reference: module_ref,
-                }),
-                AccountTransactionEffects::None {
-                    transaction_type: _,
-                    reject_reason,
-                } => Err(ModuleDeployError::Failed(reject_reason)),
-                _ => mk_error("Expected module deploy status, but did not receive it."),
-            },
+            crate::types::BlockItemSummaryDetails::AccountTransaction(at) => {
+                let v2::upward::Upward::Known(effects) = at.effects else {
+                    return mk_error(
+                        "Expected  module deploy status, but received unknown block item effect.",
+                    );
+                };
+                match effects {
+                    AccountTransactionEffects::ModuleDeployed { module_ref } => {
+                        Ok(ModuleDeployData {
+                            energy:           result.energy_cost,
+                            cost:             at.cost,
+                            module_reference: module_ref,
+                        })
+                    }
+                    AccountTransactionEffects::None {
+                        transaction_type: _,
+                        reject_reason,
+                    } => Err(ModuleDeployError::Failed(reject_reason)),
+                    _ => mk_error("Expected module deploy status, but did not receive it."),
+                }
+            }
             crate::types::BlockItemSummaryDetails::AccountCreation(_) => {
                 mk_error("Expected module deploy status, but received account creation.")
             }
@@ -1659,27 +1685,36 @@ impl ContractUpdateHandle {
             );
         };
         match details {
-            crate::types::BlockItemSummaryDetails::AccountTransaction(at) => match at.effects {
-                AccountTransactionEffects::ContractUpdateIssued { effects } => {
-                    let Some(execution_tree) = crate::types::execution_tree(effects) else {
-                        return mk_error(
-                            "Expected smart contract update, but received invalid execution tree.",
-                        );
-                    };
-                    Ok(ContractUpdateInfo {
-                        execution_tree,
-                        energy_cost: result.energy_cost,
-                        cost: at.cost,
-                        transaction_hash: self.tx_hash,
-                        sender: at.sender,
-                    })
+            crate::types::BlockItemSummaryDetails::AccountTransaction(at) => {
+                let v2::upward::Upward::Known(effects) = at.effects else {
+                    return mk_error(
+                        "Expected smart contract update status, but received unknown block item \
+                         effects.",
+                    );
+                };
+                match effects {
+                    AccountTransactionEffects::ContractUpdateIssued { effects } => {
+                        let Some(execution_tree) = crate::types::execution_tree(effects) else {
+                            return mk_error(
+                                "Expected smart contract update, but received invalid execution \
+                                 tree.",
+                            );
+                        };
+                        Ok(ContractUpdateInfo {
+                            execution_tree,
+                            energy_cost: result.energy_cost,
+                            cost: at.cost,
+                            transaction_hash: self.tx_hash,
+                            sender: at.sender,
+                        })
+                    }
+                    AccountTransactionEffects::None {
+                        transaction_type: _,
+                        reject_reason,
+                    } => Err(ContractUpdateError::Failed(reject_reason)),
+                    _ => mk_error("Expected smart contract update status, but did not receive it."),
                 }
-                AccountTransactionEffects::None {
-                    transaction_type: _,
-                    reject_reason,
-                } => Err(ContractUpdateError::Failed(reject_reason)),
-                _ => mk_error("Expected smart contract update status, but did not receive it."),
-            },
+            }
             crate::types::BlockItemSummaryDetails::AccountCreation(_) => {
                 mk_error("Expected smart contract update status, but received account creation.")
             }

--- a/src/indexer.rs
+++ b/src/indexer.rs
@@ -444,7 +444,7 @@ pub struct ContractUpdateInfo {
 
 fn update_info(summary: BlockItemSummary) -> Option<ContractUpdateInfo> {
     let at = summary.details.known()?.account_transaction()?;
-    let AccountTransactionEffects::ContractUpdateIssued { effects } = at.effects else {
+    let AccountTransactionEffects::ContractUpdateIssued { effects } = at.effects.known()? else {
         return None;
     };
 

--- a/src/types/mod.rs
+++ b/src/types/mod.rs
@@ -1210,7 +1210,7 @@ impl BlockItemSummary {
     pub fn affected_contracts(&self) -> Upward<Vec<ContractAddress>> {
         self.details
             .as_ref()
-            .map(BlockItemSummaryDetails::affected_contracts)
+            .and_then(BlockItemSummaryDetails::affected_contracts)
     }
 
     /// If the block item is a smart contract update transaction then return the
@@ -1244,7 +1244,7 @@ impl BlockItemSummary {
     pub fn affected_addresses(&self) -> Upward<Vec<AccountAddress>> {
         self.details
             .as_ref()
-            .map(BlockItemSummaryDetails::affected_addresses)
+            .and_then(BlockItemSummaryDetails::affected_addresses)
     }
 }
 
@@ -1765,12 +1765,7 @@ impl BlockItemSummaryDetails {
     /// transaction. This returns `Some` if and only if
     /// [`is_reject`](Self::is_reject) returns `true`.
     pub fn account_transaction_reject_reason(&self) -> Option<&RejectReason> {
-        match self {
-            BlockItemSummaryDetails::AccountTransaction(ad) => ad.is_rejected(),
-            BlockItemSummaryDetails::AccountCreation(_) => None,
-            BlockItemSummaryDetails::Update(_) => None,
-            BlockItemSummaryDetails::TokenCreationDetails(_) => None,
-        }
+        self.as_account_transaction()?.is_rejected()
     }
 
     /// Return the account address signing the
@@ -1779,62 +1774,38 @@ impl BlockItemSummaryDetails {
         Some(self.as_account_transaction()?.sender)
     }
 
-    fn affected_contracts(&self) -> Vec<ContractAddress> {
-        if let BlockItemSummaryDetails::AccountTransaction(at) = self {
-            match &at.effects {
-                AccountTransactionEffects::ContractInitialized { data } => vec![data.address],
-                AccountTransactionEffects::ContractUpdateIssued { effects } => {
-                    let mut seen = HashSet::new();
-                    let mut addresses = Vec::new();
-                    for effect in effects {
-                        match effect {
-                            ContractTraceElement::Updated { data } => {
-                                if seen.insert(data.address) {
-                                    addresses.push(data.address);
-                                }
-                            }
-                            ContractTraceElement::Transferred { .. } => (),
-                            ContractTraceElement::Interrupted { .. } => (),
-                            ContractTraceElement::Resumed { .. } => (),
-                            ContractTraceElement::Upgraded { .. } => (),
-                        }
-                    }
-                    addresses
-                }
-                _ => Vec::new(),
-            }
+    /// Return the list of smart contract addresses affected by the block
+    /// summary.
+    ///
+    /// Returns [`Upward::Unknown`] when encountering unfamiliar data from newer
+    /// versions of the node to stay forward-compatible.
+    fn affected_contracts(&self) -> Upward<Vec<ContractAddress>> {
+        if let Some(at) = self.as_account_transaction() {
+            at.effects
+                .as_ref()
+                .map(AccountTransactionEffects::affected_contracts)
         } else {
-            Vec::new()
+            Upward::Known(Vec::new())
         }
     }
 
     /// If the block item is a smart contract update transaction then return the
     /// execution tree.
     pub fn contract_update(self) -> Option<ExecutionTree> {
-        if let BlockItemSummaryDetails::AccountTransaction(at) = self {
-            match at.effects {
-                AccountTransactionEffects::ContractInitialized { .. } => None,
-                AccountTransactionEffects::ContractUpdateIssued { effects } => {
-                    execution_tree(effects)
-                }
-                _ => None,
-            }
-        } else {
-            None
+        match self.account_transaction()?.effects.known()? {
+            AccountTransactionEffects::ContractInitialized { .. } => None,
+            AccountTransactionEffects::ContractUpdateIssued { effects } => execution_tree(effects),
+            _ => None,
         }
     }
 
     /// If the block item is a smart contract init transaction then
     /// return the initialization data.
     pub fn contract_init(&self) -> Option<&ContractInitializedEvent> {
-        if let BlockItemSummaryDetails::AccountTransaction(at) = self {
-            match &at.effects {
-                AccountTransactionEffects::ContractInitialized { data } => Some(data),
-                AccountTransactionEffects::ContractUpdateIssued { .. } => None,
-                _ => None,
-            }
-        } else {
-            None
+        match self.as_account_transaction()?.effects.as_known()? {
+            AccountTransactionEffects::ContractInitialized { data } => Some(data),
+            AccountTransactionEffects::ContractUpdateIssued { .. } => None,
+            _ => None,
         }
     }
 
@@ -1845,111 +1816,112 @@ impl BlockItemSummaryDetails {
         &self,
     ) -> Option<impl Iterator<Item = (ContractAddress, &[smart_contracts::ContractEvent])> + '_>
     {
-        if let BlockItemSummaryDetails::AccountTransaction(at) = self {
-            match &at.effects {
-                AccountTransactionEffects::ContractInitialized { .. } => None,
-                AccountTransactionEffects::ContractUpdateIssued { effects } => {
-                    let iter = effects.iter().flat_map(|effect| match effect {
-                        ContractTraceElement::Updated { data } => {
-                            Some((data.address, &data.events[..]))
-                        }
-                        ContractTraceElement::Transferred { .. } => None,
-                        ContractTraceElement::Interrupted { address, events } => {
-                            Some((*address, &events[..]))
-                        }
-                        ContractTraceElement::Resumed { .. } => None,
-                        ContractTraceElement::Upgraded { .. } => None,
-                    });
-                    Some(iter)
-                }
-                _ => None,
+        match self.as_account_transaction()?.effects.as_known()? {
+            AccountTransactionEffects::ContractInitialized { .. } => None,
+            AccountTransactionEffects::ContractUpdateIssued { effects } => {
+                let iter = effects.iter().flat_map(|effect| match effect {
+                    ContractTraceElement::Updated { data } => {
+                        Some((data.address, &data.events[..]))
+                    }
+                    ContractTraceElement::Transferred { .. } => None,
+                    ContractTraceElement::Interrupted { address, events } => {
+                        Some((*address, &events[..]))
+                    }
+                    ContractTraceElement::Resumed { .. } => None,
+                    ContractTraceElement::Upgraded { .. } => None,
+                });
+                Some(iter)
             }
-        } else {
-            None
+            _ => None,
         }
     }
 
     /// Return the list of addresses affected by the block summary.
     /// These are addresses that have their CCD balance or plt token balance
     /// changed as part of the block summary.
-    fn affected_addresses(&self) -> Vec<AccountAddress> {
-        match self {
-            BlockItemSummaryDetails::AccountTransaction(at) => match &at.effects {
-                AccountTransactionEffects::None { .. } => vec![at.sender],
-                AccountTransactionEffects::ModuleDeployed { .. } => vec![at.sender],
-                AccountTransactionEffects::ContractInitialized { .. } => vec![at.sender],
-                AccountTransactionEffects::ContractUpdateIssued { effects } => {
-                    let mut seen = BTreeSet::new();
-                    seen.insert(at.sender);
-                    let mut addresses = vec![at.sender];
-                    for effect in effects {
-                        match effect {
-                            ContractTraceElement::Updated { .. } => (),
-                            ContractTraceElement::Transferred { to, .. } => {
-                                if seen.insert(*to) {
-                                    addresses.push(*to);
+    fn affected_addresses(&self) -> Upward<Vec<AccountAddress>> {
+        let out = match self {
+            BlockItemSummaryDetails::AccountTransaction(at) => {
+                let Upward::Known(effects) = &at.effects else {
+                    return Upward::Unknown;
+                };
+                match effects {
+                    AccountTransactionEffects::None { .. } => vec![at.sender],
+                    AccountTransactionEffects::ModuleDeployed { .. } => vec![at.sender],
+                    AccountTransactionEffects::ContractInitialized { .. } => vec![at.sender],
+                    AccountTransactionEffects::ContractUpdateIssued { effects } => {
+                        let mut seen = BTreeSet::new();
+                        seen.insert(at.sender);
+                        let mut addresses = vec![at.sender];
+                        for effect in effects {
+                            match effect {
+                                ContractTraceElement::Updated { .. } => (),
+                                ContractTraceElement::Transferred { to, .. } => {
+                                    if seen.insert(*to) {
+                                        addresses.push(*to);
+                                    }
                                 }
+                                ContractTraceElement::Interrupted { .. } => (),
+                                ContractTraceElement::Resumed { .. } => (),
+                                ContractTraceElement::Upgraded { .. } => (),
                             }
-                            ContractTraceElement::Interrupted { .. } => (),
-                            ContractTraceElement::Resumed { .. } => (),
-                            ContractTraceElement::Upgraded { .. } => (),
+                        }
+                        addresses
+                    }
+                    AccountTransactionEffects::AccountTransfer { to, .. } => {
+                        if *to == at.sender {
+                            vec![at.sender]
+                        } else {
+                            vec![at.sender, *to]
                         }
                     }
-                    addresses
-                }
-                AccountTransactionEffects::AccountTransfer { to, .. } => {
-                    if *to == at.sender {
+                    AccountTransactionEffects::AccountTransferWithMemo { to, .. } => {
+                        if *to == at.sender {
+                            vec![at.sender]
+                        } else {
+                            vec![at.sender, *to]
+                        }
+                    }
+                    AccountTransactionEffects::BakerAdded { .. } => vec![at.sender],
+                    AccountTransactionEffects::BakerRemoved { .. } => vec![at.sender],
+                    AccountTransactionEffects::BakerStakeUpdated { .. } => vec![at.sender],
+                    AccountTransactionEffects::BakerRestakeEarningsUpdated { .. } => {
                         vec![at.sender]
-                    } else {
+                    }
+                    AccountTransactionEffects::BakerKeysUpdated { .. } => vec![at.sender],
+                    AccountTransactionEffects::EncryptedAmountTransferred { removed, added } => {
+                        vec![removed.account, added.receiver]
+                    }
+                    AccountTransactionEffects::EncryptedAmountTransferredWithMemo {
+                        removed,
+                        added,
+                        ..
+                    } => vec![removed.account, added.receiver],
+                    AccountTransactionEffects::TransferredToEncrypted { data } => {
+                        vec![data.account]
+                    }
+                    AccountTransactionEffects::TransferredToPublic { removed, .. } => {
+                        vec![removed.account]
+                    }
+                    AccountTransactionEffects::TransferredWithSchedule { to, .. } => {
                         vec![at.sender, *to]
                     }
-                }
-                AccountTransactionEffects::AccountTransferWithMemo { to, .. } => {
-                    if *to == at.sender {
-                        vec![at.sender]
-                    } else {
+                    AccountTransactionEffects::TransferredWithScheduleAndMemo { to, .. } => {
                         vec![at.sender, *to]
                     }
+                    AccountTransactionEffects::CredentialKeysUpdated { .. } => vec![at.sender],
+                    AccountTransactionEffects::CredentialsUpdated { .. } => vec![at.sender],
+                    AccountTransactionEffects::DataRegistered { .. } => vec![at.sender],
+                    AccountTransactionEffects::BakerConfigured { .. } => vec![at.sender],
+                    AccountTransactionEffects::DelegationConfigured { .. } => vec![at.sender],
+                    AccountTransactionEffects::TokenUpdate { events } => {
+                        let mut addresses = BTreeSet::new();
+                        addresses.insert(at.sender);
+                        add_token_event_addresses(&mut addresses, events);
+                        addresses.into_iter().collect()
+                    }
                 }
-                AccountTransactionEffects::BakerAdded { .. } => vec![at.sender],
-                AccountTransactionEffects::BakerRemoved { .. } => vec![at.sender],
-                AccountTransactionEffects::BakerStakeUpdated { .. } => vec![at.sender],
-                AccountTransactionEffects::BakerRestakeEarningsUpdated { .. } => {
-                    vec![at.sender]
-                }
-                AccountTransactionEffects::BakerKeysUpdated { .. } => vec![at.sender],
-                AccountTransactionEffects::EncryptedAmountTransferred { removed, added } => {
-                    vec![removed.account, added.receiver]
-                }
-                AccountTransactionEffects::EncryptedAmountTransferredWithMemo {
-                    removed,
-                    added,
-                    ..
-                } => vec![removed.account, added.receiver],
-                AccountTransactionEffects::TransferredToEncrypted { data } => {
-                    vec![data.account]
-                }
-                AccountTransactionEffects::TransferredToPublic { removed, .. } => {
-                    vec![removed.account]
-                }
-                AccountTransactionEffects::TransferredWithSchedule { to, .. } => {
-                    vec![at.sender, *to]
-                }
-                AccountTransactionEffects::TransferredWithScheduleAndMemo { to, .. } => {
-                    vec![at.sender, *to]
-                }
-                AccountTransactionEffects::CredentialKeysUpdated { .. } => vec![at.sender],
-                AccountTransactionEffects::CredentialsUpdated { .. } => vec![at.sender],
-                AccountTransactionEffects::DataRegistered { .. } => vec![at.sender],
-                AccountTransactionEffects::BakerConfigured { .. } => vec![at.sender],
-                AccountTransactionEffects::DelegationConfigured { .. } => vec![at.sender],
-                AccountTransactionEffects::TokenUpdate { events } => {
-                    let mut addresses = BTreeSet::new();
-                    addresses.insert(at.sender);
-                    add_token_event_addresses(&mut addresses, events);
-                    addresses.into_iter().collect()
-                }
-            },
+            }
             BlockItemSummaryDetails::AccountCreation(_) => Vec::new(),
             BlockItemSummaryDetails::Update(_) => Vec::new(),
             BlockItemSummaryDetails::TokenCreationDetails(token_creation_details) => {
@@ -1957,7 +1929,8 @@ impl BlockItemSummaryDetails {
                 add_token_event_addresses(&mut addresses, &token_creation_details.events);
                 addresses.into_iter().collect()
             }
-        }
+        };
+        Upward::Known(out)
     }
 }
 
@@ -1971,7 +1944,7 @@ pub struct AccountTransactionDetails {
     /// Sender of the transaction.
     pub sender:  AccountAddress,
     /// Effects of the account transaction, if any.
-    pub effects: AccountTransactionEffects,
+    pub effects: Upward<AccountTransactionEffects>,
 }
 
 impl AccountTransactionDetails {
@@ -1980,10 +1953,19 @@ impl AccountTransactionDetails {
     /// [AccountTransactionEffects::None]
     /// variant in case the transaction failed with serialization failure
     /// reason.
-    pub fn transaction_type(&self) -> Option<TransactionType> { self.effects.transaction_type() }
+    ///
+    /// To remain forward-compatible the `TransactionType` is wrapped in
+    /// [`Upward`] for representing future unknown transaction types introduced
+    /// in a newer node API version.
+    pub fn transaction_type(&self) -> Option<Upward<TransactionType>> {
+        let Upward::Known(effects) = self.effects.as_ref() else {
+            return Some(Upward::Unknown);
+        };
+        effects.transaction_type().map(Upward::Known)
+    }
 
     /// Return [`Some`] if the transaction has been rejected.
-    pub fn is_rejected(&self) -> Option<&RejectReason> { self.effects.is_rejected() }
+    pub fn is_rejected(&self) -> Option<&RejectReason> { self.effects.as_known()?.is_rejected() }
 }
 
 impl AccountTransactionEffects {
@@ -2228,6 +2210,31 @@ impl AccountTransactionEffects {
             Some(reject_reason)
         } else {
             None
+        }
+    }
+
+    fn affected_contracts(&self) -> Vec<ContractAddress> {
+        match self {
+            AccountTransactionEffects::ContractInitialized { data } => vec![data.address],
+            AccountTransactionEffects::ContractUpdateIssued { effects } => {
+                let mut seen = HashSet::new();
+                let mut addresses = Vec::new();
+                for effect in effects {
+                    match effect {
+                        ContractTraceElement::Updated { data } => {
+                            if seen.insert(data.address) {
+                                addresses.push(data.address);
+                            }
+                        }
+                        ContractTraceElement::Transferred { .. } => (),
+                        ContractTraceElement::Interrupted { .. } => (),
+                        ContractTraceElement::Resumed { .. } => (),
+                        ContractTraceElement::Upgraded { .. } => (),
+                    }
+                }
+                addresses
+            }
+            _ => Vec::new(),
         }
     }
 }

--- a/src/types/summary_helper.rs
+++ b/src/types/summary_helper.rs
@@ -525,7 +525,7 @@ impl TryFrom<super::BlockItemSummary> for BlockItemSummary {
                         events: vec![ev1, ev2, ev3],
                     })
                 };
-                let (transaction_type, result) = match effects.require()? {
+                let (transaction_type, result) = match effects.known_or_err()? {
                     super::AccountTransactionEffects::None {
                         transaction_type,
                         reject_reason,

--- a/src/types/summary_helper.rs
+++ b/src/types/summary_helper.rs
@@ -525,7 +525,7 @@ impl TryFrom<super::BlockItemSummary> for BlockItemSummary {
                         events: vec![ev1, ev2, ev3],
                     })
                 };
-                let (transaction_type, result) = match effects {
+                let (transaction_type, result) = match effects.require()? {
                     super::AccountTransactionEffects::None {
                         transaction_type,
                         reject_reason,
@@ -992,10 +992,10 @@ fn convert_account_transaction(
         Ok(super::AccountTransactionDetails {
             cost,
             sender,
-            effects: super::AccountTransactionEffects::None {
+            effects: Upward::Known(super::AccountTransactionEffects::None {
                 transaction_type: ty,
                 reject_reason,
-            },
+            }),
         })
     };
 
@@ -1003,7 +1003,7 @@ fn convert_account_transaction(
         Ok(super::AccountTransactionDetails {
             cost,
             sender,
-            effects,
+            effects: Upward::Known(effects),
         })
     };
 

--- a/src/v2/conversions.rs
+++ b/src/v2/conversions.rs
@@ -1292,7 +1292,7 @@ impl TryFrom<AccountTransactionDetails> for super::types::AccountTransactionDeta
         Ok(Self {
             cost:    v.cost.require()?.into(),
             sender:  v.sender.require()?.try_into()?,
-            effects: v.effects.require()?.try_into()?,
+            effects: Upward::from(v.effects.map(TryFrom::try_from).transpose()?),
         })
     }
 }

--- a/src/v2/upward.rs
+++ b/src/v2/upward.rs
@@ -124,6 +124,17 @@ impl<A> Upward<A> {
             Self::Unknown => Upward::Unknown,
         }
     }
+
+    /// Returns [`Upward::Unknown`] if the option is [`Upward::Unknown`],
+    /// otherwise calls `f` with the wrapped value and returns the result.
+    pub fn and_then<U, F>(self, f: F) -> Upward<U>
+    where
+        F: FnOnce(A) -> Upward<U>, {
+        match self {
+            Upward::Unknown => Upward::Unknown,
+            Upward::Known(x) => f(x),
+        }
+    }
 }
 
 impl<A> From<Option<A>> for Upward<A> {


### PR DESCRIPTION
## Purpose

Make `AccountTransactionDetails` forward-compatible
Ref COR-1717

## Changes

- Wrap with `Upward` for field `effects` in `AccountTransactionDetails`, making the type forward-compatible in the case of a new effect being introduced.