### PR TITLE
Forward-compatible `Client::get_block_special_events`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@
   - Method `BlockItemSummary::affected_contracts` return value.
   - Type `AccountTransactionDetails` field `effects`.
   - Method `AccountTransactionDetails::transaction_type` return value.
+  - Method `Client::get_block_special_events` response stream items.
+  - Associated type `Indexer::Data` for `indexer::BlockEventsIndexer`.
 
 - Add `NextUpdateSequenceNumbers::protocol_level_tokens` and protobuf deserialization of it
 - Changed `TokenClient`'s `burn` and `mint` methods to accept a singular `TokenAmount`, instead of `Vec<TokenAmount>`.

--- a/examples/block-stats.rs
+++ b/examples/block-stats.rs
@@ -89,6 +89,9 @@ async fn main() -> anyhow::Result<()> {
             .await?
             .response
             .try_fold(0, |count, ev| async move {
+                let v2::Upward::Known(ev) = ev else {
+                    return Ok(count);
+                };
                 let add = match ev {
                     SpecialTransactionOutcome::PaydayFoundationReward { .. } => 1u32,
                     SpecialTransactionOutcome::PaydayAccountReward { .. } => 1u32,

--- a/src/indexer.rs
+++ b/src/indexer.rs
@@ -634,7 +634,7 @@ impl Indexer for BlockEventsIndexer {
     type Data = (
         BlockInfo,
         Vec<BlockItemSummary>,
-        Vec<SpecialTransactionOutcome>,
+        Vec<v2::Upward<SpecialTransactionOutcome>>,
     );
 
     async fn on_connect<'a>(

--- a/src/v2/conversions.rs
+++ b/src/v2/conversions.rs
@@ -2918,11 +2918,11 @@ impl TryFrom<block_special_event::AccountAmounts>
     }
 }
 
-impl TryFrom<BlockSpecialEvent> for super::types::SpecialTransactionOutcome {
+impl TryFrom<block_special_event::Event> for super::types::SpecialTransactionOutcome {
     type Error = tonic::Status;
 
-    fn try_from(message: BlockSpecialEvent) -> Result<Self, Self::Error> {
-        let event = match message.event.require()? {
+    fn try_from(special_event: block_special_event::Event) -> Result<Self, Self::Error> {
+        let event = match special_event {
             block_special_event::Event::BakingRewards(event) => Self::BakingRewards {
                 baker_rewards: event.baker_rewards.require()?.try_into()?,
                 remainder:     event.remainder.require()?.into(),
@@ -2988,6 +2988,18 @@ impl TryFrom<BlockSpecialEvent> for super::types::SpecialTransactionOutcome {
             }
         };
         Ok(event)
+    }
+}
+
+impl TryFrom<BlockSpecialEvent> for Upward<super::types::SpecialTransactionOutcome> {
+    type Error = tonic::Status;
+
+    fn try_from(message: BlockSpecialEvent) -> Result<Self, Self::Error> {
+        let event = message
+            .event
+            .map(super::types::SpecialTransactionOutcome::try_from)
+            .transpose()?;
+        Ok(Upward::from(event))
     }
 }
 


### PR DESCRIPTION
## Purpose

Ref COR-1717.
Forward-compatible `Client::get_block_special_events`.

## Changes

- Wrap return items in `Upward` allowing the stream to work even when some of the block special events are some future unknown variant.