### PR TITLE
upward residual type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@
   - `BlockInfo`
   - `ConsensusInfo`
   - `CommonRewardData`
-- Introduce `Upward<A>` for representing types, which might get extended in a future version of the Concordium Node API and allows the consumer of this library to decide how to handle some unknown future data, like new transaction types and chain events.
+- Introduce `Upward<A, R = ()>` for representing types, which might get extended in a future version of the Concordium Node API and allows the consumer of this library to decide how to handle some unknown future data, like new transaction types and chain events.
 - Use the `WasmVersionInt` defined in `concordium-base` for the wasm version (smart contract version) to make it forward-compatible.
 - Changed the `Indexer` module to use a new `OnFinalizationError` and the new result types `OnFinalizationResult`/`TraverseResult` when traversing and processing blocks. The indexer's errors/results can now represent the `Unkown` types as part of adding forward-compatibility.
 - BREAKING: Change types related to gRPC API responses to wrap `Upward` for values which might be extended in a future version of the API of the Concordium Node.

--- a/examples/list-account-balances.rs
+++ b/examples/list-account-balances.rs
@@ -122,7 +122,7 @@ async fn main() -> anyhow::Result<()> {
 
                         false
                     }
-                    v2::Upward::Unknown => false,
+                    v2::Upward::Unknown(_) => false,
                 }
             } else {
                 false

--- a/src/indexer.rs
+++ b/src/indexer.rs
@@ -637,7 +637,7 @@ impl Indexer for AffectedContractIndexer {
 
                     let affected_addresses = execution_tree.affected_addresses();
                     let v2::Upward::Known(affected_addresses) = affected_addresses else {
-                        return Ok(Some(v2::Upward::Unknown));
+                        return Ok(Some(v2::Upward::Unknown(())));
                     };
 
                     if (self.all

--- a/src/v2/conversions.rs
+++ b/src/v2/conversions.rs
@@ -1315,7 +1315,7 @@ impl TryFrom<BlockItem>
         if let Some(item) = value.block_item {
             Ok(Upward::Known(item.try_into()?))
         } else {
-            Ok(Upward::Unknown)
+            Ok(Upward::Unknown(()))
         }
     }
 }

--- a/src/v2/mod.rs
+++ b/src/v2/mod.rs
@@ -1185,7 +1185,7 @@ impl TryFrom<generated::PeersInfo> for types::network::PeersInfo {
                                 generated::peers_info::peer::CatchupStatus::try_from(status).ok(),
                             ) else {
                                 return Upward::Known(types::network::PeerConsensusInfo::Node(
-                                    Upward::Unknown,
+                                    Upward::Unknown(()),
                                 ));
                             };
                             let status = match status {
@@ -1258,7 +1258,7 @@ impl TryFrom<generated::node_info::Details> for types::NodeDetails {
             generated::node_info::Details::Bootstrapper(_) => Ok(types::NodeDetails::Bootstrapper),
             generated::node_info::Details::Node(status) => {
                 let Upward::Known(consensus_status) = Upward::from(status.consensus_status) else {
-                    return Ok(types::NodeDetails::Node(Upward::Unknown));
+                    return Ok(types::NodeDetails::Node(Upward::Unknown(())));
                 };
                 let consensus_status = match consensus_status {
                     generated::node_info::node::ConsensusStatus::NotRunning(_) => {
@@ -1270,7 +1270,7 @@ impl TryFrom<generated::node_info::Details> for types::NodeDetails {
                     generated::node_info::node::ConsensusStatus::Active(baker) => {
                         let baker_id = baker.baker_id.require()?.into();
                         let Upward::Known(status) = Upward::from(baker.status) else {
-                            return Ok(types::NodeDetails::Node(Upward::Unknown));
+                            return Ok(types::NodeDetails::Node(Upward::Unknown(())));
                         };
 
                         match status {


### PR DESCRIPTION
## Purpose

Add residual type to `Upward` that allows up to represent unknown data with e.g. `cbor::Value`. 
This is a preparation for using the `Upward` to in CBOR data model.

## Changes

_Describe the changes that were needed.

## Checklist

- [ ] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [x] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [x] (If necessary) I have updated the CHANGELOG.
