### PR TITLE
Bubble upward for new AccountVerifyKey variant for AccountInfo

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -80,6 +80,7 @@
   - Type `AccountInfo` field `account_credentials` change from `BTreeMap<CredentialIndex,Versioned<AccountCredentialWithoutProofs<ArCurve, AttributeKind>>>` to `BTreeMap<CredentialIndex,Versioned<Upward<AccountCredentialWithoutProofs<ArCurve, AttributeKind>>>>`.
   - Type `BakerPoolInfo` moved from `concordium-base` to the `rust-sdk`.
   - Type `Event`/`BakerPoolInfo` field `open_status` is now wrapped in `Upward`.
+  - Bubble `Upward` from new variants of `VerifyKey` to `Upward<AccountCredentialWithoutProofs<...>>` in `AccountInfo::account_credentials`.
 
 ## 7.0.0
 


### PR DESCRIPTION
## Purpose

Ref COR-1717.
Closes COR-1820.

Bubble upward for new `AccountVerifyKey` variant ensuring `AccountInfo` can still be constructed for accounts with new unknown keys.

Note that querying block items where an item contains a new variant of account verify key will still fail, fixing this seems tricky so will not be part of this PR and probably not this project.