### PR TITLE
Forward compatible account verify key (COR-1820)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,8 +4,9 @@
 - Added `update_token_info` method to `TokenClient`.
 - Added `Validation` as a separate enum for `TokenClient` operations.
 - Remove use of `CborTokenHolder` wrapper.
-
 - Introduce `ProtocolVersionInt` newtype, wrapping the `u64` representation of the `ProtocolVersion`. This type is forward-compatible, meaning future protocol versions can be represented using this type.
+- Added `CredentialPublicKeys`, `AccountAccessStructure`, `CredentialDeploymentValues`, `InitialCredentialDeploymentValues`, and
+`AccountCredentialWithoutProofs` types which in contrast to the corresponding `base` types have the `VerifyKey` types wrapped into `Upward`.
 - BREAKING: Change type `ProtocolVersion` to  `ProtocolVersionInt` for field `protocol_version` in the types listed below. Now introducing new protocol versions in `ProtocolVersion` does not result in RPC parsing errors, and consumers of this library can write more applications that are more forward-compatible.
   - `BlockInfo`
   - `ConsensusInfo`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 - Added `Validation` as a separate enum for `TokenClient` operations.
 - Remove use of `CborTokenHolder` wrapper.
 - Introduce `ProtocolVersionInt` newtype, wrapping the `u64` representation of the `ProtocolVersion`. This type is forward-compatible, meaning future protocol versions can be represented using this type.
-- Added `CredentialPublicKeys`, `AccountAccessStructure`, `CredentialDeploymentValues`, `InitialCredentialDeploymentValues`, and
+- Added `CredentialPublicKeys`, `CredentialDeploymentValues`, `InitialCredentialDeploymentValues`, and
 `AccountCredentialWithoutProofs` types which in contrast to the corresponding `base` types have the `VerifyKey` types wrapped into `Upward`.
 - BREAKING: Change type `ProtocolVersion` to  `ProtocolVersionInt` for field `protocol_version` in the types listed below. Now introducing new protocol versions in `ProtocolVersion` does not result in RPC parsing errors, and consumers of this library can write more applications that are more forward-compatible.
   - `BlockInfo`
@@ -14,6 +14,9 @@
 - Introduce `Upward<A, R = ()>` for representing types, which might get extended in a future version of the Concordium Node API and allows the consumer of this library to decide how to handle some unknown future data, like new transaction types and chain events.
 - Use the `WasmVersionInt` defined in `concordium-base` for the wasm version (smart contract version) to make it forward-compatible.
 - Changed the `Indexer` module to use a new `OnFinalizationError` and the new result types `OnFinalizationResult`/`TraverseResult` when traversing and processing blocks. The indexer's errors/results can now represent the `Unkown` types as part of adding forward-compatibility.
+- Removed the `From<AccountInfo>` implementation for `AccountAccessStructure`.
+- Removed the implementation of the trait `HasAccountAccessStructure` for `AccountInfo`.
+
 - BREAKING: Change types related to gRPC API responses to wrap `Upward` for values which might be extended in a future version of the API of the Concordium Node.
 
   The changes are for:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@
   - `CommonRewardData`
 - Introduce `Upward<A, R = ()>` for representing types, which might get extended in a future version of the Concordium Node API and allows the consumer of this library to decide how to handle some unknown future data, like new transaction types and chain events.
 - Use the `WasmVersionInt` defined in `concordium-base` for the wasm version (smart contract version) to make it forward-compatible.
-- Changed the `Indexer` module to use a new `OnFinalizationError` and the new result types `OnFinalizationResult`/`TraverseResult` when traversing and processing blocks. The indexer's errors/results can now represent the `Unkown` types as part of adding forward-compatibility.
+- Changed the `Indexer` module to use a new `OnFinalizationError` and the new result types `OnFinalizationResult`/`TraverseResult` when traversing and processing blocks. The indexer's errors/results can now represent the `Unknown` types as part of adding forward-compatibility.
 - Removed the `From<AccountInfo>` implementation for `AccountAccessStructure`.
 - Removed the implementation of the trait `HasAccountAccessStructure` for `AccountInfo`.
 

--- a/examples/list-account-balances.rs
+++ b/examples/list-account-balances.rs
@@ -5,7 +5,7 @@ use clap::AppSettings;
 use concordium_rust_sdk::{
     common::{types::Amount, SerdeSerialize},
     id::types::AccountAddress,
-    types::{AccountStakingInfo, CredentialType},
+    types::{AccountCredentialWithoutProofs, AccountStakingInfo, CredentialType},
     v2::{self, upward::UnknownDataError, BlockIdentifier},
 };
 use futures::TryStreamExt;
@@ -130,13 +130,11 @@ async fn main() -> anyhow::Result<()> {
             let acc_type = info.account_credentials.get(&0.into()).map_or(
                 Ok::<_, UnknownDataError>(CredentialType::Normal),
                 |cdi| match cdi.value.as_ref().known_or_err()? {
-                    id::types::AccountCredentialWithoutProofs::Initial { .. } => {
+                    AccountCredentialWithoutProofs::Initial { .. } => {
                         num_initial += 1;
                         Ok(CredentialType::Initial)
                     }
-                    id::types::AccountCredentialWithoutProofs::Normal { .. } => {
-                        Ok(CredentialType::Normal)
-                    }
+                    AccountCredentialWithoutProofs::Normal { .. } => Ok(CredentialType::Normal),
                 },
             )?;
 

--- a/examples/list-account-balances.rs
+++ b/examples/list-account-balances.rs
@@ -4,7 +4,6 @@ use anyhow::Context;
 use clap::AppSettings;
 use concordium_rust_sdk::{
     common::{types::Amount, SerdeSerialize},
-    id,
     id::types::AccountAddress,
     types::{AccountStakingInfo, CredentialType},
     v2::{self, upward::UnknownDataError, BlockIdentifier},

--- a/examples/list-initial-accounts.rs
+++ b/examples/list-initial-accounts.rs
@@ -3,7 +3,7 @@ use anyhow::Context;
 use clap::AppSettings;
 use concordium_rust_sdk::{
     types::{AccountCredentialWithoutProofs, AccountInfo},
-    v2,
+    v2::{self, upward},
 };
 use futures::TryStreamExt;
 use std::{collections::BTreeSet, io::Write, path::PathBuf};
@@ -128,12 +128,10 @@ async fn main() -> anyhow::Result<()> {
 
             let is_initial = if let Some(acred) = ainfo.account_credentials.get(&0.into()) {
                 match acred.value.as_ref().known_or_err()? {
-                    concordium_rust_sdk::id::types::AccountCredentialWithoutProofs::Initial {
-                        ..
-                    } => Ok::<_, upward::UnknownDataError>(true),
-                    concordium_rust_sdk::id::types::AccountCredentialWithoutProofs::Normal {
-                        ..
-                    } => Ok(false),
+                    AccountCredentialWithoutProofs::Initial { .. } => {
+                        Ok::<_, upward::UnknownDataError>(true)
+                    }
+                    AccountCredentialWithoutProofs::Normal { .. } => Ok(false),
                 }
             } else {
                 Ok(false)

--- a/examples/list-initial-accounts.rs
+++ b/examples/list-initial-accounts.rs
@@ -125,6 +125,7 @@ async fn main() -> anyhow::Result<()> {
         }
         for ainfo in futures::future::join_all(handles).await {
             let ainfo: AccountInfo = ainfo?.response;
+
             let is_initial = if let Some(acred) = ainfo.account_credentials.get(&0.into()) {
                 match acred.value.as_ref().known_or_err()? {
                     concordium_rust_sdk::id::types::AccountCredentialWithoutProofs::Initial {

--- a/examples/list-initial-accounts.rs
+++ b/examples/list-initial-accounts.rs
@@ -2,8 +2,8 @@
 use anyhow::Context;
 use clap::AppSettings;
 use concordium_rust_sdk::{
-    types::AccountInfo,
-    v2::{self, upward},
+    types::{AccountCredentialWithoutProofs, AccountInfo},
+    v2,
 };
 use futures::TryStreamExt;
 use std::{collections::BTreeSet, io::Write, path::PathBuf};

--- a/examples/v2_contract_deploy_init_update.rs
+++ b/examples/v2_contract_deploy_init_update.rs
@@ -63,8 +63,8 @@ enum Action {
         address: ContractAddress,
     },
     #[structopt(
-        about = "Update the contract and set the provided weather using JSON parameters and a \
-                 schema."
+        about = "Update the contract and set the provided weather using JSON parameters \
+                         and a schema."
     )]
     UpdateWithSchema {
         #[structopt(long, help = "Path of the JSON parameter.")]

--- a/src/indexer.rs
+++ b/src/indexer.rs
@@ -43,7 +43,10 @@ pub enum TraverseError {
     Query(#[from] QueryError),
     #[error("Timed out waiting for finalized blocks.")]
     Elapsed(#[from] Elapsed),
-    #[error("The type `${0}` is unkown to this SDK. This can happen if the SDK is not fully compatible with the Concordium node. You might want to update the SDK to a newer version.")]
+    #[error(
+        "The type `${0}` is unkown to this SDK. This can happen if the SDK is not fully \
+         compatible with the Concordium node. You might want to update the SDK to a newer version."
+    )]
     Unknown(String),
 }
 
@@ -62,7 +65,10 @@ impl From<OnFinalizationError> for TraverseError {
 pub enum OnFinalizationError {
     #[error("Failed to query: {0}")]
     Query(#[from] QueryError),
-    #[error("The type `${0}` is unkown to this SDK. This can happen if the SDK is not fully compatible with the Concordium node. You might want to update the SDK to a newer version.")]
+    #[error(
+        "The type `${0}` is unkown to this SDK. This can happen if the SDK is not fully \
+         compatible with the Concordium node. You might want to update the SDK to a newer version."
+    )]
     Unknown(String),
 }
 

--- a/src/indexer.rs
+++ b/src/indexer.rs
@@ -44,7 +44,7 @@ pub enum TraverseError {
     #[error("Timed out waiting for finalized blocks.")]
     Elapsed(#[from] Elapsed),
     #[error(
-        "The type `${0}` is unkown to this SDK. This can happen if the SDK is not fully \
+        "The type `${0}` is unknown to this SDK. This can happen if the SDK is not fully \
          compatible with the Concordium node. You might want to update the SDK to a newer version."
     )]
     Unknown(String),
@@ -54,7 +54,7 @@ impl From<OnFinalizationError> for TraverseError {
     fn from(e: OnFinalizationError) -> Self {
         match e {
             OnFinalizationError::Query(query_error) => query_error.into(),
-            OnFinalizationError::Unknown(unkown_type) => TraverseError::Unknown(unkown_type),
+            OnFinalizationError::Unknown(unknown_type) => TraverseError::Unknown(unknown_type),
         }
     }
 }
@@ -66,7 +66,7 @@ pub enum OnFinalizationError {
     #[error("Failed to query: {0}")]
     Query(#[from] QueryError),
     #[error(
-        "The type `${0}` is unkown to this SDK. This can happen if the SDK is not fully \
+        "The type `${0}` is unknown to this SDK. This can happen if the SDK is not fully \
          compatible with the Concordium node. You might want to update the SDK to a newer version."
     )]
     Unknown(String),

--- a/src/indexer.rs
+++ b/src/indexer.rs
@@ -111,7 +111,7 @@ pub type TraverseResult<A> = OnFinalizationResult<A>;
 ///         client: v2::Client,
 ///         ctx: &'a Self::Context,
 ///         fbi: FinalizedBlockInfo,
-///     ) -> QueryResult<Self::Data> {
+///     ) -> OnFinalizationResult<Self::Data> {
 ///         unimplemented!("Implement me.")
 ///     }
 ///

--- a/src/signatures.rs
+++ b/src/signatures.rs
@@ -49,7 +49,7 @@ pub enum SignatureError {
     )]
     UnknownAccountCredential { credential_index: u8 },
     #[error(
-        "The type `${0}` is unkown to this SDK. This can happen if the SDK is not fully \
+        "The type `${0}` is unknown to this SDK. This can happen if the SDK is not fully \
          compatible with the Concordium node. You might want to update the SDK to a newer version."
     )]
     Unknown(String),

--- a/src/signatures.rs
+++ b/src/signatures.rs
@@ -329,11 +329,10 @@ pub async fn verify_account_signature(
                 continue;
             };
 
-            let Upward::Known(public_key) = public_key else {
-                return Err(SignatureError::Unknown("PublicKey/VerifyKey".to_string()));
-            };
-
-            if public_key.verify(message_hash, signature) {
+            if public_key
+                .known_or(SignatureError::Unknown("PublicKey/VerifyKey".to_string()))?
+                .verify(message_hash, signature)
+            {
                 // If the signature is valid, increase the `valid_signatures_count`.
                 valid_signatures_count += 1;
             } else {

--- a/src/types/mod.rs
+++ b/src/types/mod.rs
@@ -253,14 +253,14 @@ pub struct CredentialPublicKeys {
 
 impl From<concordium_base::id::types::CredentialPublicKeys> for CredentialPublicKeys {
     fn from(value: concordium_base::id::types::CredentialPublicKeys) -> Self {
-        let test: BTreeMap<_, _> = value
+        let keys: BTreeMap<_, _> = value
             .keys
             .iter()
             .map(|(k, v)| (*k, Upward::Known(v.clone())))
             .collect();
 
         CredentialPublicKeys {
-            keys: test,
+            keys,
             threshold: value.threshold,
         }
     }
@@ -1576,7 +1576,7 @@ impl ExecutionTree {
     /// If the SDK is not fully compatible with the Concordium node,
     /// it can occur that new events in the execution tree occur that are
     /// unknown to the SDK or some of the execution traces are unknown.
-    /// Items of `Unkown` are inserted in the iterator in that case.
+    /// Items of `Unknown` are inserted in the iterator in that case.
     pub fn events(
         &self,
     ) -> impl Iterator<
@@ -1679,11 +1679,11 @@ impl ExecutionTree {
 /// it can occur that the `contractTraceElements` pass through a smart contract
 /// with a version that is unkonwn to this SDK. As the assumption is that new
 /// smart contract versions require a different execution tree to be accurated
-/// represented/executed, this function will return `Unkown` in that case.
+/// represented/executed, this function will return `Unknown` in that case.
 /// If some of the `contractTraceElements` are `Unknown` to this SDK, but
 /// otherwise pass through smart contracts with known versions, an execution
 /// tree can be constructed that contains all trace elements (potentially
-/// `Unkown` trace elements).
+/// `Unknown` trace elements).
 pub fn execution_tree(
     elements: Vec<Upward<ContractTraceElement>>,
 ) -> Option<Upward<ExecutionTree>> {

--- a/src/types/mod.rs
+++ b/src/types/mod.rs
@@ -3483,11 +3483,7 @@ impl WalletAccount {
         let mut keys = BTreeMap::new();
         for (&ci, k) in self.keys.keys.iter() {
             let public = concordium_base::id::types::CredentialPublicKeys {
-                keys: k
-                    .keys
-                    .iter()
-                    .map(|(ki, kp)| (*ki, VerifyKey::Ed25519VerifyKey(kp.public())))
-                    .collect(),
+                keys: k.keys.iter().map(|(ki, kp)| (*ki, kp.into())).collect(),
                 threshold: k.threshold,
             };
             keys.insert(ci, public);

--- a/src/types/transactions.rs
+++ b/src/types/transactions.rs
@@ -1,27 +1,3 @@
 //! Definition of transactions and other transaction-like messages, together
 //! with their serialization, signing, and similar auxiliary methods.
-
-use super::{AccountInfo, AccountThreshold, CredentialIndex};
-use crate::v2::Upward;
-use concordium_base::id::types::CredentialPublicKeys;
 pub use concordium_base::{transactions::*, updates::*};
-
-impl HasAccountAccessStructure for AccountInfo {
-    fn threshold(&self) -> AccountThreshold {
-        self.account_threshold
-    }
-
-    fn credential_keys(&self, idx: CredentialIndex) -> Option<&CredentialPublicKeys> {
-        let versioned_cred = self.account_credentials.get(&idx)?;
-        match versioned_cred.value {
-            Upward::Known(crate::id::types::AccountCredentialWithoutProofs::Initial {
-                ref icdv,
-            }) => Some(&icdv.cred_account),
-            Upward::Known(crate::id::types::AccountCredentialWithoutProofs::Normal {
-                ref cdv,
-                ..
-            }) => Some(&cdv.cred_key_info),
-            Upward::Unknown(_) => None,
-        }
-    }
-}

--- a/src/v2/conversions.rs
+++ b/src/v2/conversions.rs
@@ -4,7 +4,8 @@
 use super::{generated::*, upward::Upward, Require};
 use crate::types::{
     queries::{ConcordiumBFTDetails, ProtocolVersionInt},
-    AccountReleaseSchedule, ActiveBakerPoolStatus, UpdateKeysCollectionSkeleton,
+    AccountCredentialWithoutProofs, AccountReleaseSchedule, ActiveBakerPoolStatus,
+    UpdateKeysCollectionSkeleton,
 };
 use chrono::TimeZone;
 use concordium_base::{
@@ -858,22 +859,20 @@ impl TryFrom<CredentialCommitments> for crate::id::types::CredentialDeploymentCo
     }
 }
 
-impl TryFrom<AccountCredential>
-    for Upward<crate::types::AccountCredentialWithoutProofs<ArCurve, AttributeKind>>
-{
+impl TryFrom<AccountCredential> for Upward<AccountCredentialWithoutProofs<ArCurve, AttributeKind>> {
     type Error = tonic::Status;
 
     fn try_from(message: AccountCredential) -> Result<Self, Self::Error> {
         let key = message
             .credential_values
-            .map(crate::types::AccountCredentialWithoutProofs::try_from)
+            .map(AccountCredentialWithoutProofs::try_from)
             .transpose()?;
         Ok(Upward::from(key))
     }
 }
 
 impl TryFrom<account_credential::CredentialValues>
-    for crate::types::AccountCredentialWithoutProofs<ArCurve, AttributeKind>
+    for AccountCredentialWithoutProofs<ArCurve, AttributeKind>
 {
     type Error = tonic::Status;
 
@@ -886,7 +885,7 @@ impl TryFrom<account_credential::CredentialValues>
                     ip_identity: ic.ip_id.require()?.into(),
                     policy: ic.policy.require()?.try_into()?,
                 };
-                Ok(crate::types::AccountCredentialWithoutProofs::Initial { icdv })
+                Ok(AccountCredentialWithoutProofs::Initial { icdv })
             }
 
             account_credential::CredentialValues::Normal(nc) => {
@@ -909,7 +908,7 @@ impl TryFrom<account_credential::CredentialValues>
                     policy: nc.policy.require()?.try_into()?,
                 };
                 let commitments = nc.commitments.require()?.try_into()?;
-                Ok(crate::types::AccountCredentialWithoutProofs::Normal { cdv, commitments })
+                Ok(AccountCredentialWithoutProofs::Normal { cdv, commitments })
             }
         }
     }

--- a/src/v2/upward.rs
+++ b/src/v2/upward.rs
@@ -39,10 +39,12 @@ impl<A, R> Upward<A, R> {
     pub fn unwrap(self) -> A {
         match self {
             Self::Known(value) => value,
-            Self::Unknown(_) => panic!(
-                "called `Upward::<{}>::unwrap()` on an `Unknown` value",
-                type_name::<A>()
-            ),
+            Self::Unknown => {
+                panic!(
+                    "called `Upward::<{}>::unwrap()` on an `Unknown` value",
+                    type_name::<A>()
+                )
+            }
         }
     }
 

--- a/src/v2/upward.rs
+++ b/src/v2/upward.rs
@@ -20,7 +20,7 @@ pub enum Upward<A, R = ()> {
     /// New unknown variant, the structure is not known to the current version
     /// of this library. Consider updating the library if support is needed.
     ///
-    /// For protocols that support decoding unkown data, a representation
+    /// For protocols that support decoding unknown data, a representation
     /// of the data is the residual value (represented by a dynamic data type).
     /// This is the caes for CBOR e.g., but not possible for protobuf that is
     /// not self-descriptive.

--- a/src/v2/upward.rs
+++ b/src/v2/upward.rs
@@ -39,7 +39,7 @@ impl<A, R> Upward<A, R> {
     pub fn unwrap(self) -> A {
         match self {
             Self::Known(value) => value,
-            Self::Unknown => {
+            Self::Unknown(_) => {
                 panic!(
                     "called `Upward::<{}>::unwrap()` on an `Unknown` value",
                     type_name::<A>()

--- a/src/web3id.rs
+++ b/src/web3id.rs
@@ -102,33 +102,33 @@ pub async fn verify_credential_metadata(
                     actual: c.issuer(),
                 });
             }
-            
-                match &c {
-                    crate::types::AccountCredentialWithoutProofs::Initial { .. } => {
-                        Err(CredentialLookupError::InitialCredential { cred_id })
-                    }
-                    crate::types::AccountCredentialWithoutProofs::Normal { cdv, commitments } => {
-                        let now = client.get_block_info(bi).await?.response.block_slot_time;
-                        let valid_from = cdv.policy.created_at.lower().ok_or_else(|| {
-                            CredentialLookupError::InvalidResponse(
-                                "Credential creation date is not valid.".into(),
-                            )
-                        })?;
-                        let valid_until = cdv.policy.valid_to.upper().ok_or_else(|| {
-                            CredentialLookupError::InvalidResponse(
-                                "Credential creation date is not valid.".into(),
-                            )
-                        })?;
-                        let status = if valid_from > now {
-                            CredentialStatus::NotActivated
-                        } else if valid_until < now {
-                            CredentialStatus::Expired
-                        } else {
-                            CredentialStatus::Active
-                        };
-                        let inputs = CredentialsInputs::Account {
-                            commitments: commitments.cmm_attributes.clone(),
-                        };
+
+            match &c {
+                crate::types::AccountCredentialWithoutProofs::Initial { .. } => {
+                    Err(CredentialLookupError::InitialCredential { cred_id })
+                }
+                crate::types::AccountCredentialWithoutProofs::Normal { cdv, commitments } => {
+                    let now = client.get_block_info(bi).await?.response.block_slot_time;
+                    let valid_from = cdv.policy.created_at.lower().ok_or_else(|| {
+                        CredentialLookupError::InvalidResponse(
+                            "Credential creation date is not valid.".into(),
+                        )
+                    })?;
+                    let valid_until = cdv.policy.valid_to.upper().ok_or_else(|| {
+                        CredentialLookupError::InvalidResponse(
+                            "Credential creation date is not valid.".into(),
+                        )
+                    })?;
+                    let status = if valid_from > now {
+                        CredentialStatus::NotActivated
+                    } else if valid_until < now {
+                        CredentialStatus::Expired
+                    } else {
+                        CredentialStatus::Active
+                    };
+                    let inputs = CredentialsInputs::Account {
+                        commitments: commitments.cmm_attributes.clone(),
+                    };
 
                     Ok(CredentialWithMetadata { status, inputs })
                 }

--- a/src/web3id.rs
+++ b/src/web3id.rs
@@ -2,6 +2,7 @@
 
 use crate::{
     cis4::{Cis4Contract, Cis4QueryError},
+    types::AccountCredentialWithoutProofs,
     v2::{self, BlockIdentifier, IntoBlockIdentifier},
 };
 pub use concordium_base::web3id::*;
@@ -104,10 +105,10 @@ pub async fn verify_credential_metadata(
             }
 
             match &c {
-                crate::types::AccountCredentialWithoutProofs::Initial { .. } => {
+                AccountCredentialWithoutProofs::Initial { .. } => {
                     Err(CredentialLookupError::InitialCredential { cred_id })
                 }
-                crate::types::AccountCredentialWithoutProofs::Normal { cdv, commitments } => {
+                AccountCredentialWithoutProofs::Normal { cdv, commitments } => {
                     let now = client.get_block_info(bi).await?.response.block_slot_time;
                     let valid_from = cdv.policy.created_at.lower().ok_or_else(|| {
                         CredentialLookupError::InvalidResponse(

--- a/src/web3id.rs
+++ b/src/web3id.rs
@@ -27,7 +27,7 @@ pub enum CredentialLookupError {
     QueryError(#[from] v2::QueryError),
     #[error("Unable to query CIS4 contract: {0}")]
     Cis4QueryError(#[from] Cis4QueryError),
-    #[error("Credential {cred_id} no longer present or of unkown type on account: {account}")]
+    #[error("Credential {cred_id} no longer present or of unknown type on account: {account}")]
     CredentialNotPresentOrUnknown {
         cred_id: CredentialRegistrationID,
         account: AccountAddress,


### PR DESCRIPTION
## Purpose

Depends on:
https://github.com/Concordium/concordium-rust-sdk/pull/331

This PR is based on the PR-331 because both PRs change similar code snippets so that we have a clear order of merging the PRs.

The  `AccountVerifyKey` type should be wrapped in `Upward` such that the SDK can stay forward-compatible if we ever extend it with new variants in the gRPC API. The `AccountVerifyKey` appears in the  `account_credentials` field of the `AccountInfo` type. 

The first approach (first commit of this PR: https://github.com/Concordium/concordium-rust-sdk/pull/332/commits/9dfd8a9ed1c0211d6f875a3d6926c1bdc5aa2f42) was to not wrap the `AccountVerifyKey` into `Upward` directly as the expectation was that we shouldn't leak the upward type into the `base` repo and the `cryptoKey` types (such as `AccountVerifyKey`) seem unlikely to be moved to the `rust-sdk` as several crypto libraries in `base` depend on it. So the next higher level type that lives in the `rust-sdk`, meaning the `AccountCredentialWithoutProofs`, was wrapped in `Upward` instead. This bubbling up of the `upward` wrapper was deemed not desirable. As such in the second approach, the corresponding types:
`CredentialPublicKeys`,
`CredentialDeploymentValues`,
`InitialCredentialDeploymentValues`,
`AccountCredentialWithoutProofs`
were created in the `rust-sdk` that have only the `AccountVerifyKey` wrapped in upward.

Note: 
- Removed the `From` instance that converts `AccountInfo` to `AccountAccessStructure`.
- Removed `HasAccountAccessStructure` for `AccountInfo`.
Discussion: https://github.com/Concordium/concordium-rust-sdk/pull/331#discussion_r2339980656

## Changes

- Added `CredentialPublicKeys`,  `CredentialDeploymentValues`, `InitialCredentialDeploymentValues`, and
`AccountCredentialWithoutProofs` types which in contrast to the corresponding `base` types have the `VerifyKey` types wrapped into `Upward`.

## Checklist

- [ ] My code follows the style of this project.
- [ ] The code compiles without warnings.
- [ ] I have performed a self-review of the changes.
- [ ] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [ ] (If necessary) I have updated the CHANGELOG.

## CLA acceptance

_Remove if not applicable.

By submitting the contribution I accept the terms and conditions of the
Contributor License Agreement v1.0
- link: https://developers.concordium.com/CLAs/Contributor-License-Agreement-v1.0.pdf

- [ ] I accept the above linked CLA.
