### PR TITLE
Forward-compatible: ContractTraceElement

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,19 @@
   - Method `UpdateDetails::update_type` return type is wrapped.
   - Type `AccountTransactionEffects::BakerConfigured` field `data` from `Vec<BakerEvent>` to `Vec<Upward<BakerEvent>>`.
   - Type `AccountTransactionEffects::DelegationConfigured` field `data` from `Vec<DelegationEvent>` to `Vec<Upward<DelegationEvent>>`.
+  - Type `InvokeContractResult` field `events` of `Success` variant is now `Vec<Upward<ContractTraceElement>>`.
+  - Type `InvokeInstanceSuccess` field `events` is now `Vec<Upward<ContractTraceElement>>`.
+  - Method `ContractUpdateBuilder::events` return type from `&[ContractTraceElement]` to `&[Upward<ContractTraceElement>]`.
+  - Associated type `Indexer::Data` for `AffectedContractIndexer` now wraps the affected contract addresses in `Upward`.
+  - Type `AccountTransactionEffects` field `effects` of `ContractUpdateIssued` variant is now `Vec<Upward<ContractTraceElement>>`.
+  - Method `BlockItemSummary::contract_update_logs` now wraps the iterator items in `Upward`.
+  - Method `BlockItemSummaryDetails::contract_update_logs` now wraps the iterator items in `Upward`.
+  - Method `AccountTransactionEffects::affected_addresses` now wraps the return type in `Upward`.
+  - Method `ExecutionTree::affected_addresses` now wraps the return type in `Upward`.
+  - Method `ExecutionTree::events` now wraps the `Iterator::Item` in `Upward`.
+  - Function `execution_tree` parameter changed from `Vec<Upward<ContractTraceElement>>` to `Vec<ContractTraceElement>`.
+  - Type `ExecutionTreeV0` field `rest` change from `Vec<TraceV0>` to `Vec<Upward<TraceV0>>`.
+  - Type `ExecutionTreeV1` field `events` change from `Vec<TraceV1>` to `Vec<Upward<TraceV1>>`.
 
 ## 7.0.0
 

--- a/examples/v2_get_block_transaction_events.rs
+++ b/examples/v2_get_block_transaction_events.rs
@@ -48,7 +48,7 @@ async fn main() -> anyhow::Result<()> {
                 if event
                     .affected_contracts()
                     .known_or_err()?
-                    .contains(&ContractAddress::new(866, 0))
+                    .contains(&v2::Upward::Known(ContractAddress::new(866, 0)))
                 {
                     println!(
                         "Transaction {} with sender {}.",

--- a/src/contract_client.rs
+++ b/src/contract_client.rs
@@ -1615,7 +1615,7 @@ impl<Type> ContractClient<Type> {
 /// Users do not directly interact with values of this type.
 pub struct ContractUpdateInner {
     return_value: Option<ReturnValue>,
-    events:       Vec<ContractTraceElement>,
+    events:       Vec<Upward<ContractTraceElement>>,
 }
 
 /// A builder to simplify sending smart contract updates.
@@ -1639,7 +1639,11 @@ impl ContractUpdateBuilder {
     pub fn return_value(&self) -> Option<&ReturnValue> { self.inner.return_value.as_ref() }
 
     /// Get the events generated from the dry-run.
-    pub fn events(&self) -> &[ContractTraceElement] { &self.inner.events }
+    ///
+    /// Since newer versions of the Concordium Node API might introduce new
+    /// variants of [`ContractTraceElement`] the result might contain
+    /// [`Upward::Unknown`].
+    pub fn events(&self) -> &[Upward<ContractTraceElement>] { &self.inner.events }
 }
 
 /// A handle returned when sending a smart contract update transaction.

--- a/src/indexer.rs
+++ b/src/indexer.rs
@@ -543,10 +543,12 @@ impl Indexer for AffectedContractIndexer {
     type Context = ();
     type Data = (
         BlockInfo,
-        Vec<(
-            ContractUpdateInfo,
-            BTreeMap<ContractAddress, BTreeSet<OwnedReceiveName>>,
-        )>,
+        Vec<
+            v2::Upward<(
+                ContractUpdateInfo,
+                BTreeMap<ContractAddress, BTreeSet<OwnedReceiveName>>,
+            )>,
+        >,
     );
 
     async fn on_connect<'a>(
@@ -579,6 +581,9 @@ impl Indexer for AffectedContractIndexer {
                         return Ok(None);
                     };
                     let affected_addresses = info.execution_tree.affected_addresses();
+                    let v2::Upward::Known(affected_addresses) = affected_addresses else {
+                        return Ok(Some(v2::Upward::Unknown));
+                    };
                     if (self.all
                         && self
                             .addresses
@@ -589,7 +594,7 @@ impl Indexer for AffectedContractIndexer {
                             .iter()
                             .any(|addr| affected_addresses.contains_key(addr))
                     {
-                        Ok(Some((info, affected_addresses)))
+                        Ok(Some(v2::Upward::Known((info, affected_addresses))))
                     } else {
                         Ok(None)
                     }

--- a/src/types/mod.rs
+++ b/src/types/mod.rs
@@ -1230,8 +1230,9 @@ impl BlockItemSummary {
     /// logs that were produced.
     pub fn contract_update_logs(
         &self,
-    ) -> Option<impl Iterator<Item = (ContractAddress, &[smart_contracts::ContractEvent])> + '_>
-    {
+    ) -> Option<
+        impl Iterator<Item = Upward<(ContractAddress, &[smart_contracts::ContractEvent])>> + '_,
+    > {
         self.details.as_known()?.contract_update_logs()
     }
 
@@ -1299,7 +1300,12 @@ impl ExecutionTree {
     /// Return a set of contract addresses that appear in this execution
     /// tree, together with a set of [receive names](OwnedReceiveName) that
     /// were called for that contract address.
-    pub fn affected_addresses(&self) -> BTreeMap<ContractAddress, BTreeSet<OwnedReceiveName>> {
+    ///
+    /// Returns [`Upward::Unknown`] if any branch in the execution tree contains
+    /// [`Upward::Unknown`] data.
+    pub fn affected_addresses(
+        &self,
+    ) -> Upward<BTreeMap<ContractAddress, BTreeSet<OwnedReceiveName>>> {
         let mut addresses = BTreeMap::<ContractAddress, BTreeSet<_>>::new();
         let mut todo = vec![self];
         while let Some(head) = todo.pop() {
@@ -1310,6 +1316,9 @@ impl ExecutionTree {
                         .or_default()
                         .insert(v0.top_level.receive_name.clone());
                     for rest in &v0.rest {
+                        let Upward::Known(rest) = rest else {
+                            return Upward::Unknown;
+                        };
                         if let TraceV0::Call(call) = rest {
                             todo.push(call);
                         }
@@ -1321,6 +1330,9 @@ impl ExecutionTree {
                         .or_default()
                         .insert(v1.receive_name.clone());
                     for event in &v1.events {
+                        let Upward::Known(event) = event else {
+                            return Upward::Unknown;
+                        };
                         if let TraceV1::Call { call } = event {
                             todo.push(call);
                         }
@@ -1328,7 +1340,7 @@ impl ExecutionTree {
                 }
             }
         }
-        addresses
+        Upward::Known(addresses)
     }
 
     /// Get an iterator over the events logged by the contracts that were called
@@ -1339,11 +1351,11 @@ impl ExecutionTree {
     pub fn events(
         &self,
     ) -> impl Iterator<
-        Item = (
+        Item = Upward<(
             ContractAddress,
             EntrypointName<'_>,
             &[smart_contracts::ContractEvent],
-        ),
+        )>,
     > + '_ {
         // An auxiliary type used to store the list of next items produced by
         // the [`EventsIterator`]
@@ -1364,16 +1376,16 @@ impl ExecutionTree {
         }
 
         impl<'a> Iterator for LogsIterator<'a> {
-            type Item = (
+            type Item = Upward<(
                 ContractAddress,
                 EntrypointName<'a>,
                 &'a [smart_contracts::ContractEvent],
-            );
+            )>;
 
             fn next(&mut self) -> Option<Self::Item> {
                 while let Some(next) = self.next.pop() {
                     match next {
-                        LogsIteratorNext::Events(r) => return Some(r),
+                        LogsIteratorNext::Events(r) => return Some(Upward::Known(r)),
                         LogsIteratorNext::Tree(next) => match next {
                             ExecutionTree::V0(v0) => {
                                 let rv = (
@@ -1385,14 +1397,20 @@ impl ExecutionTree {
                                     &v0.top_level.events[..],
                                 );
                                 for rest in v0.rest.iter().rev() {
+                                    let Upward::Known(rest) = rest else {
+                                        return Some(Upward::Unknown);
+                                    };
                                     if let TraceV0::Call(call) = rest {
                                         self.next.push(LogsIteratorNext::Tree(call));
                                     }
                                 }
-                                return Some(rv);
+                                return Some(Upward::Known(rv));
                             }
                             ExecutionTree::V1(v1) => {
                                 for event in v1.events.iter().rev() {
+                                    let Upward::Known(event) = event else {
+                                        return Some(Upward::Unknown);
+                                    };
                                     match event {
                                         TraceV1::Events { events } => {
                                             self.next.push(LogsIteratorNext::Events((
@@ -1426,13 +1444,13 @@ impl ExecutionTree {
 /// This will fail if the list was not generated correctly, but if the list of
 /// trace elements is coming from the node it will always be in the correct
 /// format.
-pub fn execution_tree(elements: Vec<ContractTraceElement>) -> Option<ExecutionTree> {
+pub fn execution_tree(elements: Vec<Upward<ContractTraceElement>>) -> Option<ExecutionTree> {
     #[derive(Debug)]
     struct PartialTree {
         address: ContractAddress,
         /// Whether the matching resume was seen for the interrupt.
         resumed: bool,
-        events:  Vec<TraceV1>,
+        events:  Vec<Upward<TraceV1>>,
     }
 
     #[derive(Debug)]
@@ -1446,6 +1464,16 @@ pub fn execution_tree(elements: Vec<ContractTraceElement>) -> Option<ExecutionTr
     let mut stack: Vec<Worker> = Vec::new();
     let mut elements = elements.into_iter();
     while let Some(element) = elements.next() {
+        let Upward::Known(element) = element else {
+            let last = stack.last_mut()?;
+            match last {
+                Worker::V0(v0) => v0.rest.push(Upward::Unknown),
+                Worker::Partial(partial) => {
+                    partial.events.push(Upward::Unknown);
+                }
+            }
+            continue;
+        };
         match element {
             ContractTraceElement::Updated {
                 data:
@@ -1478,12 +1506,12 @@ pub fn execution_tree(elements: Vec<ContractTraceElement>) -> Option<ExecutionTr
                             amount,
                             message,
                             receive_name,
-                            events: vec![TraceV1::Events { events }],
+                            events: vec![Upward::Known(TraceV1::Events { events })],
                         }),
                     };
                     match end {
                         Worker::V0(mut v0) => {
-                            v0.rest.push(TraceV0::Call(tree));
+                            v0.rest.push(Upward::Known(TraceV0::Call(tree)));
                             stack.push(Worker::V0(v0));
                         }
                         Worker::Partial(mut partial) => {
@@ -1497,12 +1525,14 @@ pub fn execution_tree(elements: Vec<ContractTraceElement>) -> Option<ExecutionTr
                                 if let Some(last) = stack.last_mut() {
                                     match last {
                                         Worker::V0(v0) => {
-                                            v0.rest.push(TraceV0::Call(ExecutionTree::V1(tree)));
+                                            v0.rest.push(Upward::Known(TraceV0::Call(
+                                                ExecutionTree::V1(tree),
+                                            )));
                                         }
                                         Worker::Partial(v0) => {
-                                            v0.events.push(TraceV1::Call {
+                                            v0.events.push(Upward::Known(TraceV1::Call {
                                                 call: ExecutionTree::V1(tree),
-                                            });
+                                            }));
                                         }
                                     }
                                 } else {
@@ -1514,7 +1544,9 @@ pub fn execution_tree(elements: Vec<ContractTraceElement>) -> Option<ExecutionTr
                                     }
                                 }
                             } else {
-                                partial.events.push(TraceV1::Call { call: tree });
+                                partial
+                                    .events
+                                    .push(Upward::Known(TraceV1::Call { call: tree }));
                                 stack.push(Worker::Partial(partial));
                             }
                         }
@@ -1540,7 +1572,7 @@ pub fn execution_tree(elements: Vec<ContractTraceElement>) -> Option<ExecutionTr
                                 amount,
                                 message,
                                 receive_name,
-                                events: vec![TraceV1::Events { events }],
+                                events: vec![Upward::Known(TraceV1::Events { events })],
                             };
                             // and return it.
                             if elements.next().is_none() {
@@ -1555,22 +1587,29 @@ pub fn execution_tree(elements: Vec<ContractTraceElement>) -> Option<ExecutionTr
             ContractTraceElement::Transferred { from, amount, to } => {
                 let last = stack.last_mut()?;
                 match last {
-                    Worker::V0(v0) => v0.rest.push(TraceV0::Transfer { from, amount, to }),
+                    Worker::V0(v0) => {
+                        v0.rest
+                            .push(Upward::Known(TraceV0::Transfer { from, amount, to }))
+                    }
                     Worker::Partial(partial) => {
-                        partial.events.push(TraceV1::Transfer { from, amount, to });
+                        partial
+                            .events
+                            .push(Upward::Known(TraceV1::Transfer { from, amount, to }));
                     }
                 }
             }
             ContractTraceElement::Interrupted { address, events } => match stack.last_mut() {
                 Some(Worker::Partial(partial)) if partial.resumed => {
                     partial.resumed = false;
-                    partial.events.push(TraceV1::Events { events })
+                    partial
+                        .events
+                        .push(Upward::Known(TraceV1::Events { events }))
                 }
                 _ => {
                     stack.push(Worker::Partial(PartialTree {
                         address,
                         resumed: false,
-                        events: vec![TraceV1::Events { events }],
+                        events: vec![Upward::Known(TraceV1::Events { events })],
                     }));
                 }
             },
@@ -1583,9 +1622,9 @@ pub fn execution_tree(elements: Vec<ContractTraceElement>) -> Option<ExecutionTr
                         let Worker::Partial(partial) = stack.last_mut()? else {
                             return None;
                         };
-                        partial.events.push(TraceV1::Call {
+                        partial.events.push(Upward::Known(TraceV1::Call {
                             call: ExecutionTree::V0(v0),
-                        });
+                        }));
                         partial.resumed = true;
                     }
                     Worker::Partial(mut partial) => {
@@ -1605,7 +1644,9 @@ pub fn execution_tree(elements: Vec<ContractTraceElement>) -> Option<ExecutionTr
                     return None;
                 }
                 // Put an upgrade event to the list, and continue.
-                partial.events.push(TraceV1::Upgrade { from, to });
+                partial
+                    .events
+                    .push(Upward::Known(TraceV1::Upgrade { from, to }));
             }
         }
     }
@@ -1642,7 +1683,7 @@ pub struct UpdateV0 {
 /// generated by subsequent calls, not directly by the top-level call.
 pub struct ExecutionTreeV0 {
     pub top_level: UpdateV0,
-    pub rest:      Vec<TraceV0>,
+    pub rest:      Vec<Upward<TraceV0>>,
 }
 
 #[derive(Debug, PartialEq)]
@@ -1677,7 +1718,7 @@ pub struct ExecutionTreeV1 {
     pub receive_name: OwnedReceiveName,
     /// A sequence of calls, transfers, etc. performed by the contract, in the
     /// order that they took effect.
-    pub events:       Vec<TraceV1>,
+    pub events:       Vec<Upward<TraceV1>>,
 }
 
 #[derive(Debug, PartialEq)]
@@ -1783,7 +1824,7 @@ impl BlockItemSummaryDetails {
         if let Some(at) = self.as_account_transaction() {
             at.effects
                 .as_ref()
-                .map(AccountTransactionEffects::affected_contracts)
+                .and_then(AccountTransactionEffects::affected_contracts)
         } else {
             Upward::Known(Vec::new())
         }
@@ -1814,21 +1855,28 @@ impl BlockItemSummaryDetails {
     /// logs that were produced.
     pub fn contract_update_logs(
         &self,
-    ) -> Option<impl Iterator<Item = (ContractAddress, &[smart_contracts::ContractEvent])> + '_>
-    {
+    ) -> Option<
+        impl Iterator<Item = Upward<(ContractAddress, &[smart_contracts::ContractEvent])>> + '_,
+    > {
         match self.as_account_transaction()?.effects.as_known()? {
             AccountTransactionEffects::ContractInitialized { .. } => None,
             AccountTransactionEffects::ContractUpdateIssued { effects } => {
-                let iter = effects.iter().flat_map(|effect| match effect {
-                    ContractTraceElement::Updated { data } => {
-                        Some((data.address, &data.events[..]))
+                let iter = effects.iter().flat_map(|effect| {
+                    let Upward::Known(effect) = effect else {
+                        return Some(Upward::Unknown);
+                    };
+
+                    match effect {
+                        ContractTraceElement::Updated { data } => {
+                            Some(Upward::Known((data.address, &data.events[..])))
+                        }
+                        ContractTraceElement::Transferred { .. } => None,
+                        ContractTraceElement::Interrupted { address, events } => {
+                            Some(Upward::Known((*address, &events[..])))
+                        }
+                        ContractTraceElement::Resumed { .. } => None,
+                        ContractTraceElement::Upgraded { .. } => None,
                     }
-                    ContractTraceElement::Transferred { .. } => None,
-                    ContractTraceElement::Interrupted { address, events } => {
-                        Some((*address, &events[..]))
-                    }
-                    ContractTraceElement::Resumed { .. } => None,
-                    ContractTraceElement::Upgraded { .. } => None,
                 });
                 Some(iter)
             }
@@ -1854,6 +1902,9 @@ impl BlockItemSummaryDetails {
                         seen.insert(at.sender);
                         let mut addresses = vec![at.sender];
                         for effect in effects {
+                            let Upward::Known(effect) = effect else {
+                                return Upward::Unknown;
+                            };
                             match effect {
                                 ContractTraceElement::Updated { .. } => (),
                                 ContractTraceElement::Transferred { to, .. } => {
@@ -2032,13 +2083,18 @@ impl AccountTransactionEffects {
         }
     }
 
-    fn affected_contracts(&self) -> Vec<ContractAddress> {
+    fn affected_contracts(&self) -> Upward<Vec<ContractAddress>> {
         match self {
-            AccountTransactionEffects::ContractInitialized { data } => vec![data.address],
+            AccountTransactionEffects::ContractInitialized { data } => {
+                Upward::Known(vec![data.address])
+            }
             AccountTransactionEffects::ContractUpdateIssued { effects } => {
                 let mut seen = HashSet::new();
                 let mut addresses = Vec::new();
                 for effect in effects {
+                    let Upward::Known(effect) = effect else {
+                        return Upward::Unknown;
+                    };
                     match effect {
                         ContractTraceElement::Updated { data } => {
                             if seen.insert(data.address) {
@@ -2051,9 +2107,9 @@ impl AccountTransactionEffects {
                         ContractTraceElement::Upgraded { .. } => (),
                     }
                 }
-                addresses
+                Upward::Known(addresses)
             }
-            _ => Vec::new(),
+            _ => Upward::Known(Vec::new()),
         }
     }
 }
@@ -2097,7 +2153,9 @@ pub enum AccountTransactionEffects {
     /// A contract update transaction was issued and produced the given trace.
     /// This is the result of [Update](transactions::Payload::Update)
     /// transaction.
-    ContractUpdateIssued { effects: Vec<ContractTraceElement> },
+    ContractUpdateIssued {
+        effects: Vec<Upward<ContractTraceElement>>,
+    },
     /// A simple account to account transfer occurred. This is the result of a
     /// successful [`Transfer`](transactions::Payload::Transfer) transaction.
     AccountTransfer {

--- a/src/types/smart_contracts.rs
+++ b/src/types/smart_contracts.rs
@@ -256,7 +256,7 @@ pub enum InvokeContractResult {
     Success {
         return_value: Option<ReturnValue>,
         #[serde(deserialize_with = "contract_trace_via_events::deserialize")]
-        events:       Vec<ContractTraceElement>,
+        events:       Vec<Upward<ContractTraceElement>>,
         used_energy:  Energy,
     },
     #[serde(rename = "failure", rename_all = "camelCase")]
@@ -282,10 +282,10 @@ mod contract_trace_via_events {
     use serde::de::Error;
     pub fn deserialize<'de, D: serde::Deserializer<'de>>(
         des: D,
-    ) -> Result<Vec<ContractTraceElement>, D::Error> {
+    ) -> Result<Vec<Upward<ContractTraceElement>>, D::Error> {
         let xs = Vec::<super::super::summary_helper::Event>::deserialize(des)?;
         xs.into_iter()
-            .map(ContractTraceElement::try_from)
+            .map(|event| ContractTraceElement::try_from(event).map(Upward::Known))
             .collect::<Result<_, _>>()
             .map_err(|e| D::Error::custom(format!("Conversion failure: {}", e)))
     }

--- a/src/v2/conversions.rs
+++ b/src/v2/conversions.rs
@@ -1730,7 +1730,14 @@ impl TryFrom<AccountTransactionEffects> for super::types::AccountTransactionEffe
                 let effects = cui
                     .effects
                     .into_iter()
-                    .map(TryFrom::try_from)
+                    .map(|trace| {
+                        Ok(Upward::from(
+                            trace
+                                .element
+                                .map(super::types::ContractTraceElement::try_from)
+                                .transpose()?,
+                        ))
+                    })
                     .collect::<Result<_, tonic::Status>>()?;
                 Ok(Self::ContractUpdateIssued { effects })
             }
@@ -1878,11 +1885,11 @@ impl TryFrom<AccountTransactionEffects> for super::types::AccountTransactionEffe
     }
 }
 
-impl TryFrom<ContractTraceElement> for super::types::ContractTraceElement {
+impl TryFrom<contract_trace_element::Element> for super::types::ContractTraceElement {
     type Error = tonic::Status;
 
-    fn try_from(e: ContractTraceElement) -> Result<Self, Self::Error> {
-        Ok(match e.element.require()? {
+    fn try_from(element: contract_trace_element::Element) -> Result<Self, Self::Error> {
+        Ok(match element {
             contract_trace_element::Element::Updated(u) => {
                 super::types::ContractTraceElement::Updated {
                     data: u.try_into()?,
@@ -2422,7 +2429,14 @@ impl TryFrom<InvokeInstanceResponse> for super::types::smart_contracts::InvokeCo
                 events:       value
                     .effects
                     .into_iter()
-                    .map(TryFrom::try_from)
+                    .map(|trace| {
+                        Ok(Upward::from(
+                            trace
+                                .element
+                                .map(super::types::ContractTraceElement::try_from)
+                                .transpose()?,
+                        ))
+                    })
                     .collect::<Result<_, tonic::Status>>()?,
                 used_energy:  value.used_energy.require()?.into(),
             },

--- a/src/v2/dry_run.rs
+++ b/src/v2/dry_run.rs
@@ -3,7 +3,7 @@ use super::{
         self, account_transaction_payload, dry_run_error_response, dry_run_request,
         DryRunInvokeInstance, DryRunMintToAccount, DryRunSignature, DryRunStateOperation,
     },
-    AccountIdentifier, IntoBlockIdentifier,
+    AccountIdentifier, IntoBlockIdentifier, Upward,
 };
 use crate::{
     types::{
@@ -348,7 +348,7 @@ pub struct InvokeInstanceSuccess {
     /// The return value for a V1 contract call. Absent for a V0 contract call.
     pub return_value: Option<ReturnValue>,
     /// The effects produced by contract execution.
-    pub events:       Vec<ContractTraceElement>,
+    pub events:       Vec<Upward<ContractTraceElement>>,
     /// The energy used by the execution.
     pub used_energy:  Energy,
 }
@@ -394,7 +394,14 @@ impl TryFrom<Option<Result<generated::DryRunResponse, tonic::Status>>>
                             events:       result
                                 .effects
                                 .into_iter()
-                                .map(TryFrom::try_from)
+                                .map(|trace| {
+                                    Ok(Upward::from(
+                                        trace
+                                            .element
+                                            .map(ContractTraceElement::try_from)
+                                            .transpose()?,
+                                    ))
+                                })
                                 .collect::<Result<_, tonic::Status>>()?,
                             used_energy:  result.used_energy.require()?.into(),
                         };

--- a/src/v2/upward.rs
+++ b/src/v2/upward.rs
@@ -197,3 +197,37 @@ where
 #[derive(Debug, thiserror::Error)]
 #[error("Encountered unknown data from the Node API, which is required to be known.")]
 pub struct UnknownDataError;
+
+impl<A> std::iter::FromIterator<Upward<A>> for Upward<Vec<A>> {
+    fn from_iter<T: IntoIterator<Item = Upward<A>>>(iter: T) -> Self {
+        let mut vec = Vec::new();
+        for a in iter {
+            if let Upward::Known(a) = a {
+                vec.push(a);
+            } else {
+                return Upward::Unknown;
+            }
+        }
+        Upward::Known(vec)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_upward_from_iterator_all_known() {
+        let list = vec![Upward::Known(42); 50];
+        let res = list.into_iter().collect::<Upward<_>>().unwrap();
+        assert_eq!(vec![42; 50], res)
+    }
+
+    #[test]
+    fn test_upward_from_iterator_some_unknown() {
+        let mut list = vec![Upward::Known(42); 50];
+        list[25] = Upward::Unknown;
+        let res = list.into_iter().collect::<Upward<_>>();
+        assert_eq!(Upward::Unknown, res)
+    }
+}


### PR DESCRIPTION
## Purpose

Ref COR-1717.
Closes COR-1800.

## Changes

Wrap `ContractTraceElement` with `Upward` to stay forward-compatible when new variants of `ContractTraceElement` are introduced.
