### PR TITLE
Make `get_block_items` and `get_finalized_block_item` forward-compatible

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@
   - Method `AccountTransactionDetails::transaction_type` return value.
   - Method `Client::get_block_special_events` response stream items.
   - Associated type `Indexer::Data` for `indexer::BlockEventsIndexer`.
+  - Method `Client::get_block_items` response stream items.
+  - Method `Client::get_finalized_block_item` return type.
 
 - Add `NextUpdateSequenceNumbers::protocol_level_tokens` and protobuf deserialization of it
 - Changed `TokenClient`'s `burn` and `mint` methods to accept a singular `TokenAmount`, instead of `Vec<TokenAmount>`.


### PR DESCRIPTION
## Purpose

Ref COR-1717.

## Changes

- Wrap `BlockItem` in return type of `get_block_items` and `get_finalized_block_items`.

