### PR TITLE
Wrap `AccountStakingInfo` and `CooldownStatus` in `Upward`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -65,6 +65,8 @@
   - Type `NodeInfo` field `details` is now wrapped in `Upward`.
   - Type `Peer` field `consensus_info` is now wrapped in `Upward`.
   - Type `PeerConsensusInfo::Node` unnamed field is now wrapped in `Upward`.
+  - Type `AccountInfo` field `account_stake` changes from `Option<AccountStakingInfo>` to `Option<Upward<AccountStakingInfo>>`.
+  - Type `Cooldown` field `status` is now wrapped in `Upward`.
 
 ## 7.0.0
 

--- a/examples/balance-summary.rs
+++ b/examples/balance-summary.rs
@@ -4,6 +4,7 @@
 use clap::AppSettings;
 use concordium_rust_sdk::{
     common::types::Amount,
+    types::AccountStakingInfo,
     v2::{self, BlockIdentifier},
 };
 use futures::{Future, TryStreamExt};
@@ -106,11 +107,13 @@ async fn main() -> anyhow::Result<()> {
             let mut client = closure_client.clone();
             async move {
                 let info = client.get_account_info(&acc.into(), &block).await?.response;
-                let additional_stake = info
-                    .account_stake
-                    .map_or(Amount::zero(), |baker_delegator| {
-                        baker_delegator.staked_amount()
-                    });
+                let additional_stake =
+                    info.account_stake
+                        .map_or(Amount::zero(), |baker_delegator| {
+                            baker_delegator
+                                .as_ref()
+                                .map_or(Amount::zero(), AccountStakingInfo::staked_amount)
+                        });
                 let additional_liquid_amount = info.account_amount
                     - std::cmp::max(additional_stake, info.account_release_schedule.total);
                 Ok::<_, anyhow::Error>((

--- a/examples/list-account-balances.rs
+++ b/examples/list-account-balances.rs
@@ -112,16 +112,17 @@ async fn main() -> anyhow::Result<()> {
             let (acc, info) = res??;
             let is_baker = if let Some(account_stake) = info.account_stake {
                 match account_stake {
-                    AccountStakingInfo::Baker { staked_amount, .. } => {
+                    v2::Upward::Known(AccountStakingInfo::Baker { staked_amount, .. }) => {
                         num_bakers += 1;
                         total_staked_amount += staked_amount;
                         true
                     }
-                    AccountStakingInfo::Delegated { staked_amount, .. } => {
+                    v2::Upward::Known(AccountStakingInfo::Delegated { staked_amount, .. }) => {
                         total_delegated_amount += staked_amount;
 
                         false
                     }
+                    v2::Upward::Unknown => false,
                 }
             } else {
                 false

--- a/src/types/mod.rs
+++ b/src/types/mod.rs
@@ -335,7 +335,11 @@ pub struct Cooldown {
     pub amount: Amount,
 
     /// The status of the cooldown.
-    pub status: CooldownStatus,
+    ///
+    /// Note future versions of the Concordium Node API might introduce new
+    /// variants of cooldowns, therefore each event is wrapped in
+    /// [`Upward`] potentially representing some future unknown data.
+    pub status: Upward<CooldownStatus>,
 }
 
 #[derive(SerdeSerialize, SerdeDeserialize, Debug, PartialEq)]
@@ -374,10 +378,14 @@ pub struct AccountInfo {
     #[serde(default)]
     /// `Some` if and only if the account is a baker or delegator. In that case
     /// it is the information about the baker or delegator.
+    ///
+    /// Note future versions of the Concordium Node API might introduce new
+    /// variants of [`AccountStakingInfo`], therefore each event is wrapped in
+    /// [`Upward`] potentially representing some future unknown data.
     // this is a bit of a hacky way of JSON parsing, and **relies** on
     // the account staking info serde instance being "untagged"
     #[serde(rename = "accountBaker", alias = "accountDelegation")]
-    pub account_stake:            Option<AccountStakingInfo>,
+    pub account_stake:            Option<Upward<AccountStakingInfo>>,
     /// Canonical address of the account.
     pub account_address:          AccountAddress,
 

--- a/src/types/queries.rs
+++ b/src/types/queries.rs
@@ -24,6 +24,7 @@ use std::net::IpAddr;
     derive_more::Display,
 )]
 #[display(fmt = "P{_0}")]
+#[serde(transparent)]
 #[repr(transparent)]
 pub struct ProtocolVersionInt(pub u64);
 

--- a/src/v2/conversions.rs
+++ b/src/v2/conversions.rs
@@ -542,11 +542,11 @@ impl TryFrom<BakerPoolInfo> for super::types::BakerPoolInfo {
     }
 }
 
-impl TryFrom<AccountStakingInfo> for super::types::AccountStakingInfo {
+impl TryFrom<account_staking_info::StakingInfo> for super::types::AccountStakingInfo {
     type Error = tonic::Status;
 
-    fn try_from(value: AccountStakingInfo) -> Result<Self, Self::Error> {
-        match value.staking_info.require()? {
+    fn try_from(value: account_staking_info::StakingInfo) -> Result<Self, Self::Error> {
+        match value {
             account_staking_info::StakingInfo::Baker(bsi) => {
                 let staked_amount = bsi.staked_amount.require()?.into();
                 let restake_earnings = bsi.restake_earnings;
@@ -919,14 +919,8 @@ impl TryFrom<Cooldown> for super::types::Cooldown {
 
     fn try_from(cd: Cooldown) -> Result<Self, Self::Error> {
         Ok(Self {
-            status:   CooldownStatus::try_from(cd.status)
-                .map_err(|_| {
-                    tonic::Status::invalid_argument(format!(
-                        "unknown cooldown status value {}",
-                        cd.status
-                    ))
-                })?
-                .into(),
+            status:   Upward::from(CooldownStatus::try_from(cd.status).ok())
+                .map(super::types::CooldownStatus::from),
             end_time: cd.end_time.require()?.into(),
             amount:   cd.amount.require()?.into(),
         })
@@ -959,8 +953,10 @@ impl TryFrom<AccountInfo> for super::types::AccountInfo {
         let account_encrypted_amount = encrypted_balance.require()?.try_into()?;
         let account_encryption_key = encryption_key.require()?.try_into()?;
         let account_index = index.require()?.into();
-        let account_stake: Option<super::types::AccountStakingInfo> = match stake {
-            Some(stake) => Some(stake.try_into()?),
+        let account_stake: Option<Upward<super::types::AccountStakingInfo>> = match stake {
+            Some(stake) => Some(Upward::from(
+                stake.staking_info.map(TryInto::try_into).transpose()?,
+            )),
             None => None,
         };
         let account_address = address.require()?.try_into()?;
@@ -977,11 +973,12 @@ impl TryFrom<AccountInfo> for super::types::AccountInfo {
         // If we up the minimum supported node version to version 7, we can remove this
         // fallback calculation and instead require the available balance field to
         // always be present.
-        let available_balance = available_balance.map(|ab| ab.into()).unwrap_or_else(|| {
-            let active_stake = account_stake
-                .as_ref()
-                .map(|s| s.staked_amount())
-                .unwrap_or_default();
+        let available_balance = available_balance.map(|ab| ab.into()).unwrap_or({
+            let active_stake = if let Some(Upward::Known(staking_info)) = &account_stake {
+                staking_info.staked_amount()
+            } else {
+                Default::default()
+            };
 
             let inactive_stake = cooldowns.iter().map(|cd| cd.amount).sum();
 


### PR DESCRIPTION
## Purpose

Ref COR-1717.
Closes COR-1804, COR-1801.

Forward-compatible when new variants for `AccountStakingInfo` and `CooldownStatus`
