### PR TITLE
fix: add release yaml for github action to publish the sdk to crates.io

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,0 +1,59 @@
+name: Release Concordium Rust SDK
+
+on:
+
+  workflow_dispatch: # allows manual trigger
+
+  push:
+    tags:
+      - release/concordium-rust-sdk/*
+
+env:
+  CARGO_REGISTRY_TOKEN: ${{ secrets.CRATES_IO_TOKEN }}
+  TAG: ${{ github.ref_name }}
+
+jobs:
+
+  ## Concordium Rust SDK Release Build
+  concordium-rust-sdk-release:
+    name: concordium-rust-sdk:release
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          submodules: recursive
+
+      # Check that the tag exists on the main branch before proceeding
+      - name: Check git tag was created on the main branch
+        run: |
+          git fetch origin main
+          git checkout main
+
+          echo "Checking if tag $TAG exists on main branch"
+          git tag --merged main | grep $TAG || { echo "Tag $TAG not found on main branch. Exiting."; exit 1; }
+          echo "Tag $TAG found on main branch. Proceeding with release."
+
+      # Validate that the tag version matches the version in Cargo.toml
+      - name: validate tag version has correct matching tag
+        run: |
+          git checkout $TAG
+
+          echo "Validating tag version $TAG matches expected version from Cargo.toml"
+          EXPECTED_VERSION_FROM_CARGO=$(yq .package.version ./Cargo.toml)
+          TAG_VERSION_NUMBER=${TAG##release/concordium-rust-sdk/}
+          
+          # Check if the tag version number matches the expected version from Cargo.toml
+          if [ "$TAG_VERSION_NUMBER" != "$EXPECTED_VERSION_FROM_CARGO" ]; then
+            echo "version tagged: $TAG_VERSION_NUMBER  does not match cargo version: $EXPECTED_VERSION_FROM_CARGO. Exiting."
+            exit 1
+          else
+            echo "Tag version number matches expected version from Cargo.toml. Proceeding with release."
+          fi
+
+      # Publish to crates.io
+      - name: Publish to crates.io
+        run: |
+          echo "Publishing Concordium Rust SDK to crates.io for version: $TAG_VERSION"
+          cargo publish --token $CARGO_REGISTRY_TOKEN --locked


### PR DESCRIPTION
## Purpose

Create github action to be able to release to crates.io 

## Changes

Add release.yaml specifying steps for publishing the crate

## Checklist

- [ ] My code follows the style of this project.
- [ ] The code compiles without warnings.
- [ ] I have performed a self-review of the changes.
- [ ] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [ ] (If necessary) I have updated the CHANGELOG.

