### PR TITLE
Delay the deserialization of payload in `UpdateInstruction` in Rust

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,7 @@
   - Method `AccountTransactionEffects::is_rejected` return value.
   - Type `AccountTransactionEffects` field `reject_reason`.
   - Type `InvokeContractResult` field `reason`.
+  - Type `UpdateInstruction` field `payload` now needs to be decoded on-demand, ensuring errors due to new variants for `UpdatePayload` can be handled separately and the rest of `UpdateInstruction` can still be read.
 
 - Add `NextUpdateSequenceNumbers::protocol_level_tokens` and protobuf deserialization of it
 - Changed `TokenClient`'s `burn` and `mint` methods to accept a singular `TokenAmount`, instead of `Vec<TokenAmount>`.

--- a/src/protocol_level_tokens/token_client.rs
+++ b/src/protocol_level_tokens/token_client.rs
@@ -650,7 +650,8 @@ impl TokenClient {
             .info
             .token_state
             .decode_module_state()?
-            .governance_account;
+            .governance_account
+            .ok_or(TokenError::UnauthorizedGovernanceOperation)?;
 
         if governance_account.address != sender {
             return Err(TokenError::UnauthorizedGovernanceOperation);

--- a/src/v2/conversions.rs
+++ b/src/v2/conversions.rs
@@ -1254,9 +1254,7 @@ impl TryFrom<UpdateInstruction> for concordium_base::updates::UpdateInstruction 
         };
         let signatures: concordium_base::updates::UpdateInstructionSignature =
             value.signatures.require()?.try_into()?;
-
-        let payload = consume(&payload)?;
-
+        let payload = updates::EncodedUpdatePayload::from(payload);
         Ok(Self {
             header,
             payload,


### PR DESCRIPTION
## Purpose

Ref COR-1717.
Delay the deserialization of payload in `UpdateInstruction` in Rust.
This means future payload variants will not cause errors until attempting to deserialize it, and therefore information such as the effective time can still be read without knowing the exact payload type.

Most of the changes are in the PR for base:

Related base PR: https://github.com/Concordium/concordium-base/pull/734

## Changes

- Update concordium-base and fix changes.