### PR TITLE
adding Upward to the DryRunSuccessResponse

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -72,6 +72,8 @@
   - Type `PeerConsensusInfo::Node` unnamed field is now wrapped in `Upward`.
   - Type `AccountInfo` field `account_stake` changes from `Option<AccountStakingInfo>` to `Option<Upward<AccountStakingInfo>>`.
   - Type `Cooldown` field `status` is now wrapped in `Upward`.
+  - Type `DryRunSuccessResponse` field `response` is wrapped.
+  - Method `try_from` match response.response is amended to cater for Upward Known.
 
 ## 7.0.0
 

--- a/src/v2/dry_run.rs
+++ b/src/v2/dry_run.rs
@@ -233,22 +233,28 @@ impl TryFrom<Option<Result<generated::DryRunResponse, tonic::Status>>>
             Response::Success(s) => {
                 let response = s.response.require()?;
                 match response {
-                    generated::dry_run_success_response::Response::BlockStateLoaded(loaded) => {
-                        let protocol_version =
-                            generated::ProtocolVersion::try_from(loaded.protocol_version)
-                                .map_err(|_| tonic::Status::unknown("Unknown protocol version"))?
-                                .into();
-                        let loaded = BlockStateLoaded {
-                            current_timestamp: loaded.current_timestamp.require()?.into(),
-                            block_hash: loaded.block_hash.require()?.try_into()?,
-                            protocol_version,
-                        };
-                        Ok(WithRemainingQuota {
-                            inner: loaded,
-                            quota_remaining,
-                        })
-                    }
-                    _ => Err(tonic::Status::unknown("unexpected success response type"))?,
+                    Upward::Known(inner) => match inner {
+                        generated::dry_run_success_response::Response::BlockStateLoaded(loaded) => {
+                            let protocol_version =
+                                generated::ProtocolVersion::try_from(loaded.protocol_version)
+                                    .map_err(|_| {
+                                        tonic::Status::unknown("Unknown protocol version")
+                                    })?
+                                    .into();
+                            let loaded = BlockStateLoaded {
+                                current_timestamp: loaded.current_timestamp.require()?.into(),
+                                block_hash: loaded.block_hash.require()?.try_into()?,
+                                protocol_version,
+                            };
+                            Ok(WithRemainingQuota {
+                                inner: loaded,
+                                quota_remaining,
+                            })
+                        }
+                        _ => Err(tonic::Status::unknown("unexpected success response type"))?,
+                    },
+                    // Upward::Known
+                    Upward::Unknown => Err(tonic::Status::unknown("Unknown response type"))?,
                 }
             }
         }
@@ -282,11 +288,14 @@ impl TryFrom<Option<Result<generated::DryRunResponse, tonic::Status>>>
                 let response = s.response.require()?;
                 use generated::dry_run_success_response::*;
                 match response {
-                    Response::AccountInfo(info) => Ok(WithRemainingQuota {
-                        inner: info.try_into()?,
-                        quota_remaining,
-                    }),
-                    _ => Err(tonic::Status::unknown("unexpected success response type"))?,
+                    Upward::Known(inner) => match inner {
+                        Response::AccountInfo(info) => Ok(WithRemainingQuota {
+                            inner: info.try_into()?,
+                            quota_remaining,
+                        }),
+                        _ => Err(tonic::Status::unknown("unexpected success response type"))?,
+                    }, // Upward::Known
+                    Upward::Unknown => Err(tonic::Status::unknown("Unknown response type"))?,
                 }
             }
         }
@@ -320,11 +329,15 @@ impl TryFrom<Option<Result<generated::DryRunResponse, tonic::Status>>>
                 let response = s.response.require()?;
                 use generated::dry_run_success_response::*;
                 match response {
-                    Response::InstanceInfo(info) => Ok(WithRemainingQuota {
-                        inner: info.try_into()?,
-                        quota_remaining,
-                    }),
-                    _ => Err(tonic::Status::unknown("unexpected success response type"))?,
+                    Upward::Known(inner) => match inner {
+                        Response::InstanceInfo(info) => Ok(WithRemainingQuota {
+                            inner: info.try_into()?,
+                            quota_remaining,
+                        }),
+                        _ => Err(tonic::Status::unknown("unexpected success response type"))?,
+                    }, // Upward::Known
+
+                    Upward::Unknown => Err(tonic::Status::unknown("Unknown response type"))?,
                 }
             }
         }

--- a/src/v2/generated/concordium.v2.rs
+++ b/src/v2/generated/concordium.v2.rs
@@ -5045,7 +5045,7 @@ pub mod dry_run_error_response {
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct DryRunSuccessResponse {
     #[prost(oneof = "dry_run_success_response::Response", tags = "1, 2, 3, 4, 5, 6, 7")]
-    pub response: ::core::option::Option<dry_run_success_response::Response>,
+    pub response: ::core::option::Option<Upward<dry_run_success_response::Response>>,
 }
 /// Nested message and enum types in `DryRunSuccessResponse`.
 pub mod dry_run_success_response {


### PR DESCRIPTION
Jira-Id: COR-1822

## Purpose

For forward compatibility, wrap the DryRunSuccessResponse with Upward, to introduce Known and Unknown responses, preventing panic for new variant introduced in the future.

## Changes

Wrap struct DryRunSuccessResponse.response with Upward. Modify the code that is calling DryRunResponse to take into consideration the Upward wrapping in the response field.


## Checklist

- [ x ] My code follows the style of this project.
- [ x ] The code compiles without warnings.
- [ x ] I have performed a self-review of the changes.
- [ x ] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [ x ] (If necessary) I have updated the CHANGELOG.

## CLA acceptance

_Remove if not applicable.

By submitting the contribution I accept the terms and conditions of the
Contributor License Agreement v1.0
- link: https://developers.concordium.com/CLAs/Contributor-License-Agreement-v1.0.pdf

- [ ] I accept the above linked CLA.
