### PR TITLE
Fix the conversion of ProtocolVersionInt from the GRPC.

### DIFF
--- a/src/types/queries.rs
+++ b/src/types/queries.rs
@@ -7,9 +7,9 @@ use concordium_base::{
     base::*,
     common::{types::TransactionTime, SerdeDeserialize, SerdeSerialize},
 };
-use thiserror::Error;
 use derive_more::Display;
 use std::net::IpAddr;
+use thiserror::Error;
 
 /// Integer representation of the protocol version.
 #[derive(

--- a/src/types/queries.rs
+++ b/src/types/queries.rs
@@ -7,9 +7,7 @@ use concordium_base::{
     base::*,
     common::{types::TransactionTime, SerdeDeserialize, SerdeSerialize},
 };
-use derive_more::Display;
 use std::net::IpAddr;
-use thiserror::Error;
 
 /// Integer representation of the protocol version.
 #[derive(
@@ -41,27 +39,6 @@ impl TryFrom<ProtocolVersionInt> for ProtocolVersion {
 impl From<ProtocolVersion> for ProtocolVersionInt {
     fn from(value: ProtocolVersion) -> Self {
         Self(value.into())
-    }
-}
-
-#[derive(Debug, Error, Display)]
-/// A structure to represent conversion errors when converting unsigned
-/// integers to [ProtocolVersionInt]. Used if the protocol version is
-/// negative.
-pub struct InvalidProtocolVersion {
-    /// The version that was attempted to be converted, but is not supported.
-    version: i32,
-}
-
-impl ProtocolVersionInt {
-    /// Convert from the 0-based GRPC representation to the 1-based internal
-    /// representation.
-    pub fn from_grpc(value: i32) -> Result<Self, InvalidProtocolVersion> {
-        if value < 0 {
-            Err(InvalidProtocolVersion { version: value })
-        } else {
-            Ok(Self((value as u64) + 1))
-        }
     }
 }
 

--- a/src/types/queries.rs
+++ b/src/types/queries.rs
@@ -7,6 +7,8 @@ use concordium_base::{
     base::*,
     common::{types::TransactionTime, SerdeDeserialize, SerdeSerialize},
 };
+use thiserror::Error;
+use derive_more::Display;
 use std::net::IpAddr;
 
 /// Integer representation of the protocol version.
@@ -39,6 +41,27 @@ impl TryFrom<ProtocolVersionInt> for ProtocolVersion {
 impl From<ProtocolVersion> for ProtocolVersionInt {
     fn from(value: ProtocolVersion) -> Self {
         Self(value.into())
+    }
+}
+
+#[derive(Debug, Error, Display)]
+/// A structure to represent conversion errors when converting unsigned
+/// integers to [ProtocolVersionInt]. Used if the protocol version is
+/// negative.
+pub struct InvalidProtocolVersion {
+    /// The version that was attempted to be converted, but is not supported.
+    version: i32,
+}
+
+impl ProtocolVersionInt {
+    /// Convert from the 0-based GRPC representation to the 1-based internal
+    /// representation.
+    pub fn from_grpc(value: i32) -> Result<Self, InvalidProtocolVersion> {
+        if value < 0 {
+            Err(InvalidProtocolVersion { version: value })
+        } else {
+            Ok(Self((value as u64) + 1))
+        }
     }
 }
 

--- a/src/v2/conversions.rs
+++ b/src/v2/conversions.rs
@@ -2401,10 +2401,8 @@ impl TryFrom<ConsensusInfo> for super::types::queries::ConsensusInfo {
     type Error = tonic::Status;
 
     fn try_from(value: ConsensusInfo) -> Result<Self, Self::Error> {
-        let protocol_version =
-            ProtocolVersionInt(u64::try_from(value.protocol_version).map_err(|err| {
-                tonic::Status::internal(format!("Invalid protocol version: {err}"))
-            })?);
+        let protocol_version = ProtocolVersionInt::from_grpc(value.protocol_version)
+            .map_err(|err| tonic::Status::internal(format!("Invalid protocol version: {err}")))?;
         Ok(Self {
             last_finalized_block_height: value.last_finalized_block_height.require()?.into(),
             block_arrive_latency_e_m_s_d: value.block_arrive_latency_emsd,
@@ -2716,10 +2714,8 @@ impl TryFrom<BlockInfo> for super::types::queries::BlockInfo {
     type Error = tonic::Status;
 
     fn try_from(value: BlockInfo) -> Result<Self, Self::Error> {
-        let protocol_version =
-            ProtocolVersionInt(u64::try_from(value.protocol_version).map_err(|err| {
-                tonic::Status::internal(format!("Invalid protocol version: {err}"))
-            })?);
+        let protocol_version = ProtocolVersionInt::from_grpc(value.protocol_version)
+            .map_err(|err| tonic::Status::internal(format!("Invalid protocol version: {err}")))?;
 
         Ok(Self {
             transactions_size: value.transactions_size.into(),

--- a/src/v2/conversions.rs
+++ b/src/v2/conversions.rs
@@ -2877,9 +2877,10 @@ impl TryFrom<TokenomicsInfo> for super::types::RewardsOverview {
         match value.tokenomics.require()? {
             tokenomics_info::Tokenomics::V0(value) => Ok(Self::V0 {
                 data: super::types::CommonRewardData {
-                    protocol_version: ProtocolVersionInt::from_grpc(value.protocol_version).map_err(|err| {
-                        tonic::Status::internal(format!("Invalid protocol version: {err}"))
-                    })?,
+                    protocol_version: ProtocolVersionInt::from_grpc(value.protocol_version)
+                        .map_err(|err| {
+                            tonic::Status::internal(format!("Invalid protocol version: {err}"))
+                        })?,
                     total_amount: value.total_amount.require()?.into(),
                     total_encrypted_amount: value.total_encrypted_amount.require()?.into(),
                     baking_reward_account: value.baking_reward_account.require()?.into(),
@@ -2892,9 +2893,10 @@ impl TryFrom<TokenomicsInfo> for super::types::RewardsOverview {
             }),
             tokenomics_info::Tokenomics::V1(value) => Ok(Self::V1 {
                 common: super::types::CommonRewardData {
-                    protocol_version: ProtocolVersionInt::from_grpc(value.protocol_version).map_err(|err| {
-                        tonic::Status::internal(format!("Invalid protocol version: {err}"))
-                    })?,
+                    protocol_version: ProtocolVersionInt::from_grpc(value.protocol_version)
+                        .map_err(|err| {
+                            tonic::Status::internal(format!("Invalid protocol version: {err}"))
+                        })?,
                     total_amount: value.total_amount.require()?.into(),
                     total_encrypted_amount: value.total_encrypted_amount.require()?.into(),
                     baking_reward_account: value.baking_reward_account.require()?.into(),

--- a/src/v2/conversions.rs
+++ b/src/v2/conversions.rs
@@ -2877,11 +2877,9 @@ impl TryFrom<TokenomicsInfo> for super::types::RewardsOverview {
         match value.tokenomics.require()? {
             tokenomics_info::Tokenomics::V0(value) => Ok(Self::V0 {
                 data: super::types::CommonRewardData {
-                    protocol_version: ProtocolVersionInt(
-                        u64::try_from(value.protocol_version).map_err(|err| {
-                            tonic::Status::internal(format!("Invalid protocol version: {err}"))
-                        })?,
-                    ),
+                    protocol_version: ProtocolVersionInt::from_grpc(value.protocol_version).map_err(|err| {
+                        tonic::Status::internal(format!("Invalid protocol version: {err}"))
+                    })?,
                     total_amount: value.total_amount.require()?.into(),
                     total_encrypted_amount: value.total_encrypted_amount.require()?.into(),
                     baking_reward_account: value.baking_reward_account.require()?.into(),
@@ -2894,11 +2892,9 @@ impl TryFrom<TokenomicsInfo> for super::types::RewardsOverview {
             }),
             tokenomics_info::Tokenomics::V1(value) => Ok(Self::V1 {
                 common: super::types::CommonRewardData {
-                    protocol_version: ProtocolVersionInt(
-                        u64::try_from(value.protocol_version).map_err(|err| {
-                            tonic::Status::internal(format!("Invalid protocol version: {err}"))
-                        })?,
-                    ),
+                    protocol_version: ProtocolVersionInt::from_grpc(value.protocol_version).map_err(|err| {
+                        tonic::Status::internal(format!("Invalid protocol version: {err}"))
+                    })?,
                     total_amount: value.total_amount.require()?.into(),
                     total_encrypted_amount: value.total_encrypted_amount.require()?.into(),
                     baking_reward_account: value.baking_reward_account.require()?.into(),


### PR DESCRIPTION
## Purpose

Part of [COR-1928](https://linear.app/concordium/issue/COR-1928/transaction-logger-wallet-proxy-indexer-bug-while-processing-block-on)

Fix the conversion of `ProtocolVersionInt` when values are created from the GRPC API. The GRPC values use a 0 based enum (so 0 represents PROTOCOL_VERSION_1), so it's necessary to add 1 when converting.

## Changes

- Introduce `protocol_version_int_from_enum` for `ProtocolVersionInt` that does the correct conversion.
- Use the conversion where `ProtocolVersionInt` is constructed.

## Checklist

- [ ] My code follows the style of this project.
- [ ] The code compiles without warnings.
- [ ] I have performed a self-review of the changes.
- [ ] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [ ] (If necessary) I have updated the CHANGELOG.
