### PR TITLE
feat: added get_blocks endpoint to stream arriving blocks from the chain

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## Unreleased
 
-- Exposed `get_blocks` function on the v2 client which returns a stream of blocks `ArrivedBlockInfo` can be used to listen for new blocks arriving on chain.
+- Exposed `get_blocks` function on the v2 client which returns a stream of blocks `ArrivedBlockInfo`. This endpoint can be used to listen for new blocks arriving on chain.
 
 ## 9.0.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## Unreleased
 
+- Exposed `get_blocks` function on the v2 client which returns a stream of blocks `ArrivedBlockInfo` can be used to listen for new blocks arriving on chain.
+
 ## 9.0.1
 
 - Fixes a bug where using `serde` to convert `BlockItemSummary` would result in data loss with regards to transaction sponsor details.

--- a/examples/v2_get_blocks.rs
+++ b/examples/v2_get_blocks.rs
@@ -1,0 +1,36 @@
+//! Test the `GetBlocks` endpoint.
+use anyhow::Context;
+use clap::AppSettings;
+use concordium_rust_sdk::v2;
+use futures::StreamExt;
+use structopt::StructOpt;
+
+#[derive(StructOpt)]
+struct App {
+    #[structopt(
+        long = "node",
+        help = "GRPC interface of the node.",
+        default_value = "http://127.0.0.1:20000"
+    )]
+    endpoint: v2::Endpoint,
+}
+
+#[tokio::main(flavor = "multi_thread")]
+async fn main() -> anyhow::Result<()> {
+    let app = {
+        let app = App::clap().global_setting(AppSettings::ColoredHelp);
+        let matches = app.get_matches();
+        App::from_clap(&matches)
+    };
+
+    let mut client = v2::Client::new(app.endpoint)
+        .await
+        .context("Cannot connect.")?;
+
+    let stream = client.get_blocks().await?;
+
+    stream
+        .for_each(|arrived_block_info| async move { println!("{:?}", arrived_block_info) })
+        .await;
+    Ok(())
+}

--- a/src/v2/mod.rs
+++ b/src/v2/mod.rs
@@ -6,9 +6,17 @@ use crate::{
     id::{self, types::AccountCredentialMessage},
     protocol_level_tokens,
     types::{
-        self, AbsoluteBlockHeight, AccountInfo, AccountPending, BlockItemSummary, CredentialRegistrationID, Energy, Memo, Nonce, RegisteredData, SpecialTransactionOutcome, TransactionStatus, UpdateSequenceNumber, block_certificates, chain_parameters::ChainParameters, hashes::{self, BlockHash, TransactionHash, TransactionSignHash}, queries::{ConsensusDetailedStatus}, smart_contracts::{
+        self, block_certificates,
+        chain_parameters::ChainParameters,
+        hashes::{self, BlockHash, TransactionHash, TransactionSignHash},
+        queries::ConsensusDetailedStatus,
+        smart_contracts::{
             ContractContext, InstanceInfo, InvokeContractResult, ModuleReference, WasmModule,
-        }, transactions::{self, InitContractPayload, UpdateContractPayload, UpdateInstruction}
+        },
+        transactions::{self, InitContractPayload, UpdateContractPayload, UpdateInstruction},
+        AbsoluteBlockHeight, AccountInfo, AccountPending, BlockItemSummary,
+        CredentialRegistrationID, Energy, Memo, Nonce, RegisteredData, SpecialTransactionOutcome,
+        TransactionStatus, UpdateSequenceNumber,
     },
 };
 use anyhow::Context;
@@ -352,7 +360,7 @@ pub struct ArrivedBlockInfo {
     /// The block hash for the arrived block.
     pub block_hash: BlockHash,
     /// The absolute block height for the arrived block.
-    pub height: AbsoluteBlockHeight, 
+    pub height: AbsoluteBlockHeight,
 }
 
 /// Information of a finalized block.
@@ -363,7 +371,6 @@ pub struct FinalizedBlockInfo {
     /// The absolute block height for the finalized block.
     pub height: AbsoluteBlockHeight,
 }
-
 
 impl From<&BlockIdentifier> for generated::BlockHashInput {
     fn from(bi: &BlockIdentifier) -> Self {
@@ -1381,16 +1388,13 @@ impl Client {
         })
     }
 
-    /// Return a stream of blocks that arrive from the time the query is made onward. 
+    /// Return a stream of blocks that arrive from the time the query is made onward.
     /// This can be used to listen for incoming blocks.
     pub async fn get_blocks(
         &mut self,
     ) -> endpoints::QueryResult<impl Stream<Item = Result<ArrivedBlockInfo, tonic::Status>>> {
-        let response = self
-            .client
-            .get_blocks(generated::Empty::default())
-            .await?;
-        
+        let response = self.client.get_blocks(generated::Empty::default()).await?;
+
         let stream = response.into_inner().map(|x| match x {
             Ok(v) => {
                 let block_hash = v.hash.require().and_then(TryFrom::try_from)?;


### PR DESCRIPTION
## Purpose

Add get_blocks endpoint, so that a client can stream arriving blocks to the chain

## Changes

- Added get_blocks endpoint
- Added example to run against local node

## Checklist

- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [x] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [x] (If necessary) I have updated the CHANGELOG.

