### PR TITLE
fix: switch from using wasmVersion to a newly created SmartContractVe…

### DIFF
--- a/src/types/mod.rs
+++ b/src/types/mod.rs
@@ -10,7 +10,10 @@ pub mod transactions;
 use anyhow::Context;
 pub use concordium_base::hashes;
 // re-export to maintain backwards compatibility.
-use crate::{constants::*, protocol_level_tokens, v2::upward::Upward};
+use crate::{
+    constants::*, protocol_level_tokens, types::smart_contracts::SmartContractVersion,
+    v2::upward::Upward,
+};
 pub use concordium_base::{
     base::*,
     id::types::CredentialType,
@@ -39,7 +42,7 @@ use concordium_base::{
     },
     protocol_level_tokens::{TokenAmount, TokenEvent, TokenEventDetails, TokenHolder, TokenId},
     smart_contracts::{
-        ContractEvent, ModuleReference, OwnedParameter, OwnedReceiveName, WasmVersion,
+        ContractEvent, ModuleReference, OwnedParameter, OwnedReceiveName,
     },
     transactions::{AccountAccessStructure, ExactSizeTransactionSigner, TransactionSigner},
 };
@@ -1461,7 +1464,7 @@ pub fn execution_tree(elements: Vec<ContractTraceElement>) -> Option<ExecutionTr
             } => {
                 if let Some(end) = stack.pop() {
                     let tree = match contract_version {
-                        WasmVersion::V0 => ExecutionTree::V0(ExecutionTreeV0 {
+                        SmartContractVersion(0) => ExecutionTree::V0(ExecutionTreeV0 {
                             top_level: UpdateV0 {
                                 address,
                                 instigator,
@@ -1472,7 +1475,8 @@ pub fn execution_tree(elements: Vec<ContractTraceElement>) -> Option<ExecutionTr
                             },
                             rest:      Vec::new(),
                         }),
-                        WasmVersion::V1 => ExecutionTree::V1(ExecutionTreeV1 {
+
+                        _ => ExecutionTree::V1(ExecutionTreeV1 {
                             address,
                             instigator,
                             amount,
@@ -1522,7 +1526,7 @@ pub fn execution_tree(elements: Vec<ContractTraceElement>) -> Option<ExecutionTr
                 } else {
                     // no stack yet
                     match contract_version {
-                        WasmVersion::V0 => stack.push(Worker::V0(ExecutionTreeV0 {
+                        SmartContractVersion(0) => stack.push(Worker::V0(ExecutionTreeV0 {
                             top_level: UpdateV0 {
                                 address,
                                 instigator,
@@ -1533,7 +1537,8 @@ pub fn execution_tree(elements: Vec<ContractTraceElement>) -> Option<ExecutionTr
                             },
                             rest:      Vec::new(),
                         })),
-                        WasmVersion::V1 => {
+
+                        _ => {
                             let tree = ExecutionTreeV1 {
                                 address,
                                 instigator,
@@ -2475,7 +2480,7 @@ pub struct EncryptedSelfAmountAddedEvent {
 #[serde(rename_all = "camelCase")]
 pub struct ContractInitializedEvent {
     #[serde(default)]
-    pub contract_version: smart_contracts::WasmVersion,
+    pub contract_version: SmartContractVersion,
     #[serde(rename = "ref")]
     /// Module with the source code of the contract.
     pub origin_ref:       smart_contracts::ModuleReference,

--- a/src/v2/conversions.rs
+++ b/src/v2/conversions.rs
@@ -4,6 +4,7 @@
 use super::{generated::*, upward::Upward, Require};
 use crate::types::{
     queries::{ConcordiumBFTDetails, ProtocolVersionInt},
+    smart_contracts::SmartContractVersion,
     AccountReleaseSchedule, ActiveBakerPoolStatus, UpdateKeysCollectionSkeleton,
 };
 use chrono::TimeZone;
@@ -1714,7 +1715,8 @@ impl TryFrom<AccountTransactionEffects> for super::types::AccountTransactionEffe
             account_transaction_effects::Effect::ContractInitialized(cie) => {
                 Ok(Self::ContractInitialized {
                     data: super::types::ContractInitializedEvent {
-                        contract_version: cie.contract_version().into(),
+                        contract_version: SmartContractVersion::try_from(cie.contract_version)
+                            .unwrap(),
                         origin_ref:       cie.origin_ref.require()?.try_into()?,
                         address:          cie.address.require()?.into(),
                         amount:           cie.amount.require()?.into(),
@@ -2116,7 +2118,7 @@ impl TryFrom<InstanceUpdatedEvent> for super::types::InstanceUpdatedEvent {
 
     fn try_from(value: InstanceUpdatedEvent) -> Result<Self, Self::Error> {
         Ok(Self {
-            contract_version: value.contract_version().into(),
+            contract_version: SmartContractVersion::try_from(value.contract_version).unwrap(),
             address:          value.address.require()?.into(),
             instigator:       value.instigator.require()?.try_into()?,
             amount:           value.amount.require()?.into(),
@@ -2124,15 +2126,6 @@ impl TryFrom<InstanceUpdatedEvent> for super::types::InstanceUpdatedEvent {
             receive_name:     value.receive_name.require()?.try_into()?,
             events:           value.events.into_iter().map(Into::into).collect(),
         })
-    }
-}
-
-impl From<ContractVersion> for super::types::smart_contracts::WasmVersion {
-    fn from(value: ContractVersion) -> Self {
-        match value {
-            ContractVersion::V0 => Self::V0,
-            ContractVersion::V1 => Self::V1,
-        }
     }
 }
 


### PR DESCRIPTION


## Purpose

Smart Contract Version forwards compatibility

## Changes

Rather than using WasmVersion which is typed as an enum, we now will have a newly defined type in concordium base `SmartContractVersion` which stores the version as a u8. This will be forwards compatible because the i32 provided for the contract version can be converted to a u8 

## Checklist

- [ ] My code follows the style of this project.
- [ ] The code compiles without warnings.
- [ ] I have performed a self-review of the changes.
- [ ] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [ ] (If necessary) I have updated the CHANGELOG.

