### PR TITLE
rust toolchain.toml

### DIFF
--- a/.github/workflows/build-and-test.yaml
+++ b/.github/workflows/build-and-test.yaml
@@ -9,7 +9,6 @@ on:
   push:
     branches:
      - main
-     - plt
 
   pull_request:
     types: [opened, synchronize, reopened, ready_for_review, edited]
@@ -18,7 +17,6 @@ on:
 
 env:
   RUST_FMT: nightly-2023-04-01-x86_64-unknown-linux-gnu
-  RUST_VERSION: "1.85"
 
 jobs:
   "lint_fmt":
@@ -31,9 +29,8 @@ jobs:
         uses: actions/checkout@v4
       - name: Format
         run: |
-          rustup default $RUST_FMT
-          rustup component add rustfmt
-          cargo fmt -- --color=always --check
+          rustup +$RUST_FMT component add rustfmt
+          cargo +$RUST_FMT fmt -- --color=always --check
 
   "lint_doc":
     name: lint:doc
@@ -47,7 +44,6 @@ jobs:
           submodules: recursive
       - name: Docs
         run: |
-          rustup default $RUST_VERSION
           rustup component add rust-docs
           RUSTDOCFLAGS="-D warnings" cargo doc --no-deps --color=always
 
@@ -65,7 +61,6 @@ jobs:
           submodules: recursive
       - name: Check
         run: |
-          rustup default $RUST_VERSION
           cargo check --all-targets --all-features 
 
   "lint_clippy_test":
@@ -80,7 +75,6 @@ jobs:
           submodules: recursive
       - name: Clippy
         run: |
-          rustup default $RUST_VERSION
           rustup component add clippy
           cargo clippy --color=always --all-targets --all-features -- -D warnings
           # Examples can be large with a lot of debug info due to tokio. So we

--- a/.github/workflows/build-and-test.yaml
+++ b/.github/workflows/build-and-test.yaml
@@ -11,7 +11,6 @@ on:
      - main
 
   pull_request:
-    types: [opened, synchronize, reopened, ready_for_review, edited]
 
   workflow_dispatch: # allows manual trigger
 
@@ -21,8 +20,6 @@ env:
 jobs:
   "lint_fmt":
     name: lint:fmt
-    # Don't run on draft pull requests
-    if: ${{ !github.event.pull_request.draft }}
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -34,8 +31,6 @@ jobs:
 
   "lint_doc":
     name: lint:doc
-    # Don't run on draft pull requests
-    if: ${{ !github.event.pull_request.draft }}
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -51,8 +46,6 @@ jobs:
   # make sure that the features are correctly set for the normal dependencies.
   "check_pure_compilation":
     name: lint:check
-    # Don't run on draft pull requests
-    if: ${{ !github.event.pull_request.draft }}
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -65,8 +58,6 @@ jobs:
 
   "lint_clippy_test":
     name: lint:clippy
-    # Don't run on draft pull requests
-    if: ${{ !github.event.pull_request.draft }}
     runs-on: ubuntu-latest
     steps:
       - name: Checkout

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,2 @@
+[toolchain]
+channel = "1.85"


### PR DESCRIPTION
## Purpose

Use rust-toolchain.toml to specify Rust version. Means that developers get same result as CI, including those who run examples. See https://linear.app/concordium/issue/COR-1757/rust-sdk-when-compiling-a-rusk-sdk-command-warnings-are-observed

## Changes

_Describe the changes that were needed.

## Checklist

- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [x] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [x] (If necessary) I have updated the CHANGELOG.
